### PR TITLE
Raise meaningful service launch exceptions

### DIFF
--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -76,7 +76,7 @@ from blackfish.server.files import (
     validate_file_size,
 )
 from blackfish.server import sftp
-from blackfish.server.services.base import Service, ServiceStatus
+from blackfish.server.services.base import Service, ServiceLaunchError, ServiceStatus
 from blackfish.server.services.speech_recognition import SpeechRecognitionConfig
 from blackfish.server.services.text_generation import TextGenerationConfig
 from blackfish.server.jobs.base import BatchJob, BatchJobStatus
@@ -1139,9 +1139,12 @@ async def run_service(
             container_options=data.container_config,
             job_options=data.job_config,
         )
+    except ServiceLaunchError as e:
+        logger.warning(f"Service launch failed: {e.error_type}")
+        raise InternalServerException(detail=e.user_message())
     except Exception as e:
-        logger.error(f"Failed to start service: {e}")
-        raise InternalServerException(detail=f"Failed to start service: {e}")
+        logger.error(f"Unexpected error starting service: {e}")
+        raise InternalServerException(detail="Failed to launch service.")
 
     return service
 

--- a/lib/src/blackfish/server/services/base.py
+++ b/lib/src/blackfish/server/services/base.py
@@ -50,7 +50,7 @@ class ServiceLaunchError(Exception):
             "ssh": f"Could not connect to {self.host}. Check your SSH configuration.",
             "copy": f"Failed to copy files to {self.host}. Check permissions and disk space.",
             "submit": f"Job submission failed on {self.host}. The scheduler may be unavailable.",
-            "container": "Failed to start the container. Check that Docker or Apptainer is running.",
+            "container": "Failed to start the container. Check that Docker is running and, if using GPU, that nvidia-container-toolkit is installed.",
         }
         return messages.get(self.error_type, "Failed to launch service.")
 

--- a/lib/src/blackfish/server/services/base.py
+++ b/lib/src/blackfish/server/services/base.py
@@ -34,7 +34,21 @@ from blackfish.server.models.profile import BlackfishProfile, LocalProfile, Slur
 
 
 class ServiceLaunchError(Exception):
-    """Error launching a service with user-friendly messages."""
+    """Error raised when a service fails to launch, with user-friendly messages.
+
+    Error types:
+        script: Launch script generation failed
+        profile: Profile configuration is missing or invalid
+        ssh: SSH connection to remote host failed
+        copy: File copy to remote host failed
+        submit: Job submission to scheduler failed
+        container: Local container startup failed
+
+    Args:
+        error_type: One of the error types listed above
+        host: The target host where the error occurred
+        details: Optional additional context to append to the message
+    """
 
     def __init__(self, error_type: str, host: str, details: str | None = None):
         self.error_type = error_type
@@ -52,7 +66,10 @@ class ServiceLaunchError(Exception):
             "submit": f"Job submission failed on {self.host}. The scheduler may be unavailable.",
             "container": "Failed to start the container. Check that Docker is running and, if using GPU, that nvidia-container-toolkit is installed.",
         }
-        return messages.get(self.error_type, "Failed to launch service.")
+        message = messages.get(self.error_type, "Failed to launch service.")
+        if self.details:
+            message = f"{message} ({self.details})"
+        return message
 
 
 @dataclass

--- a/lib/src/blackfish/server/services/base.py
+++ b/lib/src/blackfish/server/services/base.py
@@ -33,6 +33,28 @@ from blackfish.server.config import ContainerProvider
 from blackfish.server.models.profile import BlackfishProfile, LocalProfile, SlurmProfile
 
 
+class ServiceLaunchError(Exception):
+    """Error launching a service with user-friendly messages."""
+
+    def __init__(self, error_type: str, host: str, details: str | None = None):
+        self.error_type = error_type
+        self.host = host
+        self.details = details
+        super().__init__(self.user_message())
+
+    def user_message(self) -> str:
+        """Return a user-friendly error message."""
+        messages = {
+            "script": "Failed to generate the launch script. Check model and configuration settings.",
+            "profile": "Profile configuration is missing or invalid.",
+            "ssh": f"Could not connect to {self.host}. Check your SSH configuration.",
+            "copy": f"Failed to copy files to {self.host}. Check permissions and disk space.",
+            "submit": f"Job submission failed on {self.host}. The scheduler may be unavailable.",
+            "container": "Failed to start the container. Check that Docker or Apptainer is running.",
+        }
+        return messages.get(self.error_type, "Failed to launch service.")
+
+
 @dataclass
 class BaseConfig:
     port: Optional[int]
@@ -134,7 +156,7 @@ class Service(UUIDAuditBase):
                     f.write(script)
                 except Exception as e:
                     logger.error(f"Unable to render launch script: {e}")
-                    return
+                    raise ServiceLaunchError("script", self.host)
 
             logger.info("Starting service")
 
@@ -155,7 +177,7 @@ class Service(UUIDAuditBase):
                 profile = self.get_profile()
                 if profile is None:
                     logger.error("Failed to start service: profile is missing.")
-                    return
+                    raise ServiceLaunchError("profile", self.host)
 
                 logger.debug(f"Copying job script to {self.host}:{profile.home_dir}.")
                 remote_script_dir = os.path.join(profile.home_dir, "jobs", self.id.hex)
@@ -171,8 +193,8 @@ class Service(UUIDAuditBase):
                         ]
                     )
                 except Exception as e:
-                    logger.error(f"Failed to copy job script to remote host: {e}.")
-                    raise
+                    logger.error(f"Failed to connect to remote host: {e}")
+                    raise ServiceLaunchError("ssh", self.host)
 
                 try:
                     _ = subprocess.check_output(
@@ -184,7 +206,7 @@ class Service(UUIDAuditBase):
                     )
                 except Exception as e:
                     logger.error(f"Failed to copy job script to remote host: {e}")
-                    raise
+                    raise ServiceLaunchError("copy", self.host)
 
                 logger.debug(f"Submitting batch job to {self.host}.")
                 try:
@@ -203,7 +225,7 @@ class Service(UUIDAuditBase):
                     self.job_id = job_id
                 except Exception as e:
                     logger.error(f"Failed to submit Slurm job: {e}")
-                    raise
+                    raise ServiceLaunchError("submit", self.host)
         else:
             script_path = Path(
                 os.path.join(app_config.HOME_DIR, "jobs", self.id.hex, "start.sh")
@@ -231,13 +253,14 @@ class Service(UUIDAuditBase):
                             )
                     f.write(script)
                 except Exception as e:
-                    logger.error(e)
-                    return
+                    logger.error(f"Unable to render launch script: {e}")
+                    raise ServiceLaunchError("script", "localhost")
             logger.info("Attempting to start service locally...")
             try:
                 res = subprocess.check_output(["bash", script_path.as_posix()])
             except Exception as e:
-                logger.error(f"Failed to start service: {e}")
+                logger.error(f"Failed to start container: {e}")
+                raise ServiceLaunchError("container", "localhost")
             if self.provider == ContainerProvider.Docker:
                 job_id = res.decode("utf-8").strip().split()[-1][:12]
             self.status = ServiceStatus.SUBMITTED

--- a/lib/src/blackfish/server/sftp.py
+++ b/lib/src/blackfish/server/sftp.py
@@ -56,7 +56,9 @@ def get_file_size(profile: SlurmProfile, path: str) -> int:
                 stat = sftp.stat(path)
                 size: int | None = stat.st_size
                 if size is None:
-                    raise InternalServerException(f"Could not determine file size: {path}")
+                    raise InternalServerException(
+                        f"Could not determine file size: {path}"
+                    )
                 return size
     except FileNotFoundError:
         raise NotFoundException(f"Remote file not found: {path}")

--- a/lib/tests/api/test_services.py
+++ b/lib/tests/api/test_services.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 from litestar.testing import AsyncTestClient
 
-from blackfish.server.services.base import Service
+from blackfish.server.services.base import Service, ServiceLaunchError
 
 
 pytestmark = pytest.mark.anyio
@@ -452,3 +452,98 @@ class TestPruneServicesAPI:
         # The actual count depends on test data, just verify it returns a number
         result = response.json()
         assert isinstance(result, int)
+
+
+class TestCreateServiceErrorHandling:
+    """Test cases for error handling in service creation."""
+
+    async def test_service_launch_error_returns_user_message(
+        self, client: AsyncTestClient
+    ):
+        """Test that ServiceLaunchError returns user-friendly message in response."""
+        with patch.object(
+            Service,
+            "start",
+            new_callable=AsyncMock,
+            side_effect=ServiceLaunchError("ssh", "cluster.example.com"),
+        ):
+            data = {
+                "name": "test",
+                "image": "text_generation",
+                "repo_id": "meta-llama/Llama-3.2-3B",
+                "profile": {
+                    "name": "test",
+                    "home_dir": "test",
+                    "cache_dir": "test",
+                },
+                "container_config": {"port": 8080},
+                "job_config": {},
+            }
+
+            response = await client.post("/api/services", json=data)
+
+            assert response.status_code == 500
+            result = response.json()
+            # Error message should be user-friendly, not a Python traceback
+            assert "Could not connect to cluster.example.com" in result["detail"]
+
+    async def test_service_launch_error_container_message(
+        self, client: AsyncTestClient
+    ):
+        """Test that container errors return helpful message about Docker/nvidia."""
+        with patch.object(
+            Service,
+            "start",
+            new_callable=AsyncMock,
+            side_effect=ServiceLaunchError("container", "localhost"),
+        ):
+            data = {
+                "name": "test",
+                "image": "text_generation",
+                "repo_id": "meta-llama/Llama-3.2-3B",
+                "profile": {
+                    "name": "test",
+                    "home_dir": "test",
+                    "cache_dir": "test",
+                },
+                "container_config": {"port": 8080},
+                "job_config": {},
+            }
+
+            response = await client.post("/api/services", json=data)
+
+            assert response.status_code == 500
+            result = response.json()
+            assert "Docker" in result["detail"]
+            assert "nvidia-container-toolkit" in result["detail"]
+
+    async def test_unexpected_error_returns_generic_message(
+        self, client: AsyncTestClient
+    ):
+        """Test that unexpected errors return generic message (no traceback leak)."""
+        with patch.object(
+            Service,
+            "start",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("Internal database connection failed"),
+        ):
+            data = {
+                "name": "test",
+                "image": "text_generation",
+                "repo_id": "meta-llama/Llama-3.2-3B",
+                "profile": {
+                    "name": "test",
+                    "home_dir": "test",
+                    "cache_dir": "test",
+                },
+                "container_config": {"port": 8080},
+                "job_config": {},
+            }
+
+            response = await client.post("/api/services", json=data)
+
+            assert response.status_code == 500
+            result = response.json()
+            # Should NOT leak internal error details
+            assert "Internal database connection failed" not in result["detail"]
+            assert result["detail"] == "Failed to launch service."

--- a/lib/tests/unit/test_services.py
+++ b/lib/tests/unit/test_services.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 import psutil
 
-from blackfish.server.services.base import Service
+from blackfish.server.services.base import Service, ServiceLaunchError
 
 
 pytestmark = pytest.mark.anyio
@@ -155,3 +155,70 @@ class TestCloseTunnel:
         # Should skip denied process and kill the target
         mock_proc_target.kill.assert_called_once()
         assert service.port is None
+
+
+class TestServiceLaunchError:
+    """Test cases for ServiceLaunchError exception class."""
+
+    def test_ssh_error_message(self):
+        """Test SSH error message includes host."""
+        error = ServiceLaunchError("ssh", "cluster.example.com")
+        assert "Could not connect to cluster.example.com" in error.user_message()
+        assert str(error) == error.user_message()
+
+    def test_copy_error_message(self):
+        """Test copy error message includes host."""
+        error = ServiceLaunchError("copy", "cluster.example.com")
+        assert "Failed to copy files to cluster.example.com" in error.user_message()
+
+    def test_submit_error_message(self):
+        """Test submit error message includes host."""
+        error = ServiceLaunchError("submit", "cluster.example.com")
+        assert "Job submission failed on cluster.example.com" in error.user_message()
+
+    def test_script_error_message(self):
+        """Test script error message."""
+        error = ServiceLaunchError("script", "localhost")
+        assert "Failed to generate the launch script" in error.user_message()
+
+    def test_profile_error_message(self):
+        """Test profile error message."""
+        error = ServiceLaunchError("profile", "localhost")
+        assert "Profile configuration is missing or invalid" in error.user_message()
+
+    def test_container_error_message(self):
+        """Test container error message mentions Docker and nvidia-container-toolkit."""
+        error = ServiceLaunchError("container", "localhost")
+        message = error.user_message()
+        assert "Docker" in message
+        assert "nvidia-container-toolkit" in message
+
+    def test_unknown_error_type_returns_fallback(self):
+        """Test that unknown error types return fallback message."""
+        error = ServiceLaunchError("unknown_type", "localhost")
+        assert error.user_message() == "Failed to launch service."
+
+    def test_details_parameter_stored(self):
+        """Test that details parameter is stored on the exception."""
+        error = ServiceLaunchError("ssh", "localhost", details="Connection refused")
+        assert error.details == "Connection refused"
+
+    def test_details_included_in_message(self):
+        """Test that details are appended to user message when provided."""
+        error = ServiceLaunchError("ssh", "cluster.example.com", details="Connection refused")
+        message = error.user_message()
+        assert "Could not connect to cluster.example.com" in message
+        assert "(Connection refused)" in message
+
+    def test_message_without_details(self):
+        """Test that message works without details."""
+        error = ServiceLaunchError("ssh", "cluster.example.com")
+        message = error.user_message()
+        assert "Could not connect to cluster.example.com" in message
+        assert "(" not in message  # No parentheses when no details
+
+    def test_error_attributes(self):
+        """Test that error type and host are accessible as attributes."""
+        error = ServiceLaunchError("submit", "hpc.princeton.edu")
+        assert error.error_type == "submit"
+        assert error.host == "hpc.princeton.edu"

--- a/web/src/components/ServiceModal.jsx
+++ b/web/src/components/ServiceModal.jsx
@@ -170,13 +170,20 @@ function ServiceModal({
     setLaunchError(null)
     const res = await runService(task, model, jobOptions, containerOptions, profile);
     if (!res.ok) {
-      const text = await res.text()
-      const error = new Error("A service request failed with message:", text);
+      let message = "Failed to launch service.";
+      try {
+        const body = await res.json();
+        if (body.detail) {
+          message = body.detail;
+        }
+      } catch {
+        // Response wasn't JSON, use default message
+      }
+      const error = new Error(message);
       console.error(error);
       setIsLaunching(false);
       setLaunchError(error);
-      return // TODO: or throw the error? What handling is more user-friendly and
-      // looks nice?
+      return;
     }
     const data = await res.json();
     console.debug("from handleFormSubmit: received response", data.id);

--- a/web/src/components/ServiceModal.jsx
+++ b/web/src/components/ServiceModal.jsx
@@ -176,8 +176,13 @@ function ServiceModal({
         if (body.detail) {
           message = body.detail;
         }
-      } catch {
+      } catch (parseError) {
         // Response wasn't JSON, use default message
+        console.debug("from handleFormSubmit: failed to parse error response as JSON", {
+          status: res.status,
+          statusText: res.statusText,
+          parseError,
+        });
       }
       const error = new Error(message);
       console.error(error);


### PR DESCRIPTION
## Summary

- Add `ServiceLaunchError` exception class with user-friendly error messages for script generation, profile validation, SSH connection, file copy, job submission, and container startup failures
- Update `run_service` endpoint to catch `ServiceLaunchError` and return appropriate error details
- Fix frontend `ServiceModal.jsx` to parse JSON response body for error details (previously the error message was ignored due to incorrect `Error` constructor usage)

## Test plan

- [x] Attempt to launch local service without Docker running - should see container startup error
- [x] Attempt to launch with GPU on machine without nvidia-container-toolkit - should see helpful error about nvidia-container-toolkit
- [x] Verify successful service launches still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)