### PR TITLE
Add text/code file attachments to text generation

### DIFF
--- a/web/src/routes/text-generation/components/AttachmentMenu.jsx
+++ b/web/src/routes/text-generation/components/AttachmentMenu.jsx
@@ -7,17 +7,42 @@ import {
 } from "@heroicons/react/24/outline";
 import PropTypes from "prop-types";
 
-const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const DEFAULT_MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+/**
+ * Format bytes into a human-readable string.
+ * @param {number} bytes
+ * @return {string}
+ */
+function formatBytes(bytes) {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)}KB`;
+  return `${Math.round(bytes / (1024 * 1024))}MB`;
+}
 
 /**
  * Dropdown menu for attaching files (browser upload or remote selection).
+ * Configurable for different file types (images, text files, etc.).
  * @param {object} props
+ * @param {string} props.accept - File types to accept (e.g., "image/*" or ".txt,.md,.py").
+ * @param {number} props.maxFileSize - Maximum file size in bytes.
+ * @param {React.ElementType} props.icon - Icon component to display.
+ * @param {string} props.label - Screen reader label for the button.
  * @param {object|null} props.profile - Current profile to determine remote availability.
  * @param {Function} props.onBrowserUpload - Callback when browser files are selected.
  * @param {Function} props.onRemoteSelect - Callback to open remote file browser.
  * @param {Function} props.onError - Callback when file validation fails.
  */
-function AttachmentMenu({ profile, onBrowserUpload, onRemoteSelect, onError }) {
+function AttachmentMenu({
+  accept,
+  maxFileSize = DEFAULT_MAX_FILE_SIZE,
+  icon: Icon = PaperClipIcon,
+  label = "Attach a file",
+  profile,
+  onBrowserUpload,
+  onRemoteSelect,
+  onError,
+}) {
   const fileInputRef = useRef(null);
   const isRemote = profile && profile.schema !== "local";
 
@@ -26,9 +51,9 @@ function AttachmentMenu({ profile, onBrowserUpload, onRemoteSelect, onError }) {
     const validFiles = [];
 
     for (const file of files) {
-      if (file.size > MAX_FILE_SIZE) {
+      if (file.size > maxFileSize) {
         if (onError) {
-          onError(file.name, "File exceeds 5MB limit");
+          onError(file.name, `File exceeds ${formatBytes(maxFileSize)} limit`);
         }
       } else {
         validFiles.push(file);
@@ -51,7 +76,7 @@ function AttachmentMenu({ profile, onBrowserUpload, onRemoteSelect, onError }) {
       <input
         ref={fileInputRef}
         type="file"
-        accept="image/*"
+        accept={accept}
         multiple
         onChange={handleFileInputChange}
         className="hidden"
@@ -59,8 +84,8 @@ function AttachmentMenu({ profile, onBrowserUpload, onRemoteSelect, onError }) {
 
       <Menu as="div" className="relative inline-block text-left">
         <MenuButton className="-m-2.5 flex size-10 items-center justify-center rounded-full text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 focus:outline-none">
-          <PaperClipIcon aria-hidden="true" className="size-5" />
-          <span className="sr-only">Attach a file</span>
+          <Icon aria-hidden="true" className="size-5" />
+          <span className="sr-only">{label}</span>
         </MenuButton>
 
         <MenuItems
@@ -117,6 +142,10 @@ function AttachmentMenu({ profile, onBrowserUpload, onRemoteSelect, onError }) {
 }
 
 AttachmentMenu.propTypes = {
+  accept: PropTypes.string,
+  maxFileSize: PropTypes.number,
+  icon: PropTypes.elementType,
+  label: PropTypes.string,
   profile: PropTypes.object,
   onBrowserUpload: PropTypes.func.isRequired,
   onRemoteSelect: PropTypes.func.isRequired,

--- a/web/src/routes/text-generation/components/FileAttachmentList.jsx
+++ b/web/src/routes/text-generation/components/FileAttachmentList.jsx
@@ -1,0 +1,114 @@
+import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
+import { DocumentTextIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import PropTypes from "prop-types";
+
+/**
+ * Single file chip with preview popover.
+ * @param {object} props
+ * @param {object} props.file - File object with name and content.
+ * @param {number} props.index - Index of the file in the list.
+ * @param {Function} props.onRemove - Callback to remove the file (optional for read-only display).
+ * @param {boolean} props.readOnly - If true, hide the remove button.
+ */
+function FileChip({ file, index, onRemove, readOnly = false }) {
+  const fileName = file.name || (file.file && file.file.name) || "Unknown file";
+  const truncatedName = fileName.length > 20 ? fileName.slice(0, 17) + "..." : fileName;
+
+  return (
+    <Popover className="relative">
+      <div className={`flex items-center gap-1 bg-gray-200 dark:bg-gray-600 rounded-md pl-2 ${readOnly ? 'pr-2' : 'pr-1'} py-1 text-sm text-gray-700 dark:text-gray-300`}>
+        <PopoverButton className="flex items-center gap-1.5 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none">
+          <DocumentTextIcon className="size-4 text-gray-500 dark:text-gray-400" />
+          <span className="max-w-[150px] truncate" title={fileName}>
+            {truncatedName}
+          </span>
+        </PopoverButton>
+        {!readOnly && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove(index);
+            }}
+            className="ml-1 rounded-full p-0.5 hover:bg-gray-200 dark:hover:bg-gray-600 focus:outline-none"
+          >
+            <XMarkIcon className="size-3.5 text-gray-500 dark:text-gray-400" />
+            <span className="sr-only">Remove {fileName}</span>
+          </button>
+        )}
+      </div>
+
+      <PopoverPanel
+        anchor="top"
+        className="z-50 w-96 max-h-80 rounded-lg bg-white dark:bg-gray-800 shadow-lg ring-1 ring-black/5 dark:ring-white/10 overflow-hidden mb-2"
+      >
+        <div className="p-3 border-b border-gray-200 dark:border-gray-700">
+          <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate" title={fileName}>
+            {fileName}
+          </h3>
+        </div>
+        <div className="p-3 max-h-60 overflow-y-auto">
+          <pre className="text-xs text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words font-mono">
+            {file.content || "Loading..."}
+          </pre>
+        </div>
+      </PopoverPanel>
+    </Popover>
+  );
+}
+
+FileChip.propTypes = {
+  file: PropTypes.shape({
+    source: PropTypes.oneOf(["browser", "remote"]).isRequired,
+    file: PropTypes.object,
+    path: PropTypes.string,
+    name: PropTypes.string,
+    content: PropTypes.string,
+  }).isRequired,
+  index: PropTypes.number.isRequired,
+  onRemove: PropTypes.func,
+  readOnly: PropTypes.bool,
+};
+
+/**
+ * Horizontal list of file attachment chips with preview on click.
+ * @param {object} props
+ * @param {Array} props.files - Array of file objects.
+ * @param {Function} props.onRemove - Callback to remove a file by index (optional if readOnly).
+ * @param {boolean} props.readOnly - If true, hide remove buttons (for displaying in sent messages).
+ */
+function FileAttachmentList({ files, onRemove, readOnly = false }) {
+  if (!files || files.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex gap-2 flex-wrap py-2">
+      {files.map((file, index) => (
+        <FileChip
+          key={`${file.source}-${file.source === "browser" ? file.file?.name : file.path}-${index}`}
+          file={file}
+          index={index}
+          onRemove={onRemove}
+          readOnly={readOnly}
+        />
+      ))}
+    </div>
+  );
+}
+
+FileAttachmentList.propTypes = {
+  files: PropTypes.arrayOf(
+    PropTypes.shape({
+      source: PropTypes.oneOf(["browser", "remote"]).isRequired,
+      file: PropTypes.object,
+      path: PropTypes.string,
+      name: PropTypes.string,
+      content: PropTypes.string,
+    })
+  ).isRequired,
+  onRemove: PropTypes.func,
+  readOnly: PropTypes.bool,
+};
+
+export default FileAttachmentList;

--- a/web/src/routes/text-generation/components/ImageAttachmentList.jsx
+++ b/web/src/routes/text-generation/components/ImageAttachmentList.jsx
@@ -15,7 +15,7 @@ function ImageAttachmentList({ images, onRemove, onImageError, onImageLoad }) {
   }
 
   return (
-    <div className="flex gap-2 overflow-x-auto pt-3 pb-2 px-3">
+    <div className="flex gap-2 overflow-x-auto pt-3 pb-2 pr-3">
       {images.map((image, index) => (
         <ImageAttachment
           key={`${image.source}-${image.source === "browser" ? image.file.name : image.path}-${index}`}

--- a/web/src/routes/text-generation/components/ImageAttachmentList.jsx
+++ b/web/src/routes/text-generation/components/ImageAttachmentList.jsx
@@ -39,7 +39,7 @@ ImageAttachmentList.propTypes = {
       profile: PropTypes.object,
     })
   ).isRequired,
-  onRemove: PropTypes.func.isRequired,
+  onRemove: PropTypes.func,
   onImageError: PropTypes.func,
   onImageLoad: PropTypes.func,
 };

--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
@@ -17,15 +17,15 @@ import {
   buildMultimodalContent,
   extractTextFromContent,
   extractImagesFromContent,
+  MAX_IMAGE_FILE_SIZE,
 } from "../lib/imageUtils";
 import {
-  readFileAsText,
-  fetchRemoteText,
   prependFileContext,
   getTextFileAcceptString,
   MAX_TEXT_FILE_SIZE,
   TEXT_FILE_EXTENSIONS,
 } from "../lib/fileUtils";
+import { useFileAttachments } from "../lib/useFileAttachments";
 import AttachmentMenu from "./AttachmentMenu";
 import ImageAttachmentList from "./ImageAttachmentList";
 import FileAttachmentList from "./FileAttachmentList";
@@ -152,7 +152,7 @@ function UserMessageInput({
                 {/* Image attachment menu */}
                 <AttachmentMenu
                   accept="image/*"
-                  maxFileSize={5 * 1024 * 1024}
+                  maxFileSize={MAX_IMAGE_FILE_SIZE}
                   icon={PhotoIcon}
                   label="Attach image"
                   profile={profile}
@@ -610,12 +610,23 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
     content: sessionStorage.getItem("tgcc-um") || "",
   });
   const [attachedImages, setAttachedImages] = useState([]);
-  const [attachedFiles, setAttachedFiles] = useState([]);
   const [imageBrowserOpen, setImageBrowserOpen] = useState(false);
-  const [fileBrowserOpen, setFileBrowserOpen] = useState(false);
   const [imageError, setImageError] = useState(null);
-  const [fileError, setFileError] = useState(null);
   const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
+
+  // File attachment state and handlers
+  const {
+    attachedFiles,
+    fileBrowserOpen,
+    setFileBrowserOpen,
+    fileError,
+    setFileError,
+    handleFileBrowserUpload,
+    handleFileRemoteSelect,
+    handleRemoveFile,
+    handleFileError,
+    clearFiles,
+  } = useFileAttachments();
 
   const elementRef = useRef(null);
 
@@ -658,59 +669,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
     );
   }, []);
 
-  // File attachment handlers
-  const handleFileBrowserUpload = useCallback(async (files) => {
-    for (const file of files) {
-      try {
-        const content = await readFileAsText(file);
-        setAttachedFiles((prev) => [
-          ...prev,
-          {
-            source: "browser",
-            file: file,
-            name: file.name,
-            content: content,
-          },
-        ]);
-      } catch (error) {
-        console.error("Failed to read file:", error);
-        setFileError({ fileName: file.name, message: "Failed to read file" });
-        setTimeout(() => setFileError(null), 5000);
-      }
-    }
-  }, []);
-
-  const handleFileRemoteSelect = useCallback(async (fileInfo) => {
-    try {
-      const content = await fetchRemoteText(fileInfo.path, fileInfo.profile);
-      const fileName = fileInfo.path.split("/").pop();
-      setAttachedFiles((prev) => [
-        ...prev,
-        {
-          source: "remote",
-          path: fileInfo.path,
-          profile: fileInfo.profile,
-          name: fileName,
-          content: content,
-        },
-      ]);
-    } catch (error) {
-      console.error("Failed to fetch remote file:", error);
-      const fileName = fileInfo.path.split("/").pop();
-      setFileError({ fileName, message: error.message });
-      setTimeout(() => setFileError(null), 5000);
-    }
-  }, []);
-
-  const handleRemoveFile = (index) => {
-    setAttachedFiles((prev) => prev.filter((_, i) => i !== index));
-  };
-
-  const handleFileError = useCallback((fileName, errorMessage) => {
-    setFileError({ fileName, message: errorMessage });
-    setTimeout(() => setFileError(null), 5000);
-  }, []);
-
+  
   const handleSubmit = async (event) => {
     event.preventDefault();
     console.log("user message submitted");
@@ -770,7 +729,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
 
     // Clear attachments after sending
     setAttachedImages([]);
-    setAttachedFiles([]);
+    clearFiles();
 
     // Show loading state while waiting for first response chunk
     setIsWaitingForResponse(true);

--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
@@ -3,9 +3,11 @@ import {
   ArrowPathIcon,
   CheckIcon,
   ClipboardDocumentIcon,
+  DocumentTextIcon,
   PaperAirplaneIcon,
   PencilIcon,
   XMarkIcon,
+  PhotoIcon,
 } from "@heroicons/react/24/outline";
 import { ServiceContext } from "@/providers/ServiceProvider";
 import { ProfileContext } from "@/components/ProfileSelect";
@@ -16,8 +18,17 @@ import {
   extractTextFromContent,
   extractImagesFromContent,
 } from "../lib/imageUtils";
+import {
+  readFileAsText,
+  fetchRemoteText,
+  prependFileContext,
+  getTextFileAcceptString,
+  MAX_TEXT_FILE_SIZE,
+  TEXT_FILE_EXTENSIONS,
+} from "../lib/fileUtils";
 import AttachmentMenu from "./AttachmentMenu";
 import ImageAttachmentList from "./ImageAttachmentList";
+import FileAttachmentList from "./FileAttachmentList";
 import FileSelectModal from "@/components/FileSelectModal";
 import Notification from "@/components/Notification";
 import { IMAGE_EXTENSIONS } from "../lib/imageUtils";
@@ -39,9 +50,14 @@ const Role = {
  * @param {Function} options.onRemoveImage
  * @param {Function} options.onImageError
  * @param {Function} options.onImageLoad
+ * @param {Array} options.attachedFiles
+ * @param {Function} options.onRemoveFile
+ * @param {Function} options.onFileError
  * @param {object} options.profile
- * @param {Function} options.onBrowserUpload
- * @param {Function} options.onRemoteSelect
+ * @param {Function} options.onImageBrowserUpload
+ * @param {Function} options.onImageRemoteSelect
+ * @param {Function} options.onFileBrowserUpload
+ * @param {Function} options.onFileRemoteSelect
  * @return {JSX.Element}
  */
 function UserMessageInput({
@@ -52,23 +68,38 @@ function UserMessageInput({
   onRemoveImage,
   onImageError,
   onImageLoad,
+  attachedFiles,
+  onRemoveFile,
+  onFileError,
   profile,
-  onBrowserUpload,
-  onRemoteSelect,
+  onImageBrowserUpload,
+  onImageRemoteSelect,
+  onFileBrowserUpload,
+  onFileRemoteSelect,
 }) {
   return (
     <div className="flex items-start space-x-4 mt-auto pt-4">
       <div className="min-w-0 flex-1">
         <form action="#" onSubmit={onSubmit} className="relative">
-          <div className="rounded-lg bg-white dark:bg-gray-700 outline outline-1 -outline-offset-1 outline-gray-300 dark:outline-gray-600 shadow-md">
+          <div className="rounded-lg bg-white dark:bg-gray-700 outline outline-1 -outline-offset-1 outline-gray-300 dark:outline-gray-600 shadow-md overflow-visible">
             {/* Image attachments preview */}
             {attachedImages.length > 0 && (
-              <div className="px-3 pt-2 border-b border-gray-200 dark:border-gray-600">
+              <div className="px-4 pt-2 border-b border-gray-200 dark:border-gray-600">
                 <ImageAttachmentList
                   images={attachedImages}
                   onRemove={onRemoveImage}
                   onImageError={onImageError}
                   onImageLoad={onImageLoad}
+                />
+              </div>
+            )}
+
+            {/* File attachments preview */}
+            {attachedFiles.length > 0 && (
+              <div className="px-4 pt-2 border-b border-gray-200 dark:border-gray-600">
+                <FileAttachmentList
+                  files={attachedFiles}
+                  onRemove={onRemoveFile}
                 />
               </div>
             )}
@@ -106,11 +137,27 @@ function UserMessageInput({
 
           <div className="absolute inset-x-0 bottom-0 flex justify-between py-2 pl-3 pr-2">
             <div className="flex items-center space-x-5">
-              <div className="flex items-center">
+              <div className="flex items-center gap-2">
+                {/* File attachment menu */}
                 <AttachmentMenu
+                  accept={getTextFileAcceptString()}
+                  maxFileSize={MAX_TEXT_FILE_SIZE}
+                  icon={DocumentTextIcon}
+                  label="Attach file"
                   profile={profile}
-                  onBrowserUpload={onBrowserUpload}
-                  onRemoteSelect={onRemoteSelect}
+                  onBrowserUpload={onFileBrowserUpload}
+                  onRemoteSelect={onFileRemoteSelect}
+                  onError={onFileError}
+                />
+                {/* Image attachment menu */}
+                <AttachmentMenu
+                  accept="image/*"
+                  maxFileSize={5 * 1024 * 1024}
+                  icon={PhotoIcon}
+                  label="Attach image"
+                  profile={profile}
+                  onBrowserUpload={onImageBrowserUpload}
+                  onRemoteSelect={onImageRemoteSelect}
                   onError={onImageError}
                 />
               </div>
@@ -140,9 +187,14 @@ UserMessageInput.propTypes = {
   onRemoveImage: PropTypes.func,
   onImageError: PropTypes.func,
   onImageLoad: PropTypes.func,
+  attachedFiles: PropTypes.array,
+  onRemoveFile: PropTypes.func,
+  onFileError: PropTypes.func,
   profile: PropTypes.object,
-  onBrowserUpload: PropTypes.func,
-  onRemoteSelect: PropTypes.func,
+  onImageBrowserUpload: PropTypes.func,
+  onImageRemoteSelect: PropTypes.func,
+  onFileBrowserUpload: PropTypes.func,
+  onFileRemoteSelect: PropTypes.func,
 };
 
 /**
@@ -180,14 +232,20 @@ function UserMessage({ message, onDeleteMessage, onEditMessage }) {
   const [isEditing, setIsEditing] = useState(false);
 
   // Extract text and images from content
-  const textContent = extractTextFromContent(message.content);
+  // Use _displayText if available (when files were attached), otherwise extract from content
+  const textContent = message._displayText !== undefined
+    ? message._displayText
+    : extractTextFromContent(message.content);
   const images = extractImagesFromContent(message.content);
+  const attachedFiles = message._attachedFiles || [];
   const [content, setContent] = useState(textContent);
 
   // Update content when message changes
   useEffect(() => {
-    setContent(extractTextFromContent(message.content));
-  }, [message.content]);
+    setContent(message._displayText !== undefined
+      ? message._displayText
+      : extractTextFromContent(message.content));
+  }, [message.content, message._displayText]);
 
   if (isEditing) {
     return (
@@ -210,10 +268,21 @@ function UserMessage({ message, onDeleteMessage, onEditMessage }) {
             <div className="rounded-lg bg-gray-100 dark:bg-gray-700 shadow-md">
               {/* Display attached images (read-only) */}
               {images.length > 0 && (
-                <div className="flex gap-2 flex-wrap px-4 pt-3 border-b border-gray-200 dark:border-gray-600 pb-2">
-                  {images.map((src, idx) => (
-                    <MessageImage key={idx} src={src} />
-                  ))}
+                <div className="px-4 pt-2 border-b border-gray-200 dark:border-gray-600">
+                  <div className="flex gap-2 flex-wrap py-2">
+                    {images.map((src, idx) => (
+                      <MessageImage key={idx} src={src} />
+                    ))}
+                  </div>
+                </div>
+              )}
+              {/* Display attached files as chips (read-only) */}
+              {attachedFiles.length > 0 && (
+                <div className="px-4 pt-2 border-b border-gray-200 dark:border-gray-600">
+                  <FileAttachmentList
+                    files={attachedFiles.map(f => ({ source: "browser", name: f.name, content: f.content }))}
+                    readOnly
+                  />
                 </div>
               )}
               <label htmlFor="comment" className="sr-only">
@@ -287,6 +356,15 @@ function UserMessage({ message, onDeleteMessage, onEditMessage }) {
                 {images.map((src, idx) => (
                   <MessageImage key={idx} src={src} />
                 ))}
+              </div>
+            )}
+            {/* Display attached files as chips */}
+            {attachedFiles.length > 0 && (
+              <div className="mb-2">
+                <FileAttachmentList
+                  files={attachedFiles.map(f => ({ source: "browser", name: f.name, content: f.content }))}
+                  readOnly
+                />
               </div>
             )}
             {textContent}
@@ -444,12 +522,35 @@ function MessageList({ messages, setMessages, handleResubmit, elementRef, isWait
         <Message
           key={index}
           message={message}
-          onEditMessage={(content) => {
+          onEditMessage={(newContent) => {
             console.log("editing message:", message);
             setMessages((messages) =>
               messages.map((m, i) => {
                 if (i === index) {
-                  return { ...m, content: content };
+                  // Extract text for display if content is multimodal (has images)
+                  const displayText = typeof newContent === 'string'
+                    ? newContent
+                    : extractTextFromContent(newContent);
+
+                  // Re-add file context if files were attached
+                  let finalContent = newContent;
+                  if (m._attachedFiles && m._attachedFiles.length > 0) {
+                    const textWithFileContext = prependFileContext(displayText, m._attachedFiles);
+                    // If there are images, rebuild multimodal content with file context
+                    if (typeof newContent !== 'string') {
+                      const images = extractImagesFromContent(newContent);
+                      finalContent = buildMultimodalContent(textWithFileContext, images);
+                    } else {
+                      finalContent = textWithFileContext;
+                    }
+                  }
+
+                  return {
+                    ...m,
+                    content: finalContent,
+                    _displayText: displayText,
+                    // Preserve _attachedFiles
+                  };
                 }
                 return m;
               })
@@ -509,8 +610,11 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
     content: sessionStorage.getItem("tgcc-um") || "",
   });
   const [attachedImages, setAttachedImages] = useState([]);
+  const [attachedFiles, setAttachedFiles] = useState([]);
+  const [imageBrowserOpen, setImageBrowserOpen] = useState(false);
   const [fileBrowserOpen, setFileBrowserOpen] = useState(false);
   const [imageError, setImageError] = useState(null);
+  const [fileError, setFileError] = useState(null);
   const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
 
   const elementRef = useRef(null);
@@ -524,7 +628,8 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
     scrollToElement();
   }, [messages]);
 
-  const handleBrowserUpload = (files) => {
+  // Image attachment handlers
+  const handleImageBrowserUpload = (files) => {
     const newImages = files.map((file) => ({
       source: "browser",
       file: file,
@@ -532,7 +637,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
     setAttachedImages((prev) => [...prev, ...newImages]);
   };
 
-  const handleRemoteSelect = (image) => {
+  const handleImageRemoteSelect = (image) => {
     setAttachedImages((prev) => [...prev, image]);
   };
 
@@ -553,12 +658,68 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
     );
   }, []);
 
+  // File attachment handlers
+  const handleFileBrowserUpload = useCallback(async (files) => {
+    for (const file of files) {
+      try {
+        const content = await readFileAsText(file);
+        setAttachedFiles((prev) => [
+          ...prev,
+          {
+            source: "browser",
+            file: file,
+            name: file.name,
+            content: content,
+          },
+        ]);
+      } catch (error) {
+        console.error("Failed to read file:", error);
+        setFileError({ fileName: file.name, message: "Failed to read file" });
+        setTimeout(() => setFileError(null), 5000);
+      }
+    }
+  }, []);
+
+  const handleFileRemoteSelect = useCallback(async (fileInfo) => {
+    try {
+      const content = await fetchRemoteText(fileInfo.path, fileInfo.profile);
+      const fileName = fileInfo.path.split("/").pop();
+      setAttachedFiles((prev) => [
+        ...prev,
+        {
+          source: "remote",
+          path: fileInfo.path,
+          profile: fileInfo.profile,
+          name: fileName,
+          content: content,
+        },
+      ]);
+    } catch (error) {
+      console.error("Failed to fetch remote file:", error);
+      const fileName = fileInfo.path.split("/").pop();
+      setFileError({ fileName, message: error.message });
+      setTimeout(() => setFileError(null), 5000);
+    }
+  }, []);
+
+  const handleRemoveFile = (index) => {
+    setAttachedFiles((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleFileError = useCallback((fileName, errorMessage) => {
+    setFileError({ fileName, message: errorMessage });
+    setTimeout(() => setFileError(null), 5000);
+  }, []);
+
   const handleSubmit = async (event) => {
     event.preventDefault();
     console.log("user message submitted");
 
+    // Prepend file context to the message text (for LLM)
+    const textWithFileContext = prependFileContext(userMessage.content, attachedFiles);
+
     // Build the message content (multimodal if images attached)
-    let messageContent = userMessage.content;
+    let messageContent = textWithFileContext;
     if (attachedImages.length > 0) {
       try {
         const imageUrls = await Promise.all(
@@ -575,16 +736,24 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
             }
           })
         );
-        messageContent = buildMultimodalContent(userMessage.content, imageUrls);
+        messageContent = buildMultimodalContent(textWithFileContext, imageUrls);
       } catch (error) {
         console.error("Failed to convert images:", error);
         return;
       }
     }
 
+    // Store file metadata for UI display (chips), content goes to LLM
+    const fileMetadata = attachedFiles.length > 0
+      ? attachedFiles.map(f => ({ name: f.name, content: f.content }))
+      : undefined;
+
     const newUserMessage = {
       role: Role.USER,
       content: messageContent,
+      // UI-only fields (ignored by LLM API):
+      _displayText: userMessage.content,
+      _attachedFiles: fileMetadata,
     };
 
     const stream = streamChatCompletionInference(
@@ -599,8 +768,9 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
 
     setMessages((messages) => [...messages, newUserMessage]);
 
-    // Clear attached images after sending
+    // Clear attachments after sending
     setAttachedImages([]);
+    setAttachedFiles([]);
 
     // Show loading state while waiting for first response chunk
     setIsWaitingForResponse(true);
@@ -727,19 +897,36 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
         onRemoveImage={handleRemoveImage}
         onImageError={handleImageError}
         onImageLoad={handleImageLoad}
+        attachedFiles={attachedFiles}
+        onRemoveFile={handleRemoveFile}
+        onFileError={handleFileError}
         profile={profile}
-        onBrowserUpload={handleBrowserUpload}
-        onRemoteSelect={() => setFileBrowserOpen(true)}
+        onImageBrowserUpload={handleImageBrowserUpload}
+        onImageRemoteSelect={() => setImageBrowserOpen(true)}
+        onFileBrowserUpload={handleFileBrowserUpload}
+        onFileRemoteSelect={() => setFileBrowserOpen(true)}
       />
 
+      {/* Image file browser modal */}
+      <FileSelectModal
+        open={imageBrowserOpen}
+        setOpen={setImageBrowserOpen}
+        profile={profile}
+        onSelect={(file) => handleImageRemoteSelect({ source: "remote", path: file.path, profile: file.profile })}
+        title="Select an image"
+        acceptedExtensions={IMAGE_EXTENSIONS}
+        extensionErrorMessage="Please select an image file (PNG, JPG, JPEG, GIF, BMP, TIFF, WEBP)"
+      />
+
+      {/* Text file browser modal */}
       <FileSelectModal
         open={fileBrowserOpen}
         setOpen={setFileBrowserOpen}
         profile={profile}
-        onSelect={(file) => handleRemoteSelect({ source: "remote", path: file.path, profile: file.profile })}
-        title="Select an image"
-        acceptedExtensions={IMAGE_EXTENSIONS}
-        extensionErrorMessage="Please select an image file (PNG, JPG, JPEG, GIF, BMP, TIFF, WEBP)"
+        onSelect={(file) => handleFileRemoteSelect({ path: file.path, profile: file.profile })}
+        title="Select a file"
+        acceptedExtensions={TEXT_FILE_EXTENSIONS}
+        extensionErrorMessage="Please select a text file (txt, md, json, py, js, etc.)"
       />
 
       <Notification
@@ -748,6 +935,14 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
         message="Failed to attach image"
         detail={imageError ? `${imageError.fileName}: ${imageError.message}` : ""}
         onDismiss={() => setImageError(null)}
+      />
+
+      <Notification
+        show={!!fileError}
+        variant="error"
+        message="Failed to attach file"
+        detail={fileError ? `${fileError.fileName}: ${fileError.message}` : ""}
+        onDismiss={() => setFileError(null)}
       />
     </div>
   );

--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.test.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.test.jsx
@@ -32,6 +32,9 @@ vi.mock("@heroicons/react/24/outline", () => ({
   ClipboardDocumentIcon: ({ className, ...props }) => {
     return <div data-testid="clipboard-icon" className={className} {...props} />;
   },
+  DocumentTextIcon: ({ className, ...props }) => {
+    return <div data-testid="document-text-icon" className={className} {...props} />;
+  },
   PaperAirplaneIcon: ({ className, ...props }) => {
     return <div data-testid="paper-airplane-icon" className={className} {...props} />;
   },
@@ -72,8 +75,16 @@ vi.mock("./ImageAttachmentList", () => ({
   default: () => <div data-testid="image-attachment-list" />,
 }));
 
+vi.mock("./FileAttachmentList", () => ({
+  default: () => <div data-testid="file-attachment-list" />,
+}));
+
 vi.mock("@/components/FileSelectModal", () => ({
   default: () => <div data-testid="file-select-modal" />,
+}));
+
+vi.mock("@/components/Notification", () => ({
+  default: () => <div data-testid="notification" />,
 }));
 
 const mockClipboard = {

--- a/web/src/routes/text-generation/components/TextGenerationCompletionContainer.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationCompletionContainer.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState, useCallback } from "react";
+import { useContext, useState } from "react";
 import { ServiceContext } from "@/providers/ServiceProvider";
 import { ProfileContext } from "@/components/ProfileSelect";
 import { streamCompletionInference } from "../lib/requests";
@@ -9,13 +9,12 @@ import {
   PaperAirplaneIcon,
 } from "@heroicons/react/24/outline";
 import {
-  readFileAsText,
-  fetchRemoteText,
   prependFileContext,
   getTextFileAcceptString,
   MAX_TEXT_FILE_SIZE,
   TEXT_FILE_EXTENSIONS,
 } from "../lib/fileUtils";
+import { useFileAttachments } from "../lib/useFileAttachments";
 import AttachmentMenu from "./AttachmentMenu";
 import FileAttachmentList from "./FileAttachmentList";
 import FileSelectModal from "@/components/FileSelectModal";
@@ -239,62 +238,19 @@ function TextGenerationCompletionContainer({ parameters, toolbar }) {
     sessionStorage.getItem("tgco") || ""
   );
   const [isLoading, setIsLoading] = useState(false);
-  const [attachedFiles, setAttachedFiles] = useState([]);
-  const [fileBrowserOpen, setFileBrowserOpen] = useState(false);
-  const [fileError, setFileError] = useState(null);
 
-  // File attachment handlers
-  const handleFileBrowserUpload = useCallback(async (files) => {
-    for (const file of files) {
-      try {
-        const content = await readFileAsText(file);
-        setAttachedFiles((prev) => [
-          ...prev,
-          {
-            source: "browser",
-            file: file,
-            name: file.name,
-            content: content,
-          },
-        ]);
-      } catch (error) {
-        console.error("Failed to read file:", error);
-        setFileError({ fileName: file.name, message: "Failed to read file" });
-        setTimeout(() => setFileError(null), 5000);
-      }
-    }
-  }, []);
-
-  const handleFileRemoteSelect = useCallback(async (fileInfo) => {
-    try {
-      const content = await fetchRemoteText(fileInfo.path, fileInfo.profile);
-      const fileName = fileInfo.path.split("/").pop();
-      setAttachedFiles((prev) => [
-        ...prev,
-        {
-          source: "remote",
-          path: fileInfo.path,
-          profile: fileInfo.profile,
-          name: fileName,
-          content: content,
-        },
-      ]);
-    } catch (error) {
-      console.error("Failed to fetch remote file:", error);
-      const fileName = fileInfo.path.split("/").pop();
-      setFileError({ fileName, message: error.message });
-      setTimeout(() => setFileError(null), 5000);
-    }
-  }, []);
-
-  const handleRemoveFile = (index) => {
-    setAttachedFiles((prev) => prev.filter((_, i) => i !== index));
-  };
-
-  const handleFileError = useCallback((fileName, errorMessage) => {
-    setFileError({ fileName, message: errorMessage });
-    setTimeout(() => setFileError(null), 5000);
-  }, []);
+  // File attachment state and handlers
+  const {
+    attachedFiles,
+    fileBrowserOpen,
+    setFileBrowserOpen,
+    fileError,
+    setFileError,
+    handleFileBrowserUpload,
+    handleFileRemoteSelect,
+    handleRemoveFile,
+    handleFileError,
+  } = useFileAttachments();
 
   const handleSubmit = async (event) => {
     event.preventDefault();

--- a/web/src/routes/text-generation/components/TextGenerationCompletionContainer.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationCompletionContainer.jsx
@@ -1,12 +1,25 @@
-import { useContext, useState } from "react";
+import { useContext, useState, useCallback } from "react";
 import { ServiceContext } from "@/providers/ServiceProvider";
+import { ProfileContext } from "@/components/ProfileSelect";
 import { streamCompletionInference } from "../lib/requests";
 import {
   ArrowPathIcon,
   ClipboardDocumentIcon,
+  DocumentTextIcon,
   PaperAirplaneIcon,
 } from "@heroicons/react/24/outline";
-
+import {
+  readFileAsText,
+  fetchRemoteText,
+  prependFileContext,
+  getTextFileAcceptString,
+  MAX_TEXT_FILE_SIZE,
+  TEXT_FILE_EXTENSIONS,
+} from "../lib/fileUtils";
+import AttachmentMenu from "./AttachmentMenu";
+import FileAttachmentList from "./FileAttachmentList";
+import FileSelectModal from "@/components/FileSelectModal";
+import Notification from "@/components/Notification";
 import { ServiceStatus } from "@/lib/util";
 import PropTypes from "prop-types";
 
@@ -19,6 +32,12 @@ import PropTypes from "prop-types";
  * @param {Function} options.handleSubmit
  * @param {object} options.selectedService
  * @param {JSX.Element} options.toolbar
+ * @param {Array} options.attachedFiles
+ * @param {Function} options.onRemoveFile
+ * @param {Function} options.onFileError
+ * @param {object} options.profile
+ * @param {Function} options.onFileBrowserUpload
+ * @param {Function} options.onFileRemoteSelect
  * @return {JSX.Element}
  */
 function TextGenerationPromptInput({
@@ -27,6 +46,12 @@ function TextGenerationPromptInput({
   handleSubmit,
   selectedService,
   toolbar,
+  attachedFiles,
+  onRemoveFile,
+  onFileError,
+  profile,
+  onFileBrowserUpload,
+  onFileRemoteSelect,
 }) {
   /**
    * Set input value in React state and session storage.
@@ -50,6 +75,16 @@ function TextGenerationPromptInput({
         <div className="min-w-0 flex-1">
           <form action="#" onSubmit={handleSubmit} className="relative">
             <div className="rounded-lg bg-white dark:bg-gray-700 outline outline-1 -outline-offset-1 outline-gray-300 dark:outline-gray-600 shadow-md">
+              {/* File attachments preview */}
+              {attachedFiles.length > 0 && (
+                <div className="px-4 pt-2 border-b border-gray-200 dark:border-gray-600">
+                  <FileAttachmentList
+                    files={attachedFiles}
+                    onRemove={onRemoveFile}
+                  />
+                </div>
+              )}
+
               <label htmlFor="text-generation-text-input" className="sr-only">
                 Prompt anything
               </label>
@@ -81,7 +116,20 @@ function TextGenerationPromptInput({
               </div>
             </div>
 
-            <div className="absolute inset-x-0 bottom-0 flex justify-end py-2 pl-3 pr-2">
+            <div className="absolute inset-x-0 bottom-0 flex justify-between py-2 pl-3 pr-2">
+              <div className="flex items-center">
+                {/* File attachment menu */}
+                <AttachmentMenu
+                  accept={getTextFileAcceptString()}
+                  maxFileSize={MAX_TEXT_FILE_SIZE}
+                  icon={DocumentTextIcon}
+                  label="Attach file"
+                  profile={profile}
+                  onBrowserUpload={onFileBrowserUpload}
+                  onRemoteSelect={onFileRemoteSelect}
+                  onError={onFileError}
+                />
+              </div>
               <div className="shrink-0">
                 <button
                   type="submit"
@@ -108,6 +156,12 @@ TextGenerationPromptInput.propTypes = {
   handleSubmit: PropTypes.func,
   selectedService: PropTypes.object,
   toolbar: PropTypes.node,
+  attachedFiles: PropTypes.array,
+  onRemoveFile: PropTypes.func,
+  onFileError: PropTypes.func,
+  profile: PropTypes.object,
+  onFileBrowserUpload: PropTypes.func,
+  onFileRemoteSelect: PropTypes.func,
 };
 
 /**
@@ -177,6 +231,7 @@ TextGenerationResponseOutput.propTypes = {
  */
 function TextGenerationCompletionContainer({ parameters, toolbar }) {
   const { selectedService } = useContext(ServiceContext);
+  const { profile } = useContext(ProfileContext);
   const [prompt, setPrompt] = useState(
     sessionStorage.getItem("tgci") || ""
   );
@@ -184,11 +239,69 @@ function TextGenerationCompletionContainer({ parameters, toolbar }) {
     sessionStorage.getItem("tgco") || ""
   );
   const [isLoading, setIsLoading] = useState(false);
+  const [attachedFiles, setAttachedFiles] = useState([]);
+  const [fileBrowserOpen, setFileBrowserOpen] = useState(false);
+  const [fileError, setFileError] = useState(null);
+
+  // File attachment handlers
+  const handleFileBrowserUpload = useCallback(async (files) => {
+    for (const file of files) {
+      try {
+        const content = await readFileAsText(file);
+        setAttachedFiles((prev) => [
+          ...prev,
+          {
+            source: "browser",
+            file: file,
+            name: file.name,
+            content: content,
+          },
+        ]);
+      } catch (error) {
+        console.error("Failed to read file:", error);
+        setFileError({ fileName: file.name, message: "Failed to read file" });
+        setTimeout(() => setFileError(null), 5000);
+      }
+    }
+  }, []);
+
+  const handleFileRemoteSelect = useCallback(async (fileInfo) => {
+    try {
+      const content = await fetchRemoteText(fileInfo.path, fileInfo.profile);
+      const fileName = fileInfo.path.split("/").pop();
+      setAttachedFiles((prev) => [
+        ...prev,
+        {
+          source: "remote",
+          path: fileInfo.path,
+          profile: fileInfo.profile,
+          name: fileName,
+          content: content,
+        },
+      ]);
+    } catch (error) {
+      console.error("Failed to fetch remote file:", error);
+      const fileName = fileInfo.path.split("/").pop();
+      setFileError({ fileName, message: error.message });
+      setTimeout(() => setFileError(null), 5000);
+    }
+  }, []);
+
+  const handleRemoveFile = (index) => {
+    setAttachedFiles((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleFileError = useCallback((fileName, errorMessage) => {
+    setFileError({ fileName, message: errorMessage });
+    setTimeout(() => setFileError(null), 5000);
+  }, []);
 
   const handleSubmit = async (event) => {
     event.preventDefault();
 
-    const textInput = prompt === "" ? "Write me a haiku about orcas." : prompt;
+    // Prepend file context to the prompt
+    const promptWithFileContext = prependFileContext(prompt, attachedFiles);
+    const textInput = promptWithFileContext === "" ? "Write me a haiku about orcas." : promptWithFileContext;
 
     setIsLoading(true);
     setResponse("");
@@ -227,12 +340,37 @@ function TextGenerationCompletionContainer({ parameters, toolbar }) {
         selectedService={selectedService}
         isLoading={isLoading}
         toolbar={toolbar}
+        attachedFiles={attachedFiles}
+        onRemoveFile={handleRemoveFile}
+        onFileError={handleFileError}
+        profile={profile}
+        onFileBrowserUpload={handleFileBrowserUpload}
+        onFileRemoteSelect={() => setFileBrowserOpen(true)}
       />
       <TextGenerationResponseOutput
         content={response || ""}
         handleSubmit={handleSubmit}
         selectedService={selectedService}
         isLoading={isLoading}
+      />
+
+      {/* Text file browser modal */}
+      <FileSelectModal
+        open={fileBrowserOpen}
+        setOpen={setFileBrowserOpen}
+        profile={profile}
+        onSelect={(file) => handleFileRemoteSelect({ path: file.path, profile: file.profile })}
+        title="Select a file"
+        acceptedExtensions={TEXT_FILE_EXTENSIONS}
+        extensionErrorMessage="Please select a text file (txt, md, json, py, js, etc.)"
+      />
+
+      <Notification
+        show={!!fileError}
+        variant="error"
+        message="Failed to attach file"
+        detail={fileError ? `${fileError.fileName}: ${fileError.message}` : ""}
+        onDismiss={() => setFileError(null)}
       />
     </div>
   );

--- a/web/src/routes/text-generation/components/TextGenerationCompletionContainer.test.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationCompletionContainer.test.jsx
@@ -5,11 +5,33 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import TextGenerationCompletionContainer from "./TextGenerationCompletionContainer";
 import { ServiceContext } from "@/providers/ServiceProvider";
+import { ProfileContext } from "@/components/ProfileSelect";
 import { streamCompletionInference } from "../lib/requests";
 import { ServiceStatus } from "@/lib/util";
 
 vi.mock("../lib/requests", () => ({
   streamCompletionInference: vi.fn(),
+}));
+
+vi.mock("./AttachmentMenu", () => ({
+  default: ({ onBrowserUpload, onRemoteSelect }) => (
+    <div data-testid="attachment-menu">
+      <button data-testid="upload-button" onClick={() => onBrowserUpload([])}>Upload</button>
+      <button data-testid="remote-button" onClick={onRemoteSelect}>Remote</button>
+    </div>
+  ),
+}));
+
+vi.mock("./FileAttachmentList", () => ({
+  default: () => <div data-testid="file-attachment-list" />,
+}));
+
+vi.mock("@/components/FileSelectModal", () => ({
+  default: () => <div data-testid="file-select-modal" />,
+}));
+
+vi.mock("@/components/Notification", () => ({
+  default: () => <div data-testid="notification" />,
 }));
 
 vi.mock("@heroicons/react/24/outline", () => ({
@@ -19,8 +41,14 @@ vi.mock("@heroicons/react/24/outline", () => ({
   ClipboardDocumentIcon: ({ className, ...props }) => {
     return <div data-testid="clipboard-icon" className={className} {...props} />;
   },
+  DocumentTextIcon: ({ className, ...props }) => {
+    return <div data-testid="document-text-icon" className={className} {...props} />;
+  },
   PaperAirplaneIcon: ({ className, ...props }) => {
     return <div data-testid="paper-airplane-icon" className={className} {...props} />;
+  },
+  PaperClipIcon: ({ className, ...props }) => {
+    return <div data-testid="paper-clip-icon" className={className} {...props} />;
   },
 }));
 
@@ -39,10 +67,17 @@ const mockSelectedService = {
   id: "test-service-1",
 };
 
-const MockProviders = ({ children, selectedService = mockSelectedService }) => (
-  <ServiceContext.Provider value={{ selectedService }}>
-    {children}
-  </ServiceContext.Provider>
+const mockProfile = {
+  name: "test-profile",
+  schema: "local",
+};
+
+const MockProviders = ({ children, selectedService = mockSelectedService, profile = mockProfile }) => (
+  <ProfileContext.Provider value={{ profile }}>
+    <ServiceContext.Provider value={{ selectedService }}>
+      {children}
+    </ServiceContext.Provider>
+  </ProfileContext.Provider>
 );
 
 describe("TextGenerationCompletionContainer", () => {

--- a/web/src/routes/text-generation/components/__snapshots__/TextGenerationChatContainer.test.jsx.snap
+++ b/web/src/routes/text-generation/components/__snapshots__/TextGenerationChatContainer.test.jsx.snap
@@ -45,6 +45,16 @@ exports[`TextGenerationChatContainer > Component rendering > renders the main co
               Remote
             </button>,
             "3": <button
+              data-testid="upload-button"
+            >
+              Upload
+            </button>,
+            "4": <button
+              data-testid="remote-button"
+            >
+              Remote
+            </button>,
+            "5": <button
               class="inline-flex items-center rounded-full bg-white dark:bg-gray-600 p-2 text-sm font-semibold text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-500 shadow-sm hover:bg-gray-100 dark:hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600 disabled:text-gray-400 disabled:opacity-50 disabled:hover:bg-white dark:disabled:hover:bg-gray-600 disabled:border-gray-200 dark:disabled:border-gray-600 disabled:shadow-none"
               type="submit"
             >
@@ -65,13 +75,14 @@ exports[`TextGenerationChatContainer > Component rendering > renders the main co
         data-testid="file-select-modal"
       />
       <div
-        aria-live="assertive"
-        class="pointer-events-none fixed inset-0 flex items-end px-4 py-6 sm:p-6 z-50"
-      >
-        <div
-          class="flex w-full flex-col items-center space-y-4 sm:items-end"
-        />
-      </div>
+        data-testid="file-select-modal"
+      />
+      <div
+        data-testid="notification"
+      />
+      <div
+        data-testid="notification"
+      />
     </div>
   </div>
 </body>

--- a/web/src/routes/text-generation/components/__snapshots__/TextGenerationCompletionContainer.test.jsx.snap
+++ b/web/src/routes/text-generation/components/__snapshots__/TextGenerationCompletionContainer.test.jsx.snap
@@ -31,6 +31,16 @@ exports[`TextGenerationCompletionContainer > Component rendering > renders the m
                 rows="10"
               />,
               "1": <button
+                data-testid="upload-button"
+              >
+                Upload
+              </button>,
+              "2": <button
+                data-testid="remote-button"
+              >
+                Remote
+              </button>,
+              "3": <button
                 class="inline-flex items-center rounded-full bg-white dark:bg-gray-600 p-2 text-sm font-semibold text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-500 shadow-sm hover:bg-gray-100 dark:hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600 disabled:text-gray-400 disabled:opacity-50 disabled:hover:bg-white dark:disabled:hover:bg-gray-600 disabled:border-gray-200 dark:disabled:border-gray-600 disabled:shadow-none"
                 type="submit"
               >
@@ -43,6 +53,12 @@ exports[`TextGenerationCompletionContainer > Component rendering > renders the m
           </div>
         </div>
       </div>
+      <div
+        data-testid="file-select-modal"
+      />
+      <div
+        data-testid="notification"
+      />
     </div>
   </div>
 </body>

--- a/web/src/routes/text-generation/lib/fileUtils.js
+++ b/web/src/routes/text-generation/lib/fileUtils.js
@@ -1,0 +1,122 @@
+/**
+ * File utility functions for text generation file attachments.
+ */
+
+import { blackfishApiURL } from "@/config";
+
+/**
+ * Supported text file extensions for attachments.
+ */
+export const TEXT_FILE_EXTENSIONS = [
+  ".txt",
+  ".md",
+  ".json",
+  ".py",
+  ".js",
+  ".jsx",
+  ".ts",
+  ".tsx",
+  ".html",
+  ".css",
+  ".sh",
+  ".sql",
+  ".toml",
+  ".yaml",
+  ".yml",
+  ".log",
+  ".csv",
+  ".xml",
+];
+
+/**
+ * Maximum file size for text attachments (100KB).
+ */
+export const MAX_TEXT_FILE_SIZE = 100 * 1024;
+
+/**
+ * Get the accept string for file input.
+ * @returns {string} Comma-separated list of accepted extensions.
+ */
+export function getTextFileAcceptString() {
+  return TEXT_FILE_EXTENSIONS.join(",");
+}
+
+/**
+ * Check if a filename has a supported text extension.
+ * @param {string} filename - The filename to check.
+ * @returns {boolean} True if supported text file.
+ */
+export function isTextFile(filename) {
+  const lower = filename.toLowerCase();
+  return TEXT_FILE_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+/**
+ * Read a browser File as text.
+ * @param {File} file - The file to read.
+ * @returns {Promise<string>} The file content as text.
+ */
+export function readFileAsText(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsText(file);
+  });
+}
+
+/**
+ * Fetch text content from a remote file.
+ * @param {string} path - The file path on the remote server.
+ * @param {object} profile - The profile object (for remote servers).
+ * @returns {Promise<string>} The file content as text.
+ */
+export async function fetchRemoteText(path, profile) {
+  const profileParam =
+    profile && profile.schema !== "local"
+      ? `&profile=${encodeURIComponent(profile.name)}`
+      : "";
+  const url = `${blackfishApiURL}/api/text?path=${encodeURIComponent(path)}${profileParam}`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    const statusMessages = {
+      404: "File not found",
+      403: "Access denied",
+      500: "Server error",
+    };
+    throw new Error(statusMessages[response.status] || `Error (${response.status})`);
+  }
+
+  return response.text();
+}
+
+/**
+ * Build file context section for prepending to messages.
+ * Uses <document> tags to clearly delimit file content.
+ * @param {Array} files - Array of file objects with name and content.
+ * @returns {string} Formatted file context string.
+ */
+export function buildFileContext(files) {
+  if (!files || files.length === 0) {
+    return "";
+  }
+
+  return files
+    .map((f) => `<document name="${f.name}">\n${f.content}\n</document>`)
+    .join("\n\n");
+}
+
+/**
+ * Prepend file context to a message.
+ * @param {string} message - The user's message.
+ * @param {Array} files - Array of file objects with name and content.
+ * @returns {string} Message with file context prepended.
+ */
+export function prependFileContext(message, files) {
+  const fileContext = buildFileContext(files);
+  if (!fileContext) {
+    return message;
+  }
+  return `${fileContext}\n\n${message}`;
+}

--- a/web/src/routes/text-generation/lib/fileUtils.js
+++ b/web/src/routes/text-generation/lib/fileUtils.js
@@ -81,14 +81,33 @@ export async function fetchRemoteText(path, profile) {
   const response = await fetch(url);
   if (!response.ok) {
     const statusMessages = {
-      404: "File not found",
+      400: "Bad request",
+      401: "Authentication required",
       403: "Access denied",
+      404: "File not found",
       500: "Server error",
+      502: "Bad gateway",
+      503: "Service unavailable",
+      504: "Gateway timeout",
     };
     throw new Error(statusMessages[response.status] || `Error (${response.status})`);
   }
 
   return response.text();
+}
+
+/**
+ * Escape special characters in a string for use in XML/HTML attributes.
+ * @param {string} str - The string to escape.
+ * @returns {string} Escaped string.
+ */
+function escapeXmlAttribute(str) {
+  return str.replace(/[<>"&]/g, (c) => ({
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    '&': '&amp;',
+  }[c]));
 }
 
 /**
@@ -103,7 +122,10 @@ export function buildFileContext(files) {
   }
 
   return files
-    .map((f) => `<document name="${f.name}">\n${f.content}\n</document>`)
+    .map((f) => {
+      const safeName = escapeXmlAttribute(f.name);
+      return `<document name="${safeName}">\n${f.content}\n</document>`;
+    })
     .join("\n\n");
 }
 

--- a/web/src/routes/text-generation/lib/imageUtils.js
+++ b/web/src/routes/text-generation/lib/imageUtils.js
@@ -108,6 +108,11 @@ export const IMAGE_EXTENSIONS = [
 ];
 
 /**
+ * Maximum file size for image attachments (5MB).
+ */
+export const MAX_IMAGE_FILE_SIZE = 5 * 1024 * 1024;
+
+/**
  * Check if a filename has a supported image extension.
  * @param {string} filename - The filename to check.
  * @returns {boolean} True if supported image file.

--- a/web/src/routes/text-generation/lib/useFileAttachments.js
+++ b/web/src/routes/text-generation/lib/useFileAttachments.js
@@ -1,0 +1,102 @@
+import { useState, useCallback } from "react";
+import { readFileAsText, fetchRemoteText } from "./fileUtils";
+
+/**
+ * Custom hook for managing file attachments in text generation.
+ * Handles browser uploads, remote file selection, removal, and errors.
+ * @returns {object} File attachment state and handlers.
+ */
+export function useFileAttachments() {
+  const [attachedFiles, setAttachedFiles] = useState([]);
+  const [fileBrowserOpen, setFileBrowserOpen] = useState(false);
+  const [fileError, setFileError] = useState(null);
+
+  /**
+   * Handle file upload from browser file picker.
+   * @param {File[]} files - Array of File objects from input.
+   */
+  const handleFileBrowserUpload = useCallback(async (files) => {
+    for (const file of files) {
+      try {
+        const content = await readFileAsText(file);
+        setAttachedFiles((prev) => [
+          ...prev,
+          {
+            source: "browser",
+            file: file,
+            name: file.name,
+            content: content,
+          },
+        ]);
+      } catch (error) {
+        console.error("Failed to read file:", error);
+        setFileError({ fileName: file.name, message: "Failed to read file" });
+        setTimeout(() => setFileError(null), 5000);
+      }
+    }
+  }, []);
+
+  /**
+   * Handle file selection from remote file browser.
+   * @param {object} fileInfo - Object with path and profile properties.
+   */
+  const handleFileRemoteSelect = useCallback(async (fileInfo) => {
+    try {
+      const content = await fetchRemoteText(fileInfo.path, fileInfo.profile);
+      const fileName = fileInfo.path.split("/").pop();
+      setAttachedFiles((prev) => [
+        ...prev,
+        {
+          source: "remote",
+          path: fileInfo.path,
+          profile: fileInfo.profile,
+          name: fileName,
+          content: content,
+        },
+      ]);
+    } catch (error) {
+      console.error("Failed to fetch remote file:", error);
+      const fileName = fileInfo.path.split("/").pop();
+      setFileError({ fileName, message: error.message });
+      setTimeout(() => setFileError(null), 5000);
+    }
+  }, []);
+
+  /**
+   * Remove a file attachment by index.
+   * @param {number} index - Index of file to remove.
+   */
+  const handleRemoveFile = useCallback((index) => {
+    setAttachedFiles((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  /**
+   * Handle file validation errors from AttachmentMenu.
+   * @param {string} fileName - Name of the file that failed.
+   * @param {string} errorMessage - Error message to display.
+   */
+  const handleFileError = useCallback((fileName, errorMessage) => {
+    setFileError({ fileName, message: errorMessage });
+    setTimeout(() => setFileError(null), 5000);
+  }, []);
+
+  /**
+   * Clear all attached files (e.g., after submission).
+   */
+  const clearFiles = useCallback(() => {
+    setAttachedFiles([]);
+  }, []);
+
+  return {
+    attachedFiles,
+    fileBrowserOpen,
+    setFileBrowserOpen,
+    fileError,
+    setFileError,
+    handleFileBrowserUpload,
+    handleFileRemoteSelect,
+    handleRemoveFile,
+    handleFileError,
+    clearFiles,
+  };
+}


### PR DESCRIPTION
## Summary

- Add file attachment support to text generation for attaching text/code files (.txt, .md, .py, .js, etc.)
- Generalize `AttachmentMenu` component with configurable props for reuse with different file types
- Create `FileAttachmentList` component displaying file chips with click-to-preview popover
- Support attachments in both Chat and Completion modes (unlike images which are Chat-only)
- File content prepended to messages using `<document name="filename">` delimiters

## Test plan

- [x] Attach a text file from browser in Chat mode, verify chip displays
- [x] Attach a remote file in Chat mode, verify chip displays
- [x] Send message with file attachment, verify chip displays in sent message
- [x] Click file chip to preview content
- [x] Edit message with file attachment, verify chips visible and content preserved
- [x] Attach file in Completion mode, verify chip persists after submission
- [x] Verify file content is included in LLM request (check network tab)
- [x] Run `npm test` - all text-generation tests pass

Closes #197