### PR TITLE
Add partition input to service launcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,12 @@ npm run build:lib  # Build and copy to Python package
 - **Services**: Text Generation, Speech Recognition (extensible base classes)
 - **CLI**: Rich-click powered, profile/service/job management
 
+## Commits
+
+Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+
+Scopes: `lib`, `web`, `ci`, `docs` (optional — omit for cross-cutting changes)
+
 ## Key Conventions
 
 - Python 3.12+, strict MyPy type checking enabled

--- a/web/src/components/ServiceModal.jsx
+++ b/web/src/components/ServiceModal.jsx
@@ -11,7 +11,7 @@ import ServiceModalForm from "@/components/ServiceModalForm";
 import ServiceLaunchErrorAlert from "@/components/ServiceLaunchErrorAlert";
 import { ServiceContext } from "@/providers/ServiceProvider";
 import { runService, fetchProfileResources } from "@/lib/requests";
-import { useModels, useServices } from "@/lib/loaders";
+import { useModels, useServices, useClusterStatus } from "@/lib/loaders";
 import { sleep, randomInt, isDeepEmpty } from "@/lib/util";
 import PropTypes from "prop-types";
 
@@ -105,6 +105,9 @@ function ServiceModal({
   const {
     models,
   } = useModels(profile, task);
+  const {
+    status: clusterStatus,
+  } = useClusterStatus(profile);
 
   const { setSelectedServiceId } = useContext(ServiceContext);
 
@@ -112,6 +115,9 @@ function ServiceModal({
   const [jobOptions, setJobOptions] = React.useState(() => getDefaultJobOptions(profile));
   const [model, setModel] = useState(null);
   const [resources, setResources] = useState(null);
+  const clusterPartitions = clusterStatus?.partitions
+    ? Object.keys(clusterStatus.partitions)
+    : null;
 
   // Fetch resources when profile changes
   useEffect(() => {
@@ -277,6 +283,7 @@ function ServiceModal({
                         profile={profile}
                         task={task}
                         resources={resources}
+                        clusterPartitions={clusterPartitions}
                       >
                         { children }
                       </ServiceModalForm>

--- a/web/src/components/ServiceModal.test.jsx
+++ b/web/src/components/ServiceModal.test.jsx
@@ -5,7 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import ServiceModal from "@/components/ServiceModal";
 import { ServiceContext } from "@/providers/ServiceProvider";
-import { useModels, useServices } from "@/lib/loaders";
+import { useModels, useServices, useClusterStatus } from "@/lib/loaders";
 import { runService, fetchProfileResources } from "@/lib/requests";
 import { sleep, randomInt, isDeepEmpty } from "@/lib/util";
 
@@ -119,6 +119,14 @@ describe("ServiceModal", () => {
         { repo_id: "model-1" },
         { repo_id: "model-2" }
       ]
+    });
+
+    useClusterStatus.mockReturnValue({
+      status: null,
+      error: null,
+      isLoading: false,
+      isRefreshing: false,
+      refresh: vi.fn(),
     });
 
     randomInt.mockReturnValue(12345);

--- a/web/src/components/ServiceModalForm.jsx
+++ b/web/src/components/ServiceModalForm.jsx
@@ -7,8 +7,7 @@ import TierSelect from "@/components/TierSelect";
 import ServiceModalValidatedInput from "@/components/ServiceModalValidatedInput";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/20/solid";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
-import { classNames } from "@/lib/util";
-import { selectTierByModelSize } from "@/lib/util";
+import { classNames, selectTierByModelSize } from "@/lib/util";
 import { fetchModelSizeFromHub } from "@/lib/requests";
 import PropTypes from "prop-types";
 
@@ -352,6 +351,7 @@ function ServiceModalForm({
                   type="text"
                   id="partition"
                   name="partition"
+                  placeholder="Default"
                   value={selectedPartition}
                   onChange={(e) => {
                     setSelectedPartition(e.target.value);

--- a/web/src/components/ServiceModalForm.jsx
+++ b/web/src/components/ServiceModalForm.jsx
@@ -3,10 +3,11 @@ import Info from "./Info";
 import Alert from "@/components/Alert";
 import ModelSelect from "@/components/ModelSelect"
 import RevisionSelect from "@/components/RevisionSelect"
-import PartitionSelect from "@/components/PartitionSelect";
 import TierSelect from "@/components/TierSelect";
 import ServiceModalValidatedInput from "@/components/ServiceModalValidatedInput";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/20/solid";
+import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import { classNames } from "@/lib/util";
 import { selectTierByModelSize } from "@/lib/util";
 import { fetchModelSizeFromHub } from "@/lib/requests";
 import PropTypes from "prop-types";
@@ -33,6 +34,7 @@ function ServiceModalForm({
   profile,
   task,
   resources,
+  clusterPartitions,
   children
 }) {
 
@@ -40,9 +42,10 @@ function ServiceModalForm({
   const [modelId, setModelId] = React.useState(null);
 
   // Tier-based resource selection state
-  const [selectedPartition, setSelectedPartition] = React.useState(null);
+  const [selectedPartition, setSelectedPartition] = React.useState("");
   const [selectedTier, setSelectedTier] = React.useState(null);
   const [recommendedTier, setRecommendedTier] = React.useState(null);
+  const [partitionWarning, setPartitionWarning] = React.useState(null);
   const [showAdvanced, setShowAdvanced] = React.useState(false);
   const [account, setAccount] = React.useState("");
 
@@ -82,31 +85,25 @@ function ServiceModalForm({
     },
   ], []);
 
-  const defaultPartitions = React.useMemo(() => [
-    { name: "default", default: true, tiers: defaultTiers }
-  ], [defaultTiers]);
 
-  // Memoize partitions and tiers to avoid re-renders
-  const partitions = React.useMemo(() =>
-    resources?.partitions?.length > 0 ? resources.partitions : defaultPartitions,
-    [resources?.partitions, defaultPartitions]
+  // Resource spec partitions (for tier matching)
+  const specPartitions = React.useMemo(() =>
+    resources?.partitions?.length > 0 ? resources.partitions : [],
+    [resources?.partitions]
   );
-  const currentPartition = React.useMemo(() =>
-    partitions.find(p => p.name === selectedPartition) ||
-    partitions.find(p => p.default) ||
-    partitions[0],
-    [partitions, selectedPartition]
-  );
-  const tiers = React.useMemo(() => currentPartition?.tiers || [], [currentPartition?.tiers]);
-  const timeConfig = resources?.time || { default: 30, max: 180 };
 
-  // Initialize selected partition when resources load
-  React.useEffect(() => {
-    if (partitions.length > 0 && !selectedPartition) {
-      const defaultPartition = partitions.find(p => p.default) || partitions[0];
-      setSelectedPartition(defaultPartition.name);
+  // Resolve tiers: match typed partition against spec, else use default tiers
+  const tiers = React.useMemo(() => {
+    if (selectedPartition) {
+      const match = specPartitions.find(p => p.name === selectedPartition);
+      if (match) return match.tiers;
     }
-  }, [partitions, selectedPartition]);
+    // Fall back: use default spec partition's tiers if available, else default tiers
+    const defaultSpec = specPartitions.find(p => p.default) || specPartitions[0];
+    return defaultSpec?.tiers || defaultTiers;
+  }, [selectedPartition, specPartitions, defaultTiers]);
+
+  const timeConfig = resources?.time || { default: 30, max: 180 };
 
   // Select recommended tier based on model size
   // Priority: 1. model override, 2. client-side data, 3. HuggingFace Hub, 4. no auto-selection
@@ -177,7 +174,7 @@ function ServiceModalForm({
     } else {
       console.debug(`[TierSelect] No repo_id for model ${modelId}, skipping tier selection`);
     }
-  }, [modelId, tiers, models, resources?.models]);
+  }, [modelId, tiers, selectedPartition, models, resources?.models]);
 
   // Update jobOptions when tier selection changes
   React.useEffect(() => {
@@ -189,7 +186,7 @@ function ServiceModalForm({
           ntasks_per_node: tier.cpu_cores,
           mem: tier.memory_gb,
           gres: tier.gpu_count,
-          partition: selectedPartition,
+          partition: selectedPartition || null,
           constraint: tier.slurm?.constraint || null,
           account: account || null,
         }));
@@ -345,25 +342,58 @@ function ServiceModalForm({
       {profile.schema === "slurm"
         ? (
           <>
-            {/* Partition selector - only show if multiple partitions */}
-            {partitions.length > 1 && (
-              <fieldset>
-                <label className="block text-sm font-semibold leading-6 text-gray-900 dark:text-gray-100 mb-2">
-                  Partition
-                </label>
-                <PartitionSelect
-                  partitions={partitions}
-                  selectedPartition={selectedPartition}
-                  setSelectedPartition={(name) => {
-                    setSelectedPartition(name);
+            {/* Partition input */}
+            <fieldset>
+              <label htmlFor="partition" className="block text-sm font-semibold leading-6 text-gray-900 dark:text-gray-100 mb-2">
+                Partition
+              </label>
+              <div className="relative mt-2 rounded-md shadow-sm">
+                <input
+                  type="text"
+                  id="partition"
+                  name="partition"
+                  value={selectedPartition}
+                  onChange={(e) => {
+                    setSelectedPartition(e.target.value);
+                    setPartitionWarning(null);
                     // Reset tier selection when partition changes
                     setSelectedTier(null);
                     setRecommendedTier(null);
                   }}
+                  onBlur={() => {
+                    if (selectedPartition && clusterPartitions && !clusterPartitions.includes(selectedPartition)) {
+                      setPartitionWarning(`Partition "${selectedPartition}" was not found on the cluster.`);
+                    } else {
+                      setPartitionWarning(null);
+                    }
+                  }}
                   disabled={disabled}
+                  className={classNames(
+                    partitionWarning
+                      ? "ring-yellow-400 dark:ring-yellow-500 focus:ring-yellow-500"
+                      : "ring-gray-300 dark:ring-gray-600 focus:ring-blue-500",
+                    "block w-full rounded-md border-0 py-1.5 pr-10 ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:ring-1 disabled:ring-gray-300 dark:disabled:ring-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                  )}
                 />
-              </fieldset>
-            )}
+                {partitionWarning && (
+                  <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
+                    <ExclamationTriangleIcon
+                      className="h-5 w-5 text-yellow-500"
+                      aria-hidden="true"
+                    />
+                  </div>
+                )}
+              </div>
+              {partitionWarning ? (
+                <p className="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
+                  {partitionWarning}
+                </p>
+              ) : (
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  Specify a SLURM partition, or leave empty to use the cluster default.
+                </p>
+              )}
+            </fieldset>
 
             {/* Resources selector */}
             <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 -mx-1 space-y-4">
@@ -530,6 +560,7 @@ ServiceModalForm.propTypes = {
     ),
     models: PropTypes.objectOf(PropTypes.string),
   }),
+  clusterPartitions: PropTypes.arrayOf(PropTypes.string),
   children: PropTypes.node,
 };
 

--- a/web/src/components/ServiceModalForm.test.jsx
+++ b/web/src/components/ServiceModalForm.test.jsx
@@ -1,0 +1,200 @@
+/* eslint react/prop-types: 0 */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import ServiceModalForm from "@/components/ServiceModalForm";
+
+// Mock child components that aren't relevant to partition tests
+vi.mock("@/components/ModelSelect", () => ({
+  default: () => <div data-testid="model-select" />,
+}));
+vi.mock("@/components/RevisionSelect", () => ({
+  default: () => <div data-testid="revision-select" />,
+}));
+vi.mock("@/components/TierSelect", () => ({
+  default: ({ tiers, selectedTier }) => (
+    <div data-testid="tier-select">
+      {tiers.map((t) => (
+        <span key={t.name} data-testid={`tier-${t.name}`}>
+          {t.name}
+        </span>
+      ))}
+      {selectedTier && (
+        <span data-testid="selected-tier">{selectedTier}</span>
+      )}
+    </div>
+  ),
+}));
+vi.mock("@/components/ServiceModalValidatedInput", () => ({
+  default: ({ label, value }) => (
+    <div data-testid={`input-${label.toLowerCase()}`}>{value}</div>
+  ),
+}));
+vi.mock("@/lib/requests", () => ({
+  fetchModelSizeFromHub: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("@/lib/util", () => ({
+  classNames: (...args) => args.filter(Boolean).join(" "),
+  selectTierByModelSize: vi.fn(),
+}));
+
+describe("ServiceModalForm – Partition Input", () => {
+  const defaultProps = {
+    models: [{ repo_id: "model-1", id: "m1" }],
+    services: [],
+    setModel: vi.fn(),
+    jobOptions: {
+      name: "blackfish-12345",
+      time: "00:30:00",
+      ntasks_per_node: null,
+      mem: null,
+      gres: null,
+      partition: null,
+      constraint: null,
+      account: null,
+    },
+    setJobOptions: vi.fn(),
+    setValidationErrors: vi.fn(),
+    disabled: false,
+    profile: { schema: "slurm", host: "test-host", user: "testuser" },
+    task: "text-generation",
+    resources: {
+      partitions: [],
+      time: { default: 30, max: 180 },
+    },
+    clusterPartitions: null,
+    children: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderForm = (props = {}) =>
+    render(<ServiceModalForm {...defaultProps} {...props} />);
+
+  it("shows warning when blurred with a partition not on the cluster", async () => {
+    const user = userEvent.setup();
+    renderForm({ clusterPartitions: ["gpu", "cpu"] });
+
+    const input = screen.getByRole("textbox", { name: /partition/i });
+    await user.type(input, "nonexistent");
+    await user.tab(); // blur
+
+    expect(
+      screen.getByText(
+        'Partition "nonexistent" was not found on the cluster.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("does not show warning when blurred with a valid partition", async () => {
+    const user = userEvent.setup();
+    renderForm({ clusterPartitions: ["gpu", "cpu"] });
+
+    const input = screen.getByRole("textbox", { name: /partition/i });
+    await user.type(input, "gpu");
+    await user.tab();
+
+    expect(
+      screen.queryByText(/was not found on the cluster/)
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show warning when cluster status is unavailable", async () => {
+    const user = userEvent.setup();
+    renderForm({ clusterPartitions: null });
+
+    const input = screen.getByRole("textbox", { name: /partition/i });
+    await user.type(input, "anything");
+    await user.tab();
+
+    expect(
+      screen.queryByText(/was not found on the cluster/)
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears warning when the input value changes", async () => {
+    const user = userEvent.setup();
+    renderForm({ clusterPartitions: ["gpu"] });
+
+    const input = screen.getByRole("textbox", { name: /partition/i });
+
+    // Trigger warning
+    await user.type(input, "bad");
+    await user.tab();
+    expect(
+      screen.getByText('Partition "bad" was not found on the cluster.')
+    ).toBeInTheDocument();
+
+    // Type again — warning should clear immediately on change
+    await user.type(input, "x");
+    expect(
+      screen.queryByText(/was not found on the cluster/)
+    ).not.toBeInTheDocument();
+  });
+
+  it("updates tiers when partition matches a spec entry", async () => {
+    const user = userEvent.setup();
+    const gpuTiers = [
+      { name: "A100-Small", gpu_count: 1, gpu_type: "A100", cpu_cores: 4, memory_gb: 16 },
+      { name: "A100-Large", gpu_count: 4, gpu_type: "A100", cpu_cores: 16, memory_gb: 64 },
+    ];
+    const defaultTiers = [
+      { name: "Default-Tier", gpu_count: 0, gpu_type: null, cpu_cores: 2, memory_gb: 4 },
+    ];
+
+    renderForm({
+      resources: {
+        partitions: [
+          { name: "gpu", default: false, tiers: gpuTiers },
+          { name: "cpu", default: true, tiers: defaultTiers },
+        ],
+        time: { default: 30, max: 180 },
+      },
+    });
+
+    // Initially should show the default partition's tiers
+    expect(screen.getByTestId("tier-Default-Tier")).toBeInTheDocument();
+    expect(screen.queryByTestId("tier-A100-Small")).not.toBeInTheDocument();
+
+    // Type a partition that matches a spec entry
+    const input = screen.getByRole("textbox", { name: /partition/i });
+    await user.type(input, "gpu");
+    await user.tab();
+
+    // Now should show the gpu partition's tiers
+    expect(screen.getByTestId("tier-A100-Small")).toBeInTheDocument();
+    expect(screen.getByTestId("tier-A100-Large")).toBeInTheDocument();
+    expect(screen.queryByTestId("tier-Default-Tier")).not.toBeInTheDocument();
+  });
+
+  it("falls back to default tiers when partition does not match any spec", async () => {
+    const user = userEvent.setup();
+    const gpuTiers = [
+      { name: "A100-Small", gpu_count: 1, gpu_type: "A100", cpu_cores: 4, memory_gb: 16 },
+    ];
+    const defaultTiers = [
+      { name: "Default-Tier", gpu_count: 0, gpu_type: null, cpu_cores: 2, memory_gb: 4 },
+    ];
+
+    renderForm({
+      resources: {
+        partitions: [
+          { name: "gpu", default: false, tiers: gpuTiers },
+          { name: "cpu", default: true, tiers: defaultTiers },
+        ],
+        time: { default: 30, max: 180 },
+      },
+    });
+
+    const input = screen.getByRole("textbox", { name: /partition/i });
+    await user.type(input, "unknown");
+    await user.tab();
+
+    // Should still show default tiers, not gpu tiers
+    expect(screen.getByTestId("tier-Default-Tier")).toBeInTheDocument();
+    expect(screen.queryByTestId("tier-A100-Small")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Replace `PartitionSelect` dropdown with a text input for SLURM partition selection
- Input starts empty (no `--partition` flag sent to sbatch), letting the cluster use its default
- Tiers update dynamically: if typed partition matches a `resource_specs.yaml` entry, show its tiers; otherwise show default tiers
- Validates against live cluster data on blur with a non-blocking yellow warning if partition not found
- Tier auto-selection re-runs when partition changes

## Test plan
- [x] Partition input visible for SLURM profiles
- [x] Empty input shows default tiers and sends `partition: null`
- [x] Typing a partition matching a spec entry switches to that partition's tiers
- [x] Clearing input returns to default tiers without snapping back
- [x] Non-existent partition shows yellow warning (doesn't block launch)
- [x] Warning hidden if cluster status unavailable
- [x] Tier auto-selection works consistently across partition changes
- [x] ServiceModal tests pass (22/22)
- [x] Lint clean (no new errors)