### PR TITLE
Support multi-instance GPUs with vLLM

### DIFF
--- a/src/app/templates/base_slurm.sh
+++ b/src/app/templates/base_slurm.sh
@@ -19,6 +19,9 @@
 {% block prelude %}
 export APPTAINER_CACHEDIR=/scratch/gpfs/{{ profile.user }}/APPTAINER_CACHE
 export APPTAINER_TMPDIR=/tmp
+{%- if job_config.gres > 0 %}
+export APPTAINERENV_CUDA_VISIBLE_DEVICES={{ range(job_config.gres) | join(',') }}
+{%- endif %}
 {% raw %}
 port=$(comm -23 <(seq 8080 8899 | sort) <(ss -Htan | awk '{{print $4}}' | cut -d':' -f2 | sort -u) | shuf | head -n 1)
 {% endraw %}

--- a/src/app/templates/speech_recognition_local.sh
+++ b/src/app/templates/speech_recognition_local.sh
@@ -1,7 +1,7 @@
 {% extends "base_local.sh" %}
 {% block command %}
 {%- if provider == "docker" %}
-docker run -d {{ ' --gpus all' if job_config.gres else '' }} \
+docker run -d {{ '--runtime nvidia --gpus all' if job_config.gres else '' }} \
   -p {{ container_config.port }}:{{ container_config.port }} \
   -v {{ mount }}:/data/audio \
   -v {{ container_config.model_dir }}:/data/models \


### PR DESCRIPTION
Fixes #108 by setting `APPTAINERENV_CUDA_VISIBLE_DEVICES` to enumerate the selected number of devices, e.g., `gres = 4 => 0,1,2,3`.

This PR does not adjust the current launch command for services launched using the local strategy (regardless of provider). In other words, we assume local launches do not use MIG.