### PR TITLE
99 fix documentation preview and enable documentation versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,15 +56,19 @@ jobs:
   docs-preview:
     name: Preview documentation 📖
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - run: pip install mkdocs-material mkdocstrings 'mkdocstrings[python]' mkdocs-swagger-ui-tag
-      - name: Build documentation
-        run: mkdocs build
-      - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
         with:
-          source-dir: ./site/
+          python-version: 3.x
+      - run: pip install mkdocs-material mkdocstrings 'mkdocstrings[python]' mkdocs-swagger-ui-tag mike
+      - name: Build and deploy documentation
+        run: mike deploy --push --allow-empty --deploy-prefix pr-preview pr-${{ github.event.number }}
 
   docs:
     name: Deploy documentation 📚
@@ -79,15 +83,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache
-          restore-keys: |
-            mkdocs-material-
-      - run: pip install mkdocs-material mkdocstrings 'mkdocstrings[python]' mkdocs-swagger-ui-tag
-      - run: mkdocs gh-deploy --force
+      - run: pip install mkdocs-material mkdocstrings 'mkdocstrings[python]' mkdocs-swagger-ui-tag mike
+      - name: Build and deploy documentation
+        run: mike deploy --push --update-aliases --allow-empty ${{ github.ref_name }} latest
 
   build:
     name: Build distribution 📦

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
           python-version: 3.x
       - run: pip install mkdocs-material mkdocstrings 'mkdocstrings[python]' mkdocs-swagger-ui-tag mike
       - name: Build and deploy documentation
-        run: mike deploy --push --allow-empty --deploy-prefix pr-preview pr-${{ github.event.number }}
+        run: /
+          mike set-default latest
+          mike deploy --push --allow-empty --deploy-prefix pr-preview pr-${{ github.event.number }} --message "Deploying docs preview for PR \#${{ github.event.number }} 🛫"
 
   docs:
     name: Deploy documentation 📚
@@ -85,7 +87,9 @@ jobs:
           python-version: 3.x
       - run: pip install mkdocs-material mkdocstrings 'mkdocstrings[python]' mkdocs-swagger-ui-tag mike
       - name: Build and deploy documentation
-        run: mike deploy --push --update-aliases --allow-empty ${{ github.ref_name }} latest
+        run: /
+          mike set-default latest
+          mike deploy --push --update-aliases --allow-empty ${{ github.ref_name }} latest --message "Deploying docs version ${{ github.ref_name }} 🛫"
 
   build:
     name: Build distribution 📦

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,7 @@ jobs:
           python-version: 3.x
       - run: pip install mkdocs-material mkdocstrings 'mkdocstrings[python]' mkdocs-swagger-ui-tag mike
       - name: Build and deploy documentation
-        run: /
-          mike set-default latest
-          mike deploy --push --allow-empty --deploy-prefix pr-preview pr-${{ github.event.number }} --message "Deploying docs preview for PR \#${{ github.event.number }} 🛫"
+        run: mike deploy --push --allow-empty --deploy-prefix pr-preview pr-${{ github.event.number }} --message "Deploying docs preview for PR #${{ github.event.number }} 🛫"
 
   docs:
     name: Deploy documentation 📚
@@ -87,9 +85,7 @@ jobs:
           python-version: 3.x
       - run: pip install mkdocs-material mkdocstrings 'mkdocstrings[python]' mkdocs-swagger-ui-tag mike
       - name: Build and deploy documentation
-        run: /
-          mike set-default latest
-          mike deploy --push --update-aliases --allow-empty ${{ github.ref_name }} latest --message "Deploying docs version ${{ github.ref_name }} 🛫"
+        run: mike deploy --push --update-aliases --allow-empty ${{ github.ref_name }} latest --message "Deploying docs version ${{ github.ref_name }} 🛫"
 
   build:
     name: Build distribution 📦

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,10 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - name: Checkout gh-pages branch
+      - name: Checkout PR branch
         run: |
           git fetch origin
-          git checkout gh-pages
+          git checkout ${{ github.event.pull_request.head.ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -84,10 +84,10 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - name: Checkout gh-pages branch
+      - name: Checkout merge branch
         run: |
           git fetch origin
-          git checkout gh-pages
+          git checkout ${{ github.ref_name }}
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Checkout gh-pages branch
+        run: |
+          git fetch origin
+          git checkout gh-pages
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -80,6 +84,10 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Checkout gh-pages branch
+        run: |
+          git fetch origin
+          git checkout gh-pages
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           python-version: 3.x
       - run: pip install mkdocs-material mkdocstrings 'mkdocstrings[python]' mkdocs-swagger-ui-tag mike
       - name: Build and deploy documentation
-        run: mike deploy --push --allow-empty --deploy-prefix pr-preview pr-${{ github.event.number }} --message "Deploying docs preview for PR #${{ github.event.number }} 🛫"
+        run: mike deploy --push --allow-empty --deploy-prefix pr-preview pr-${{ github.event.number }} --message "Deploying docs preview for PR ${{ github.event.number }} 🛫"
 
   docs:
     name: Deploy documentation 📚

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Blackfish
 site_url: https://princeton-ddss.github.io/blackfish
 repo_url: https://github.com/princeton-ddss/blackfish
-copyright: Copyright &copy; 2024 Princeton University
+copyright: Copyright &copy; 2024 Colin Swaney and The Trustees of Princeton University
 theme:
   name: "material"
   logo: assets/img/logo.png

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,8 +35,6 @@ nav:
     - 'Jobs': 'api/jobs.md'
     - 'Services': 'api/services.md'
     - 'OpenAPI (Swagger)': 'api/swagger.md'
-    # - 'Swagger': 'api/swagger.html'
-  - 'Contributing': 'contrib.md'
 plugins:
   - search
   - mkdocstrings:
@@ -52,7 +50,7 @@ plugins:
   #     enable_creation_date: true
   - swagger-ui-tag:
       supportedSubmitMethods: []
-  - mike:
+  - mike
 markdown_extensions:
   - footnotes
   - admonition

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ plugins:
   #     enable_creation_date: true
   - swagger-ui-tag:
       supportedSubmitMethods: []
+  - mike:
 markdown_extensions:
   - footnotes
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ scripts.blackfish = "app.cli.__main__:main"
 dev = [
   "ipython>=9.0.2",
   "locust>=2.33.2",
+  "mike>=2.1.3",
   "mkdocs>=1.6.1",
   "mkdocs-material>=9.6.2",
   "mkdocs-swagger-ui-tag>=0.6.11",

--- a/uv.lock
+++ b/uv.lock
@@ -291,6 +291,7 @@ uv = [
 dev = [
     { name = "ipython" },
     { name = "locust" },
+    { name = "mike" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocs-swagger-ui-tag" },
@@ -304,7 +305,7 @@ requires-dist = [
     { name = "advanced-alchemy", specifier = ">=0.27.1,<0.28" },
     { name = "aiohttp", specifier = ">=3.11.11" },
     { name = "aiosqlite", specifier = ">=0.20" },
-    { name = "alembic", specifier = ">=1.14.0,<1.16" },
+    { name = "alembic", specifier = ">=1.14,<1.16" },
     { name = "colorlog", specifier = ">=6.9" },
     { name = "fabric", specifier = ">=3.2.2" },
     { name = "huggingface-hub", specifier = ">=0.27.1" },
@@ -327,6 +328,7 @@ requires-dist = [
 dev = [
     { name = "ipython", specifier = ">=9.0.2" },
     { name = "locust", specifier = ">=2.33.2" },
+    { name = "mike", specifier = ">=2.1.3" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.6.2" },
     { name = "mkdocs-swagger-ui-tag", specifier = ">=0.6.11" },
@@ -928,6 +930,27 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656 },
+]
+
+[[package]]
+name = "importlib-resources"
+version = "6.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461 },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1194,6 +1217,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354 },
+]
+
+[[package]]
+name = "mike"
+version = "2.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "importlib-resources" },
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "verspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/f7/2933f1a1fb0e0f077d5d6a92c6c7f8a54e6128241f116dff4df8b6050bbf/mike-2.1.3.tar.gz", hash = "sha256:abd79b8ea483fb0275b7972825d3082e5ae67a41820f8d8a0dc7a3f49944e810", size = 38119 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/1a/31b7cd6e4e7a02df4e076162e9783620777592bea9e4bb036389389af99d/mike-2.1.3-py3-none-any.whl", hash = "sha256:d90c64077e84f06272437b464735130d380703a76a5738b152932884c60c062a", size = 33754 },
 ]
 
 [[package]]
@@ -1781,6 +1823,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyparsing"
+version = "3.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/22/f1129e69d94ffff626bdb5c835506b3a5b4f3d070f17ea295e12c2c6f60f/pyparsing-3.2.3.tar.gz", hash = "sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be", size = 1088608 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/e7/df2285f3d08fee213f2d041540fa4fc9ca6c2d44cf36d3a035bf2a8d2bcc/pyparsing-3.2.3-py3-none-any.whl", hash = "sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf", size = 111120 },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2204,6 +2255,15 @@ wheels = [
 ]
 
 [[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640 },
+]
+
+[[package]]
 name = "virtualenv"
 version = "20.31.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2400,6 +2460,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/3c/70df5034e6712fcc238b76f6afd1871de143a2a124d80ae2c377cde180f3/yaspin-3.1.0.tar.gz", hash = "sha256:7b97c7e257ec598f98cef9878e038bfa619ceb54ac31d61d8ead2b3128f8d7c7", size = 36791 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/78/fa25b385d9f2c406719b5cf574a0980f5ccc6ea1f8411d56249f44acd3c2/yaspin-3.1.0-py3-none-any.whl", hash = "sha256:5e3d4dfb547d942cae6565718123f1ecfa93e745b7e51871ad2bbae839e71b73", size = 18629 },
+]
+
+[[package]]
+name = "zipp"
+version = "3.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/50/bad581df71744867e9468ebd0bcd6505de3b275e06f202c2cb016e3ff56f/zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4", size = 24545 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/1a/7e4798e9339adc931158c9d69ecc34f5e6791489d469f5e50ec15e35f458/zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931", size = 9630 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR uses `mike` to handle documentation versioning *and* previews.

We set up `mike` by manually running
```
mike delete --all
mike deploy 0.1.0 latest
mike set-default latest
```

This creates three commits to `gh-pages`: one that deleted the existing documentation, one that created new documentation in `0.1.0`, and one that created `latest` linked to `0.1.0`. The PR itself generates a preview documentation site in `pr-previews/pr-100`. Therefore, after this PR is merged, `gh-pages` will look like this:
```
0.1.0
latest
pr-preview
  |-pr-100
```

Going forward, each PR will create a new preview deployment under `pr-preview`. You can delete these previews from a development branch by running
```
mike delete --deploy-prefix pr-[N]
```

Pushing to `main` does *not* generate new documentation under the current setup, but new tags on `main` will create a a new document version and update `latest` to point to the new version.