### PR TITLE
Fix psutil.AccessDenied crash in close_tunnel

### DIFF
--- a/lib/.pre-commit-config.yaml
+++ b/lib/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.13
+    rev: v0.14.14
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]

--- a/lib/docs/assets/img/coverage.svg
+++ b/lib/docs/assets/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">57%</text>
-        <text x="80" y="14">57%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">58%</text>
+        <text x="80" y="14">58%</text>
     </g>
 </svg>

--- a/lib/src/blackfish/server/services/base.py
+++ b/lib/src/blackfish/server/services/base.py
@@ -595,7 +595,7 @@ class Service(UUIDAuditBase):
             try:
                 cs = p.net_connections()
             except psutil.AccessDenied:
-                logger.warning(f"Access denied to process {p}.")
+                logger.warning(f"Access denied to process {pid}.")
                 continue
             for c in cs:
                 if c.laddr.port == self.port:

--- a/lib/src/blackfish/server/services/base.py
+++ b/lib/src/blackfish/server/services/base.py
@@ -583,7 +583,13 @@ class Service(UUIDAuditBase):
             return
 
         logger.info(f"Closing tunnel for service {self.id} on port {self.port}.")
-        ps = [p for p in psutil.process_iter() if p.name() == "ssh"]
+        ps = []
+        for p in psutil.process_iter(["name"]):
+            try:
+                if p.info.get("name") == "ssh":
+                    ps.append(p)
+            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+                continue
         for p in ps:
             pid = p.pid
             try:

--- a/lib/tests/unit/test_services.py
+++ b/lib/tests/unit/test_services.py
@@ -1,0 +1,163 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import psutil
+
+from blackfish.server.services.base import Service
+
+
+pytestmark = pytest.mark.anyio
+
+
+class TestCloseTunnel:
+    """Test cases for Service.close_tunnel method."""
+
+    async def test_close_tunnel_handles_access_denied_on_name(self, session):
+        """Test that AccessDenied on p.info['name'] doesn't crash close_tunnel."""
+        service = Service(port=8080)
+
+        # Create mock process that raises AccessDenied when accessing info
+        mock_proc = MagicMock()
+        mock_proc.info = property(
+            lambda self: (_ for _ in ()).throw(psutil.AccessDenied(pid=1234))
+        )
+
+        # Simulate AccessDenied by having info.get() raise
+        mock_proc_with_error = MagicMock()
+        mock_proc_with_error.info.get.side_effect = psutil.AccessDenied(pid=1234)
+
+        with patch("blackfish.server.services.base.psutil.process_iter") as mock_iter:
+            mock_iter.return_value = [mock_proc_with_error]
+            # Should not raise - this is the bug we fixed
+            await service.close_tunnel(session)
+
+        # Port should be set to None even if we couldn't find the tunnel
+        assert service.port is None
+
+    async def test_close_tunnel_handles_no_such_process(self, session):
+        """Test that NoSuchProcess during iteration is handled."""
+        service = Service(port=8080)
+
+        mock_proc = MagicMock()
+        mock_proc.info.get.side_effect = psutil.NoSuchProcess(pid=1234)
+
+        with patch("blackfish.server.services.base.psutil.process_iter") as mock_iter:
+            mock_iter.return_value = [mock_proc]
+            await service.close_tunnel(session)
+
+        assert service.port is None
+
+    async def test_close_tunnel_handles_zombie_process(self, session):
+        """Test that ZombieProcess during iteration is handled."""
+        service = Service(port=8080)
+
+        mock_proc = MagicMock()
+        mock_proc.info.get.side_effect = psutil.ZombieProcess(pid=1234)
+
+        with patch("blackfish.server.services.base.psutil.process_iter") as mock_iter:
+            mock_iter.return_value = [mock_proc]
+            await service.close_tunnel(session)
+
+        assert service.port is None
+
+    async def test_close_tunnel_handles_access_denied_on_connections(self, session):
+        """Test that AccessDenied on p.net_connections() is handled."""
+        service = Service(port=8080)
+
+        mock_proc = MagicMock()
+        mock_proc.info.get.return_value = "ssh"
+        mock_proc.pid = 1234
+        mock_proc.net_connections.side_effect = psutil.AccessDenied(pid=1234)
+
+        with patch("blackfish.server.services.base.psutil.process_iter") as mock_iter:
+            mock_iter.return_value = [mock_proc]
+            await service.close_tunnel(session)
+
+        assert service.port is None
+
+    async def test_close_tunnel_kills_matching_ssh_process(self, session):
+        """Test that close_tunnel kills the correct ssh process."""
+        service = Service(port=8080)
+
+        mock_conn = MagicMock()
+        mock_conn.laddr.port = 8080
+
+        mock_proc = MagicMock()
+        mock_proc.info.get.return_value = "ssh"
+        mock_proc.pid = 1234
+        mock_proc.net_connections.return_value = [mock_conn]
+
+        with patch("blackfish.server.services.base.psutil.process_iter") as mock_iter:
+            mock_iter.return_value = [mock_proc]
+            await service.close_tunnel(session)
+
+        mock_proc.kill.assert_called_once()
+        assert service.port is None
+
+    async def test_close_tunnel_skips_non_ssh_processes(self, session):
+        """Test that close_tunnel only considers ssh processes."""
+        service = Service(port=8080)
+
+        mock_proc = MagicMock()
+        mock_proc.info.get.return_value = "python"  # Not ssh
+        mock_proc.pid = 1234
+
+        with patch("blackfish.server.services.base.psutil.process_iter") as mock_iter:
+            mock_iter.return_value = [mock_proc]
+            await service.close_tunnel(session)
+
+        # Should not try to get connections for non-ssh processes
+        mock_proc.net_connections.assert_not_called()
+        assert service.port is None
+
+    async def test_close_tunnel_skips_ssh_on_different_port(self, session):
+        """Test that close_tunnel doesn't kill ssh on different port."""
+        service = Service(port=8080)
+
+        mock_conn = MagicMock()
+        mock_conn.laddr.port = 9999  # Different port
+
+        mock_proc = MagicMock()
+        mock_proc.info.get.return_value = "ssh"
+        mock_proc.pid = 1234
+        mock_proc.net_connections.return_value = [mock_conn]
+
+        with patch("blackfish.server.services.base.psutil.process_iter") as mock_iter:
+            mock_iter.return_value = [mock_proc]
+            await service.close_tunnel(session)
+
+        mock_proc.kill.assert_not_called()
+        assert service.port is None
+
+    async def test_close_tunnel_noop_when_port_is_none(self, session):
+        """Test that close_tunnel does nothing when port is None."""
+        service = Service(port=None)
+
+        with patch("blackfish.server.services.base.psutil.process_iter") as mock_iter:
+            await service.close_tunnel(session)
+
+        # Should not iterate processes when port is None
+        mock_iter.assert_not_called()
+
+    async def test_close_tunnel_handles_mixed_accessible_processes(self, session):
+        """Test close_tunnel with mix of accessible and inaccessible processes."""
+        service = Service(port=8080)
+
+        # First process raises AccessDenied
+        mock_proc_denied = MagicMock()
+        mock_proc_denied.info.get.side_effect = psutil.AccessDenied(pid=1111)
+
+        # Second process is the one we want to kill
+        mock_conn = MagicMock()
+        mock_conn.laddr.port = 8080
+        mock_proc_target = MagicMock()
+        mock_proc_target.info.get.return_value = "ssh"
+        mock_proc_target.pid = 2222
+        mock_proc_target.net_connections.return_value = [mock_conn]
+
+        with patch("blackfish.server.services.base.psutil.process_iter") as mock_iter:
+            mock_iter.return_value = [mock_proc_denied, mock_proc_target]
+            await service.close_tunnel(session)
+
+        # Should skip denied process and kill the target
+        mock_proc_target.kill.assert_called_once()
+        assert service.port is None


### PR DESCRIPTION
## Summary

- Fix unhandled `psutil.AccessDenied` exception in `close_tunnel()` that caused 500 errors when running `blackfish ls` on HPC clusters
- The `p.name()` call in the process iteration was not exception-wrapped, unlike `p.net_connections()`
- Add 9 unit tests for `close_tunnel()` covering various psutil exception scenarios

## Test plan

- [x] Unit tests pass (9 new tests for `close_tunnel`)
- [x] Full test suite passes (351 tests)
- [ ] Manual testing on HPC cluster with timed-out services

🤖 Generated with [Claude Code](https://claude.com/claude-code)