### PR TITLE
refactor: replace TigerFlowClient.status() with report()

### DIFF
--- a/lib/src/blackfish/server/jobs/base.py
+++ b/lib/src/blackfish/server/jobs/base.py
@@ -268,6 +268,7 @@ class BatchJob(UUIDAuditBase):
         report = await client.report(self.output_dir)
 
         # Update progress from report
+        # staged = items waiting + items actively processing (both are "not yet finished")
         pipeline = report.progress.pipeline
         self.staged = pipeline.staged + pipeline.in_progress
         self.finished = pipeline.finished

--- a/lib/src/blackfish/server/jobs/base.py
+++ b/lib/src/blackfish/server/jobs/base.py
@@ -258,23 +258,24 @@ class BatchJob(UUIDAuditBase):
             Current batch job status
 
         Raises:
-            TigerFlowError: If status check fails
+            TigerFlowError: If report command fails
         """
         logger.debug(
             f"Checking status of batch job {self.id}. "
             f"Current status is {format_status(self.status)}."
         )
 
-        tf_status = await client.status(self.output_dir)
+        report = await client.report(self.output_dir)
 
-        # Update progress
-        self.staged = tf_status.staged
-        self.finished = tf_status.finished
-        self.errored = tf_status.failed
-        self.pid = str(tf_status.pid) if tf_status.pid else None
+        # Update progress from report
+        pipeline = report.progress.pipeline
+        self.staged = pipeline.staged + pipeline.in_progress
+        self.finished = pipeline.finished
+        self.errored = pipeline.errored
+        self.pid = str(report.status.pid) if report.status.pid else None
 
         # Map TigerFlow running state to BatchJobStatus
-        if tf_status.running:
+        if report.status.running:
             self.status = BatchJobStatus.RUNNING
         else:
             self.status = BatchJobStatus.STOPPED

--- a/lib/src/blackfish/server/jobs/client.py
+++ b/lib/src/blackfish/server/jobs/client.py
@@ -107,7 +107,7 @@ class TigerFlowError(Exception):
     """Error raised when TigerFlow operations fail.
 
     Args:
-        error_type: Type of error (ssh, command, setup, install, version, missing, run, status, stop)
+        error_type: Type of error (ssh, command, setup, install, version, missing, run, report, stop)
         host: The target host where the error occurred
         details: Optional additional context
     """
@@ -129,7 +129,7 @@ class TigerFlowError(Exception):
             "version": f"TigerFlow version on {self.host} is too old. Run profile setup to upgrade.",
             "missing": f"TigerFlow is not installed on {self.host}. Run profile setup to install.",
             "run": f"Failed to start TigerFlow job on {self.host}.",
-            "status": f"Failed to get TigerFlow job status on {self.host}.",
+            "report": f"Failed to get TigerFlow job report on {self.host}.",
             "stop": f"Failed to stop TigerFlow job on {self.host}.",
             "unsupported": f"Required tigerflow features not available on {self.host}. Upgrade tigerflow.",
         }
@@ -687,15 +687,17 @@ class TigerFlowClient:
                     if stderr
                     else f"Exit code {returncode}"
                 )
-                raise TigerFlowError("status", self.host, error_detail)
+                raise TigerFlowError("report", self.host, error_detail)
 
             raise TigerFlowError(
-                "status", self.host, "Empty response from tigerflow report"
+                "report", self.host, "Empty response from tigerflow report"
             )
         except json.JSONDecodeError as e:
-            raise TigerFlowError("status", self.host, f"Invalid JSON response: {e}")
+            raise TigerFlowError("report", self.host, f"Invalid JSON response: {e}")
         except ValidationError as e:
-            raise TigerFlowError("status", self.host, f"Invalid status format: {e}")
+            raise TigerFlowError(
+                "report", self.host, f"Invalid report format: {e}"
+            )
 
     async def stop(self, output_dir: str) -> None:
         """Stop a running job.

--- a/lib/src/blackfish/server/jobs/client.py
+++ b/lib/src/blackfish/server/jobs/client.py
@@ -665,33 +665,19 @@ class TigerFlowClient:
 
         command = f"{self._tigerflow_bin} report {output_dir} --json"
 
-        # Use runner.run() directly instead of _run() because tigerflow report
-        # returns exit code 1 for stopped pipelines but still outputs valid JSON
         try:
-            returncode, stdout, stderr = await self.runner.run(command)
+            stdout, _ = await self._run(command)
             output = stdout.decode("utf-8").strip()
 
-            # Try to parse JSON even on non-zero exit code
-            # tigerflow returns exit code 1 for stopped pipelines with valid output
-            if output:
-                try:
-                    data = json.loads(output)
-                    return TigerFlowReport.model_validate(data)
-                except (json.JSONDecodeError, ValidationError):
-                    pass  # Fall through to error handling
-
-            # No valid JSON output - report the error
-            if returncode != 0:
-                error_detail = (
-                    stderr.decode("utf-8").strip()
-                    if stderr
-                    else f"Exit code {returncode}"
+            if not output:
+                raise TigerFlowError(
+                    "report", self.host, "Empty response from tigerflow report"
                 )
-                raise TigerFlowError("report", self.host, error_detail)
 
-            raise TigerFlowError(
-                "report", self.host, "Empty response from tigerflow report"
-            )
+            data = json.loads(output)
+            return TigerFlowReport.model_validate(data)
+        except TigerFlowError:
+            raise
         except json.JSONDecodeError as e:
             raise TigerFlowError("report", self.host, f"Invalid JSON response: {e}")
         except ValidationError as e:

--- a/lib/src/blackfish/server/jobs/client.py
+++ b/lib/src/blackfish/server/jobs/client.py
@@ -23,14 +23,77 @@ MIN_TIGERFLOW_ML_VERSION = "0.1.0a0"
 VENV_PATH = ".venv"
 
 
-class TigerFlowStatus(BaseModel):
-    """Status returned by tigerflow status command."""
+class TigerFlowReportStatus(BaseModel):
+    """Status section from tigerflow report."""
 
-    pid: Optional[int]
     running: bool
-    staged: int
+    pid: Optional[int]
+
+
+class TigerFlowPipelineProgress(BaseModel):
+    """Pipeline progress from tigerflow report."""
+
     finished: int
+    in_progress: int
+    staged: int
+    errored: int
+
+
+class TigerFlowTaskProgress(BaseModel):
+    """Per-task progress from tigerflow report."""
+
+    name: str
+    processed: int
+    staged: int
     failed: int
+
+
+class TigerFlowProgress(BaseModel):
+    """Progress section from tigerflow report."""
+
+    pipeline: TigerFlowPipelineProgress
+    tasks: list[TigerFlowTaskProgress]
+
+
+class TigerFlowFileMetric(BaseModel):
+    """Per-file metric from tigerflow report."""
+
+    file: str
+    started_at: str
+    finished_at: str
+    duration_ms: float
+    status: str  # "success" | "error"
+
+
+class TigerFlowTaskMetrics(BaseModel):
+    """Per-task metrics summary from tigerflow report."""
+
+    count: int
+    avg_ms: float
+    min_ms: float
+    max_ms: float
+    durations: list[float]
+    files: list[TigerFlowFileMetric]
+
+
+class TigerFlowErrorDetail(BaseModel):
+    """Error detail for a single file from tigerflow report."""
+
+    file: str
+    path: str
+    timestamp: Optional[str]
+    exception_type: str
+    message: str
+    traceback: str
+
+
+class TigerFlowReport(BaseModel):
+    """Full report from tigerflow report --json."""
+
+    status: TigerFlowReportStatus
+    progress: TigerFlowProgress
+    metrics: dict[str, TigerFlowTaskMetrics]
+    errors: dict[str, list[TigerFlowErrorDetail]]
 
 
 class TigerFlowVersions(BaseModel):
@@ -365,9 +428,7 @@ class TigerFlowClient:
         if tigerflow_spec.startswith("git+") or tigerflow_ml_spec.startswith("git+"):
             try:
                 self._on_progress("Uninstalling existing packages...")
-                await self._run(
-                    f"{self._pip_bin} uninstall -y tigerflow tigerflow-ml"
-                )
+                await self._run(f"{self._pip_bin} uninstall -y tigerflow tigerflow-ml")
                 self._on_progress("Installing packages...")
                 await self._run(
                     f"{self._pip_bin} install {tigerflow_spec} {tigerflow_ml_spec}"
@@ -385,7 +446,10 @@ class TigerFlowClient:
             if returncode == 0:
                 outdated = json.loads(stdout.decode("utf-8"))
                 outdated_names = {pkg["name"].lower() for pkg in outdated}
-                if "tigerflow" not in outdated_names and "tigerflow-ml" not in outdated_names:
+                if (
+                    "tigerflow" not in outdated_names
+                    and "tigerflow-ml" not in outdated_names
+                ):
                     return "TigerFlow up-to-date."
 
             # Upgrade needed
@@ -517,9 +581,9 @@ class TigerFlowClient:
                     "tigerflow tasks command not available",
                 )
 
-        # Check pipeline support by trying 'tigerflow status --help'
+        # Check pipeline support by trying 'tigerflow report --help'
         returncode, _, stderr = await self.runner.run(
-            f"{self._tigerflow_bin} status --help"
+            f"{self._tigerflow_bin} report --help"
         )
         if returncode != 0:
             stderr_str = stderr.decode("utf-8", errors="replace").lower()
@@ -527,7 +591,7 @@ class TigerFlowClient:
                 raise TigerFlowError(
                     "unsupported",
                     self.host,
-                    "tigerflow status command not available",
+                    "tigerflow report command not available",
                 )
 
     # -------------------------------------------------------------------------
@@ -585,23 +649,23 @@ class TigerFlowClient:
 
         logger.info("TigerFlow job started successfully")
 
-    async def status(self, output_dir: str) -> TigerFlowStatus:
-        """Get job status.
+    async def report(self, output_dir: str) -> TigerFlowReport:
+        """Get full job report including status, progress, metrics, and errors.
 
         Args:
             output_dir: Path to output directory on cluster
 
         Returns:
-            TigerFlowStatus with current job state and progress
+            TigerFlowReport with current job state, progress, and file-level metrics
 
         Raises:
-            TigerFlowError: If status check fails
+            TigerFlowError: If report command fails
         """
-        logger.debug(f"Checking TigerFlow status for {output_dir}")
+        logger.debug(f"Fetching TigerFlow report for {output_dir}")
 
-        command = f"{self._tigerflow_bin} status {output_dir} --json"
+        command = f"{self._tigerflow_bin} report {output_dir} --json"
 
-        # Use runner.run() directly instead of _run() because tigerflow status
+        # Use runner.run() directly instead of _run() because tigerflow report
         # returns exit code 1 for stopped pipelines but still outputs valid JSON
         try:
             returncode, stdout, stderr = await self.runner.run(command)
@@ -612,16 +676,22 @@ class TigerFlowClient:
             if output:
                 try:
                     data = json.loads(output)
-                    return TigerFlowStatus.model_validate(data)
+                    return TigerFlowReport.model_validate(data)
                 except (json.JSONDecodeError, ValidationError):
                     pass  # Fall through to error handling
 
             # No valid JSON output - report the error
             if returncode != 0:
-                error_detail = stderr.decode("utf-8").strip() if stderr else f"Exit code {returncode}"
+                error_detail = (
+                    stderr.decode("utf-8").strip()
+                    if stderr
+                    else f"Exit code {returncode}"
+                )
                 raise TigerFlowError("status", self.host, error_detail)
 
-            raise TigerFlowError("status", self.host, "Empty response from tigerflow status")
+            raise TigerFlowError(
+                "status", self.host, "Empty response from tigerflow report"
+            )
         except json.JSONDecodeError as e:
             raise TigerFlowError("status", self.host, f"Invalid JSON response: {e}")
         except ValidationError as e:

--- a/lib/tests/api/test_jobs.py
+++ b/lib/tests/api/test_jobs.py
@@ -364,7 +364,12 @@ class TestStopBatchJobAPI:
         session: AsyncSession,
     ):
         """Test successfully stopping a job."""
-        from blackfish.server.jobs.client import TigerFlowStatus
+        from blackfish.server.jobs.client import (
+            TigerFlowReport,
+            TigerFlowReportStatus,
+            TigerFlowProgress,
+            TigerFlowPipelineProgress,
+        )
 
         job_id = "2a7a8e62-40cc-4240-a825-463e5b11a81f"
         output_dir = "/data/output"  # From fixture
@@ -372,9 +377,17 @@ class TestStopBatchJobAPI:
         # Set up mock TigerFlowClient
         mock_tigerflow = AsyncMock()
         mock_tigerflow.stop = AsyncMock()
-        mock_tigerflow.status = AsyncMock(
-            return_value=TigerFlowStatus(
-                pid=None, running=False, staged=10, finished=10, failed=0, tasks=[]
+        mock_tigerflow.report = AsyncMock(
+            return_value=TigerFlowReport(
+                status=TigerFlowReportStatus(running=False, pid=None),
+                progress=TigerFlowProgress(
+                    pipeline=TigerFlowPipelineProgress(
+                        finished=10, in_progress=0, staged=0, errored=0
+                    ),
+                    tasks=[],
+                ),
+                metrics={},
+                errors={},
             )
         )
         mock_create_client.return_value = mock_tigerflow
@@ -395,9 +408,9 @@ class TestStopBatchJobAPI:
         assert result["id"] == job_id
         assert result["status"] == "stopped"
 
-        # Verify stop and status were called to update the job
+        # Verify stop and report were called to update the job
         mock_tigerflow.stop.assert_called_once_with(output_dir)
-        mock_tigerflow.status.assert_called_once_with(output_dir)
+        mock_tigerflow.report.assert_called_once_with(output_dir)
 
     @patch("blackfish.server.asgi.create_tigerflow_client")
     async def test_stop_job_already_stopped(
@@ -407,7 +420,12 @@ class TestStopBatchJobAPI:
         session: AsyncSession,
     ):
         """Test stopping a job that's already stopped."""
-        from blackfish.server.jobs.client import TigerFlowStatus
+        from blackfish.server.jobs.client import (
+            TigerFlowReport,
+            TigerFlowReportStatus,
+            TigerFlowProgress,
+            TigerFlowPipelineProgress,
+        )
 
         job_id = "391769fc-5a40-43db-bbfa-cec80a8c3710"
         output_dir = "/data/output2"  # From fixture
@@ -415,9 +433,17 @@ class TestStopBatchJobAPI:
         # Set up mock TigerFlowClient
         mock_tigerflow = AsyncMock()
         mock_tigerflow.stop = AsyncMock()
-        mock_tigerflow.status = AsyncMock(
-            return_value=TigerFlowStatus(
-                pid=None, running=False, staged=5, finished=5, failed=0, tasks=[]
+        mock_tigerflow.report = AsyncMock(
+            return_value=TigerFlowReport(
+                status=TigerFlowReportStatus(running=False, pid=None),
+                progress=TigerFlowProgress(
+                    pipeline=TigerFlowPipelineProgress(
+                        finished=5, in_progress=0, staged=0, errored=0
+                    ),
+                    tasks=[],
+                ),
+                metrics={},
+                errors={},
             )
         )
         mock_create_client.return_value = mock_tigerflow
@@ -438,8 +464,8 @@ class TestStopBatchJobAPI:
 
         # stop() should not have been called since job was already stopped
         mock_tigerflow.stop.assert_not_called()
-        # status() should still be called to get final state
-        mock_tigerflow.status.assert_called_once_with(output_dir)
+        # report() should still be called to get final state
+        mock_tigerflow.report.assert_called_once_with(output_dir)
 
     async def test_stop_job_not_found(self, client: AsyncTestClient):
         """Test stopping a job that doesn't exist."""

--- a/lib/tests/unit/test_client.py
+++ b/lib/tests/unit/test_client.py
@@ -469,10 +469,12 @@ class TestTigerFlowClientUpgrade:
         runner = MockRunner()
         # First: pip list --outdated returns tigerflow as outdated
         # Second: pip install --upgrade
-        runner.set_responses([
-            (0, b'[{"name": "tigerflow", "version": "0.1.0"}]', b""),
-            (0, b"Successfully installed", b""),
-        ])
+        runner.set_responses(
+            [
+                (0, b'[{"name": "tigerflow", "version": "0.1.0"}]', b""),
+                (0, b"Successfully installed", b""),
+            ]
+        )
         client = TigerFlowClient(runner, "/home/user")
 
         await client.upgrade()
@@ -484,10 +486,12 @@ class TestTigerFlowClientUpgrade:
     async def test_upgrade_uses_venv_pip(self) -> None:
         """upgrade should use pip from the venv."""
         runner = MockRunner()
-        runner.set_responses([
-            (0, b'[{"name": "tigerflow", "version": "0.1.0"}]', b""),
-            (0, b"Successfully installed", b""),
-        ])
+        runner.set_responses(
+            [
+                (0, b'[{"name": "tigerflow", "version": "0.1.0"}]', b""),
+                (0, b"Successfully installed", b""),
+            ]
+        )
         client = TigerFlowClient(runner, "/home/user")
 
         await client.upgrade()
@@ -499,10 +503,16 @@ class TestTigerFlowClientUpgrade:
     async def test_upgrade_raises_install_error_on_failure(self) -> None:
         """upgrade should raise install error if pip upgrade fails."""
         runner = MockRunner()
-        runner.set_responses([
-            (0, b'[{"name": "tigerflow", "version": "0.1.0"}]', b""),  # outdated check
-            (1, b"", b"Network error"),  # install fails
-        ])
+        runner.set_responses(
+            [
+                (
+                    0,
+                    b'[{"name": "tigerflow", "version": "0.1.0"}]',
+                    b"",
+                ),  # outdated check
+                (1, b"", b"Network error"),  # install fails
+            ]
+        )
         client = TigerFlowClient(runner, "/home/user")
 
         with pytest.raises(TigerFlowError) as exc_info:
@@ -526,10 +536,12 @@ class TestTigerFlowClientUpgrade:
     async def test_upgrade_uninstalls_first_for_git_tigerflow_spec(self) -> None:
         """upgrade should uninstall then install when tigerflow_spec is a git URL."""
         runner = MockRunner()
-        runner.set_responses([
-            (0, b"", b""),  # uninstall
-            (0, b"Successfully installed", b""),  # install
-        ])
+        runner.set_responses(
+            [
+                (0, b"", b""),  # uninstall
+                (0, b"Successfully installed", b""),  # install
+            ]
+        )
         client = TigerFlowClient(runner, "/home/user")
 
         await client.upgrade(tigerflow_spec="git+https://github.com/org/tigerflow@main")
@@ -541,10 +553,12 @@ class TestTigerFlowClientUpgrade:
     async def test_upgrade_uninstalls_first_for_git_tigerflow_ml_spec(self) -> None:
         """upgrade should uninstall then install when tigerflow_ml_spec is a git URL."""
         runner = MockRunner()
-        runner.set_responses([
-            (0, b"", b""),  # uninstall
-            (0, b"Successfully installed", b""),  # install
-        ])
+        runner.set_responses(
+            [
+                (0, b"", b""),  # uninstall
+                (0, b"Successfully installed", b""),  # install
+            ]
+        )
         client = TigerFlowClient(runner, "/home/user")
 
         await client.upgrade(
@@ -558,10 +572,12 @@ class TestTigerFlowClientUpgrade:
     async def test_upgrade_no_uninstall_for_pypi_packages(self) -> None:
         """upgrade should use --upgrade without uninstall for regular PyPI packages."""
         runner = MockRunner()
-        runner.set_responses([
-            (0, b'[{"name": "tigerflow", "version": "0.1.0"}]', b""),  # outdated
-            (0, b"Successfully installed", b""),  # install
-        ])
+        runner.set_responses(
+            [
+                (0, b'[{"name": "tigerflow", "version": "0.1.0"}]', b""),  # outdated
+                (0, b"Successfully installed", b""),  # install
+            ]
+        )
         client = TigerFlowClient(runner, "/home/user")
 
         await client.upgrade()
@@ -734,12 +750,12 @@ class TestTigerFlowClientCheckCapabilities:
     """Tests for TigerFlowClient.check_capabilities()."""
 
     async def test_check_capabilities_passes_when_all_features_available(self) -> None:
-        """check_capabilities should pass when tasks and status commands work."""
+        """check_capabilities should pass when tasks and report commands work."""
         runner = MockRunner()
         runner.set_responses(
             [
                 (0, b'[{"name": "transcribe"}]', b""),  # tasks list
-                (0, b"Usage: tigerflow status", b""),  # status --help
+                (0, b"Usage: tigerflow report", b""),  # report --help
             ]
         )
         client = TigerFlowClient(runner, "/home/user")
@@ -763,13 +779,13 @@ class TestTigerFlowClientCheckCapabilities:
         assert exc_info.value.error_type == "unsupported"
         assert "tasks" in str(exc_info.value.details).lower()
 
-    async def test_check_capabilities_raises_when_status_command_unknown(self) -> None:
-        """check_capabilities should raise when status command not available."""
+    async def test_check_capabilities_raises_when_report_command_unknown(self) -> None:
+        """check_capabilities should raise when report command not available."""
         runner = MockRunner()
         runner.set_responses(
             [
                 (0, b'[{"name": "transcribe"}]', b""),  # tasks list succeeds
-                (1, b"", b"Error: no such command 'status'"),  # status --help fails
+                (1, b"", b"Error: no such command 'report'"),  # report --help fails
             ]
         )
         client = TigerFlowClient(runner, "/home/user")
@@ -778,7 +794,7 @@ class TestTigerFlowClientCheckCapabilities:
             await client.check_capabilities()
 
         assert exc_info.value.error_type == "unsupported"
-        assert "status" in str(exc_info.value.details).lower()
+        assert "report" in str(exc_info.value.details).lower()
 
     async def test_check_capabilities_ignores_other_errors(self) -> None:
         """check_capabilities should not raise for non-'unknown command' errors."""
@@ -901,108 +917,144 @@ class TestTigerFlowClientRun:
         assert exc_info.value.error_type == "run"
 
 
-class TestTigerFlowClientStatus:
-    """Tests for TigerFlowClient.status()."""
+class TestTigerFlowClientReport:
+    """Tests for TigerFlowClient.report()."""
 
-    async def test_status_parses_valid_response(self) -> None:
-        """status should parse valid tigerflow JSON response."""
-        runner = MockRunner()
-        runner.set_response(
-            0,
-            json.dumps(
-                {
-                    "pid": 12345,
-                    "running": True,
-                    "staged": 100,
-                    "finished": 50,
-                    "failed": 5,
-                    "tasks": [
+    @staticmethod
+    def _make_report_json(
+        running: bool = True,
+        pid: int | None = 12345,
+        finished: int = 50,
+        in_progress: int = 10,
+        staged: int = 40,
+        errored: int = 5,
+    ) -> dict:
+        """Build a valid tigerflow report JSON dict."""
+        return {
+            "status": {"running": running, "pid": pid},
+            "progress": {
+                "pipeline": {
+                    "finished": finished,
+                    "in_progress": in_progress,
+                    "staged": staged,
+                    "errored": errored,
+                },
+                "tasks": [
+                    {
+                        "name": "transcribe",
+                        "processed": finished,
+                        "staged": staged,
+                        "failed": errored,
+                    },
+                ],
+            },
+            "metrics": {
+                "transcribe": {
+                    "count": finished,
+                    "avg_ms": 1000.0,
+                    "min_ms": 500.0,
+                    "max_ms": 1500.0,
+                    "durations": [1000.0],
+                    "files": [
                         {
-                            "name": "transcribe",
-                            "processed": 50,
-                            "ongoing": 10,
-                            "failed": 5,
+                            "file": "audio_001.mp3",
+                            "started_at": "2026-04-03T10:00:00+00:00",
+                            "finished_at": "2026-04-03T10:00:01+00:00",
+                            "duration_ms": 1000.0,
+                            "status": "success",
                         },
                     ],
-                }
-            ).encode(),
-        )
+                },
+            },
+            "errors": {},
+        }
+
+    async def test_report_parses_valid_response(self) -> None:
+        """report should parse valid tigerflow JSON response."""
+        runner = MockRunner()
+        report_data = self._make_report_json()
+        runner.set_response(0, json.dumps(report_data).encode())
         client = TigerFlowClient(runner, "/home/user")
 
-        status = await client.status("/data/out")
+        report = await client.report("/data/out")
 
-        assert status.pid == 12345
-        assert status.running is True
-        assert status.staged == 100
-        assert status.finished == 50
-        assert status.failed == 5
-        assert len(status.tasks) == 1
-        assert status.tasks[0].name == "transcribe"
+        assert report.status.pid == 12345
+        assert report.status.running is True
+        assert report.progress.pipeline.finished == 50
+        assert report.progress.pipeline.in_progress == 10
+        assert report.progress.pipeline.staged == 40
+        assert report.progress.pipeline.errored == 5
+        assert len(report.progress.tasks) == 1
+        assert report.progress.tasks[0].name == "transcribe"
+        assert "transcribe" in report.metrics
+        assert len(report.metrics["transcribe"].files) == 1
 
-    async def test_status_raises_error_when_format_changes(self) -> None:
-        """status should raise error if tigerflow changes its response format."""
+    async def test_report_raises_error_when_format_changes(self) -> None:
+        """report should raise error if tigerflow changes its response format."""
         runner = MockRunner()
         runner.set_response(
             0,
-            json.dumps(
-                {
-                    "unexpected": "format",
-                }
-            ).encode(),
+            json.dumps({"unexpected": "format"}).encode(),
         )
         client = TigerFlowClient(runner, "/home/user")
 
         with pytest.raises(TigerFlowError) as exc_info:
-            await client.status("/data/out")
+            await client.report("/data/out")
 
         assert exc_info.value.error_type == "status"
 
-    async def test_status_raises_error_on_invalid_json(self) -> None:
-        """status should raise error when response is not valid JSON."""
+    async def test_report_raises_error_on_invalid_json(self) -> None:
+        """report should raise error when response is not valid JSON."""
         runner = MockRunner()
         runner.set_response(0, b"not json")
         client = TigerFlowClient(runner, "/home/user")
 
         with pytest.raises(TigerFlowError) as exc_info:
-            await client.status("/data/out")
+            await client.report("/data/out")
 
         assert exc_info.value.error_type == "status"
 
-    async def test_status_builds_command_with_output_dir_and_json_flag(self) -> None:
-        """status should build command with output_dir and --json flag."""
+    async def test_report_builds_command_with_output_dir_and_json_flag(self) -> None:
+        """report should build command with output_dir and --json flag."""
         runner = MockRunner()
-        runner.set_response(
-            0,
-            json.dumps(
-                {
-                    "pid": None,
-                    "running": False,
-                    "staged": 0,
-                    "finished": 0,
-                    "failed": 0,
-                    "tasks": [],
-                }
-            ).encode(),
+        report_data = self._make_report_json(
+            running=False, pid=None, finished=0, in_progress=0, staged=0, errored=0
         )
+        runner.set_response(0, json.dumps(report_data).encode())
         client = TigerFlowClient(runner, "/home/user")
 
-        await client.status("/data/output")
+        await client.report("/data/output")
 
         cmd = runner.commands[0]
-        assert "status" in cmd
+        assert "report" in cmd
         assert "/data/output" in cmd
         assert "--json" in cmd
 
-    async def test_status_raises_error_on_command_failure(self) -> None:
-        """status should raise error when tigerflow command fails."""
+    async def test_report_raises_error_on_command_failure(self) -> None:
+        """report should raise error when tigerflow command fails."""
         runner = MockRunner()
         runner.set_response(1, b"", b"Failed to read progress")
         client = TigerFlowClient(runner, "/home/user")
 
         with pytest.raises(TigerFlowError) as exc_info:
-            await client.status("/data/out")
+            await client.report("/data/out")
 
         assert exc_info.value.error_type == "status"
+
+    async def test_report_parses_stopped_pipeline_with_exit_code_1(self) -> None:
+        """report should parse valid JSON even when tigerflow returns exit code 1 for stopped pipelines."""
+        runner = MockRunner()
+        report_data = self._make_report_json(
+            running=False, pid=None, finished=10, in_progress=0, staged=0, errored=2
+        )
+        runner.set_response(1, json.dumps(report_data).encode())
+        client = TigerFlowClient(runner, "/home/user")
+
+        report = await client.report("/data/out")
+
+        assert report.status.running is False
+        assert report.progress.pipeline.finished == 10
+        assert report.progress.pipeline.errored == 2
 
 
 class TestTigerFlowClientStop:

--- a/lib/tests/unit/test_client.py
+++ b/lib/tests/unit/test_client.py
@@ -1001,7 +1001,7 @@ class TestTigerFlowClientReport:
         with pytest.raises(TigerFlowError) as exc_info:
             await client.report("/data/out")
 
-        assert exc_info.value.error_type == "status"
+        assert exc_info.value.error_type == "report"
 
     async def test_report_raises_error_on_invalid_json(self) -> None:
         """report should raise error when response is not valid JSON."""
@@ -1012,7 +1012,7 @@ class TestTigerFlowClientReport:
         with pytest.raises(TigerFlowError) as exc_info:
             await client.report("/data/out")
 
-        assert exc_info.value.error_type == "status"
+        assert exc_info.value.error_type == "report"
 
     async def test_report_builds_command_with_output_dir_and_json_flag(self) -> None:
         """report should build command with output_dir and --json flag."""
@@ -1039,7 +1039,7 @@ class TestTigerFlowClientReport:
         with pytest.raises(TigerFlowError) as exc_info:
             await client.report("/data/out")
 
-        assert exc_info.value.error_type == "status"
+        assert exc_info.value.error_type == "report"
 
     async def test_report_parses_stopped_pipeline_with_exit_code_1(self) -> None:
         """report should parse valid JSON even when tigerflow returns exit code 1 for stopped pipelines."""

--- a/lib/tests/unit/test_client.py
+++ b/lib/tests/unit/test_client.py
@@ -1031,7 +1031,7 @@ class TestTigerFlowClientReport:
         assert "--json" in cmd
 
     async def test_report_raises_error_on_command_failure(self) -> None:
-        """report should raise error when tigerflow command fails."""
+        """report should raise error when tigerflow command fails (e.g. invalid directory)."""
         runner = MockRunner()
         runner.set_response(1, b"", b"Failed to read progress")
         client = TigerFlowClient(runner, "/home/user")
@@ -1039,15 +1039,15 @@ class TestTigerFlowClientReport:
         with pytest.raises(TigerFlowError) as exc_info:
             await client.report("/data/out")
 
-        assert exc_info.value.error_type == "report"
+        assert exc_info.value.error_type == "command"
 
-    async def test_report_parses_stopped_pipeline_with_exit_code_1(self) -> None:
-        """report should parse valid JSON even when tigerflow returns exit code 1 for stopped pipelines."""
+    async def test_report_returns_stopped_pipeline(self) -> None:
+        """report should return stopped pipeline data (exit code 0)."""
         runner = MockRunner()
         report_data = self._make_report_json(
             running=False, pid=None, finished=10, in_progress=0, staged=0, errored=2
         )
-        runner.set_response(1, json.dumps(report_data).encode())
+        runner.set_response(0, json.dumps(report_data).encode())
         client = TigerFlowClient(runner, "/home/user")
 
         report = await client.report("/data/out")

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -12,7 +12,10 @@ from blackfish.server.jobs.base import (
 )
 from blackfish.server.jobs.client import (
     TigerFlowClient,
-    TigerFlowStatus,
+    TigerFlowReport,
+    TigerFlowReportStatus,
+    TigerFlowProgress,
+    TigerFlowPipelineProgress,
     TigerFlowError,
     TigerFlowVersions,
 )
@@ -147,6 +150,31 @@ class TestBatchJobStart:
             await job.start(client)
 
 
+def make_mock_report(
+    running: bool = True,
+    pid: int | None = 12345,
+    finished: int = 5,
+    in_progress: int = 3,
+    staged: int = 2,
+    errored: int = 0,
+) -> TigerFlowReport:
+    """Create a TigerFlowReport for testing."""
+    return TigerFlowReport(
+        status=TigerFlowReportStatus(running=running, pid=pid),
+        progress=TigerFlowProgress(
+            pipeline=TigerFlowPipelineProgress(
+                finished=finished,
+                in_progress=in_progress,
+                staged=staged,
+                errored=errored,
+            ),
+            tasks=[],
+        ),
+        metrics={},
+        errors={},
+    )
+
+
 class TestBatchJobUpdate:
     """Tests for BatchJob.update()."""
 
@@ -154,19 +182,14 @@ class TestBatchJobUpdate:
         """update should set status to RUNNING when tigerflow reports running."""
         job = create_test_batch_job(status=BatchJobStatus.RUNNING)
         client = create_mock_client()
-        client.status.return_value = TigerFlowStatus(
-            pid=12345,
-            running=True,
-            staged=10,
-            finished=5,
-            failed=0,
-            tasks=[],
+        client.report.return_value = make_mock_report(
+            running=True, pid=12345, finished=5, in_progress=3, staged=2, errored=0
         )
 
         result = await job.update(client)
 
         assert result == BatchJobStatus.RUNNING
-        assert job.staged == 10
+        assert job.staged == 5  # in_progress + staged
         assert job.finished == 5
         assert job.errored == 0
         assert job.pid == "12345"
@@ -175,19 +198,14 @@ class TestBatchJobUpdate:
         """update should set status to STOPPED when tigerflow reports not running."""
         job = create_test_batch_job(status=BatchJobStatus.RUNNING)
         client = create_mock_client()
-        client.status.return_value = TigerFlowStatus(
-            pid=None,
-            running=False,
-            staged=10,
-            finished=5,
-            failed=5,
-            tasks=[],
+        client.report.return_value = make_mock_report(
+            running=False, pid=None, finished=5, in_progress=0, staged=0, errored=5
         )
 
         result = await job.update(client)
 
         assert result == BatchJobStatus.STOPPED
-        assert job.staged == 10
+        assert job.staged == 0
         assert job.finished == 5
         assert job.errored == 5
 
@@ -195,7 +213,7 @@ class TestBatchJobUpdate:
         """update should propagate TigerFlowError from client."""
         job = create_test_batch_job(status=BatchJobStatus.RUNNING)
         client = create_mock_client()
-        client.status.side_effect = TigerFlowError("status", "host", "failed")
+        client.report.side_effect = TigerFlowError("status", "host", "failed")
 
         with pytest.raises(TigerFlowError):
             await job.update(client)

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -213,7 +213,7 @@ class TestBatchJobUpdate:
         """update should propagate TigerFlowError from client."""
         job = create_test_batch_job(status=BatchJobStatus.RUNNING)
         client = create_mock_client()
-        client.report.side_effect = TigerFlowError("status", "host", "failed")
+        client.report.side_effect = TigerFlowError("report", "host", "failed")
 
         with pytest.raises(TigerFlowError):
             await job.update(client)


### PR DESCRIPTION
## Summary

Migrates from `tigerflow status` to `tigerflow report` command to align with [princeton-ddss/tigerflow#62](https://github.com/princeton-ddss/tigerflow/pull/62), which unifies status/report into a single command.

- Replace `TigerFlowStatus` model with `TigerFlowReport` and sub-models for the full report structure (status, progress, metrics, errors)
- Update `BatchJob.update()` to extract status/progress from report
- Update `check_capabilities()` to check for `report` command instead of `status`
- Update all unit and API tests

**Note:** This PR should be merged after TigerFlow PR #62 lands, since the `tigerflow report --json` command does not exist yet.

## Test plan

- [x] `TestTigerFlowClientReport` — parses valid response, handles errors, validates command format
- [x] `TestBatchJobUpdate` — maps report fields to job status correctly
- [x] `TestStopBatchJobAPI` — stop endpoint works with new report-based update
- [x] All existing tests pass (2 pre-existing failures unrelated to this change)