### PR TITLE
feat: add file-level results for batch jobs

### DIFF
--- a/lib/docs/assets/img/coverage.svg
+++ b/lib/docs/assets/img/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#fe7d37" d="M63 0h36v20H63z"/>
+        <path fill="#dfb317" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">52%</text>
-        <text x="80" y="14">52%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">67%</text>
+        <text x="80" y="14">67%</text>
     </g>
 </svg>

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -88,6 +88,9 @@ from blackfish.server.jobs.base import (
     create_tigerflow_client,
     create_tigerflow_client_for_profile,
 )
+from blackfish.server.jobs.tasks import (
+    get_default_output_ext,
+)
 from blackfish.server.config import config as blackfish_config
 from blackfish.server.utils import find_port
 from blackfish.server.models.profile import (
@@ -1543,7 +1546,7 @@ async def get_job_results(
     latest: dict[tuple[str, str], JobFileResult] = {}
     for task_name, task_metrics in report.metrics.items():
         task_errors = error_lookup.get(task_name, {})
-        output_ext = job.output_ext or ""
+        output_ext = job.output_ext or get_default_output_ext(job.task) or ""
         for file_metric in task_metrics.files:
             stem = PurePosixPath(file_metric.file).stem
             output_file = f"{job.output_dir}/{task_name}/{stem}{output_ext}"

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -1553,11 +1553,15 @@ async def get_job_results(
 
             key = (task_name, file_metric.file)
             prev = latest.get(key)
-            if prev is None or file_metric.finished_at > prev.finished_at:
+            if prev is None or datetime.fromisoformat(
+                file_metric.finished_at
+            ) > datetime.fromisoformat(prev.finished_at):
                 latest[key] = JobFileResult(
                     file=file_metric.file,
                     task=task_name,
-                    output_file=output_file if file_metric.status == "success" else None,
+                    output_file=output_file
+                    if file_metric.status == "success"
+                    else None,
                     started_at=file_metric.started_at,
                     finished_at=file_metric.finished_at,
                     duration_ms=file_metric.duration_ms,

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -1539,18 +1539,19 @@ async def get_job_results(
     for task_name, error_list in report.errors.items():
         error_lookup[task_name] = {err.file: err.message for err in error_list}
 
-    # Flatten metrics across tasks into file results
-    results: list[JobFileResult] = []
+    # Flatten metrics across tasks, deduplicating by (task, file) — keep latest
+    latest: dict[tuple[str, str], JobFileResult] = {}
     for task_name, task_metrics in report.metrics.items():
         task_errors = error_lookup.get(task_name, {})
+        output_ext = job.output_ext or ""
         for file_metric in task_metrics.files:
-            # Construct output file path: {output_dir}/{task}/{stem}{output_ext}
             stem = PurePosixPath(file_metric.file).stem
-            output_ext = job.output_ext or ""
             output_file = f"{job.output_dir}/{task_name}/{stem}{output_ext}"
 
-            results.append(
-                JobFileResult(
+            key = (task_name, file_metric.file)
+            prev = latest.get(key)
+            if prev is None or file_metric.finished_at > prev.finished_at:
+                latest[key] = JobFileResult(
                     file=file_metric.file,
                     task=task_name,
                     output_file=output_file if file_metric.status == "success" else None,
@@ -1560,9 +1561,8 @@ async def get_job_results(
                     status=file_metric.status,
                     error=task_errors.get(file_metric.file),
                 )
-            )
 
-    return results
+    return list(latest.values())
 
 
 @put("/api/jobs/{job_id:str}/stop", guards=ENDPOINT_GUARDS)

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -65,7 +65,7 @@ from litestar.enums import RequestEncodingType
 from litestar.params import Body
 
 from huggingface_hub import login as hf_login, HfApi, model_info as hf_model_info
-from huggingface_hub.errors import GatedRepoError, HfHubHTTPError, RepositoryNotFoundError
+from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError
 
 from blackfish.server.logger import logger
 from blackfish.server import services
@@ -103,7 +103,11 @@ from blackfish.server.jobs.client import (
     SSHRunner,
     LocalRunner,
 )
-from blackfish.server.setup import ProfileManager, ProfileSetupError, repair_slurm_profile
+from blackfish.server.setup import (
+    ProfileManager,
+    ProfileSetupError,
+    repair_slurm_profile,
+)
 from blackfish.server.models.model import (
     Model,
     PIPELINE_IMAGES,
@@ -1498,6 +1502,67 @@ async def get_job(
         return res.scalar_one()
     except NoResultFound:
         raise NotFoundException(detail=f"Job {id} not found")
+
+
+@dataclass
+class JobFileResult:
+    file: str
+    task: str
+    output_file: str | None
+    started_at: str
+    finished_at: str
+    duration_ms: float
+    status: str
+    error: str | None
+
+
+@get("/api/jobs/{job_id:str}/results", guards=ENDPOINT_GUARDS)
+async def get_job_results(
+    job_id: str,
+    session: AsyncSession,
+    state: State,
+) -> list[JobFileResult]:
+    """Get file-level results for a batch job."""
+    job = await get_batch_job(job_id, session)
+    if job is None:
+        raise NotFoundException(detail=f"Job {job_id} not found")
+
+    client = create_tigerflow_client(job, state)
+
+    try:
+        report = await client.report(job.output_dir)
+    except TigerFlowError as e:
+        raise InternalServerException(detail=f"Failed to fetch job results: {e}")
+
+    # Build error lookup: {task: {filename: error_message}}
+    error_lookup: dict[str, dict[str, str]] = {}
+    for task_name, error_list in report.errors.items():
+        error_lookup[task_name] = {err.file: err.message for err in error_list}
+
+    # Flatten metrics across tasks into file results
+    results: list[JobFileResult] = []
+    for task_name, task_metrics in report.metrics.items():
+        task_errors = error_lookup.get(task_name, {})
+        for file_metric in task_metrics.files:
+            # Construct output file path: {output_dir}/{task}/{stem}{output_ext}
+            stem = file_metric.file.rsplit(".", 1)[0] if "." in file_metric.file else file_metric.file
+            output_ext = job.output_ext or ""
+            output_file = f"{job.output_dir}/{task_name}/{stem}{output_ext}"
+
+            results.append(
+                JobFileResult(
+                    file=file_metric.file,
+                    task=task_name,
+                    output_file=output_file if file_metric.status == "success" else None,
+                    started_at=file_metric.started_at,
+                    finished_at=file_metric.finished_at,
+                    duration_ms=file_metric.duration_ms,
+                    status=file_metric.status,
+                    error=task_errors.get(file_metric.file),
+                )
+            )
+
+    return results
 
 
 @put("/api/jobs/{job_id:str}/stop", guards=ENDPOINT_GUARDS)
@@ -3023,9 +3088,15 @@ async def get_hf_token_status() -> HfTokenStatusResponse:
             fullname=user_info.get("fullname"),
             email=user_info.get("email"),
             avatar_url=_hf_avatar_url(user_info.get("avatarUrl")),
-            token_name=access_token.get("displayName") if isinstance(access_token, dict) else None,
-            token_role=access_token.get("role") if isinstance(access_token, dict) else None,
-            token_created_at=access_token.get("createdAt") if isinstance(access_token, dict) else None,
+            token_name=access_token.get("displayName")
+            if isinstance(access_token, dict)
+            else None,
+            token_role=access_token.get("role")
+            if isinstance(access_token, dict)
+            else None,
+            token_created_at=access_token.get("createdAt")
+            if isinstance(access_token, dict)
+            else None,
         )
     except Exception:
         return HfTokenStatusResponse(configured=False)
@@ -3068,9 +3139,15 @@ async def set_hf_token(data: HfTokenRequest) -> HfTokenStatusResponse:
             fullname=user_info.get("fullname"),
             email=user_info.get("email"),
             avatar_url=_hf_avatar_url(user_info.get("avatarUrl")),
-            token_name=access_token.get("displayName") if isinstance(access_token, dict) else None,
-            token_role=access_token.get("role") if isinstance(access_token, dict) else None,
-            token_created_at=access_token.get("createdAt") if isinstance(access_token, dict) else None,
+            token_name=access_token.get("displayName")
+            if isinstance(access_token, dict)
+            else None,
+            token_role=access_token.get("role")
+            if isinstance(access_token, dict)
+            else None,
+            token_created_at=access_token.get("createdAt")
+            if isinstance(access_token, dict)
+            else None,
         )
     except Exception as e:
         logger.error(f"Failed to set HF token: {e}")
@@ -3357,6 +3434,7 @@ app = Litestar(
         run_job,
         fetch_jobs,
         get_job,
+        get_job_results,
         stop_job,
         delete_job,
         get_model,

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from collections.abc import AsyncGenerator
 from typing import Optional, Tuple, Any, Type, Annotated, Callable
 import asyncio
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import bcrypt
 from importlib import import_module
 from uuid import UUID
@@ -1545,7 +1545,7 @@ async def get_job_results(
         task_errors = error_lookup.get(task_name, {})
         for file_metric in task_metrics.files:
             # Construct output file path: {output_dir}/{task}/{stem}{output_ext}
-            stem = file_metric.file.rsplit(".", 1)[0] if "." in file_metric.file else file_metric.file
+            stem = PurePosixPath(file_metric.file).stem
             output_ext = job.output_ext or ""
             output_file = f"{job.output_dir}/{task_name}/{stem}{output_ext}"
 

--- a/lib/src/blackfish/server/jobs/base.py
+++ b/lib/src/blackfish/server/jobs/base.py
@@ -269,8 +269,9 @@ class BatchJob(UUIDAuditBase):
 
         # Update progress from report
         # staged = items waiting + items actively processing (both are "not yet finished")
+        # pipeline.staged is None when pipeline is stopped (no items waiting)
         pipeline = report.progress.pipeline
-        self.staged = pipeline.staged + pipeline.in_progress
+        self.staged = (pipeline.staged or 0) + pipeline.in_progress
         self.finished = pipeline.finished
         self.errored = pipeline.errored
         self.pid = str(report.status.pid) if report.status.pid else None

--- a/lib/src/blackfish/server/jobs/client.py
+++ b/lib/src/blackfish/server/jobs/client.py
@@ -35,7 +35,7 @@ class TigerFlowPipelineProgress(BaseModel):
 
     finished: int
     in_progress: int
-    staged: int
+    staged: Optional[int]  # None when pipeline is stopped
     errored: int
 
 

--- a/lib/tests/api/test_jobs.py
+++ b/lib/tests/api/test_jobs.py
@@ -586,6 +586,267 @@ class TestGetJobResultsAPI:
         assert error["error"] == "Decoding failed"
 
     @patch("blackfish.server.asgi.create_tigerflow_client")
+    async def test_get_results_no_output_ext(
+        self,
+        mock_create_client,
+        client: AsyncTestClient,
+        session: AsyncSession,
+    ):
+        """Test output path has no extension when output_ext and default are both None."""
+        from blackfish.server.jobs.client import (
+            TigerFlowReport,
+            TigerFlowReportStatus,
+            TigerFlowProgress,
+            TigerFlowPipelineProgress,
+            TigerFlowTaskMetrics,
+            TigerFlowFileMetric,
+        )
+
+        job_id = "2a7a8e62-40cc-4240-a825-463e5b11a81f"
+
+        # Clear output_ext on the fixture job (task="transcribe" has no default either)
+        job = await session.get(BatchJob, UUID(job_id))
+        job.output_ext = None
+        await session.commit()
+
+        mock_tigerflow = AsyncMock()
+        mock_tigerflow.report = AsyncMock(
+            return_value=TigerFlowReport(
+                status=TigerFlowReportStatus(running=False, pid=None),
+                progress=TigerFlowProgress(
+                    pipeline=TigerFlowPipelineProgress(
+                        finished=1, in_progress=0, staged=0, errored=0
+                    ),
+                    tasks=[],
+                ),
+                metrics={
+                    "transcribe": TigerFlowTaskMetrics(
+                        count=1,
+                        avg_ms=500.0,
+                        min_ms=500.0,
+                        max_ms=500.0,
+                        durations=[500.0],
+                        files=[
+                            TigerFlowFileMetric(
+                                file="audio_001.wav",
+                                started_at="2026-04-03T10:00:00+00:00",
+                                finished_at="2026-04-03T10:00:01+00:00",
+                                duration_ms=500.0,
+                                status="success",
+                            ),
+                        ],
+                    ),
+                },
+                errors={},
+            )
+        )
+        mock_create_client.return_value = mock_tigerflow
+
+        response = await client.get(f"/api/jobs/{job_id}/results")
+
+        assert response.status_code == 200
+        results = response.json()
+        assert len(results) == 1
+        assert results[0]["output_file"] == "/data/output/transcribe/audio_001"
+
+    @patch("blackfish.server.asgi.create_tigerflow_client")
+    async def test_get_results_falls_back_to_default_output_ext(
+        self,
+        mock_create_client,
+        client: AsyncTestClient,
+        session: AsyncSession,
+    ):
+        """Test output path uses task default ext when output_ext is None."""
+        from blackfish.server.jobs.client import (
+            TigerFlowReport,
+            TigerFlowReportStatus,
+            TigerFlowProgress,
+            TigerFlowPipelineProgress,
+            TigerFlowTaskMetrics,
+            TigerFlowFileMetric,
+        )
+
+        job_id = "2a7a8e62-40cc-4240-a825-463e5b11a81f"
+
+        # Set task to "detect" (default ext = ".json") and clear output_ext
+        job = await session.get(BatchJob, UUID(job_id))
+        job.output_ext = None
+        job.task = "detect"
+        await session.commit()
+
+        mock_tigerflow = AsyncMock()
+        mock_tigerflow.report = AsyncMock(
+            return_value=TigerFlowReport(
+                status=TigerFlowReportStatus(running=False, pid=None),
+                progress=TigerFlowProgress(
+                    pipeline=TigerFlowPipelineProgress(
+                        finished=1, in_progress=0, staged=0, errored=0
+                    ),
+                    tasks=[],
+                ),
+                metrics={
+                    "detect": TigerFlowTaskMetrics(
+                        count=1,
+                        avg_ms=500.0,
+                        min_ms=500.0,
+                        max_ms=500.0,
+                        durations=[500.0],
+                        files=[
+                            TigerFlowFileMetric(
+                                file="image_001.png",
+                                started_at="2026-04-03T10:00:00+00:00",
+                                finished_at="2026-04-03T10:00:01+00:00",
+                                duration_ms=500.0,
+                                status="success",
+                            ),
+                        ],
+                    ),
+                },
+                errors={},
+            )
+        )
+        mock_create_client.return_value = mock_tigerflow
+
+        response = await client.get(f"/api/jobs/{job_id}/results")
+
+        assert response.status_code == 200
+        results = response.json()
+        assert len(results) == 1
+        assert results[0]["output_file"] == "/data/output/detect/image_001.json"
+
+    @patch("blackfish.server.asgi.create_tigerflow_client")
+    async def test_get_results_dedup_keeps_latest(
+        self,
+        mock_create_client,
+        client: AsyncTestClient,
+    ):
+        """Test that duplicate (task, file) entries keep the latest by finished_at."""
+        from blackfish.server.jobs.client import (
+            TigerFlowReport,
+            TigerFlowReportStatus,
+            TigerFlowProgress,
+            TigerFlowPipelineProgress,
+            TigerFlowTaskMetrics,
+            TigerFlowFileMetric,
+        )
+
+        job_id = "2a7a8e62-40cc-4240-a825-463e5b11a81f"
+
+        mock_tigerflow = AsyncMock()
+        mock_tigerflow.report = AsyncMock(
+            return_value=TigerFlowReport(
+                status=TigerFlowReportStatus(running=False, pid=None),
+                progress=TigerFlowProgress(
+                    pipeline=TigerFlowPipelineProgress(
+                        finished=1, in_progress=0, staged=0, errored=0
+                    ),
+                    tasks=[],
+                ),
+                metrics={
+                    "transcribe": TigerFlowTaskMetrics(
+                        count=2,
+                        avg_ms=500.0,
+                        min_ms=500.0,
+                        max_ms=500.0,
+                        durations=[500.0, 500.0],
+                        files=[
+                            TigerFlowFileMetric(
+                                file="audio_001.wav",
+                                started_at="2026-04-03T10:00:00+00:00",
+                                finished_at="2026-04-03T10:00:01+00:00",
+                                duration_ms=500.0,
+                                status="error",
+                            ),
+                            TigerFlowFileMetric(
+                                file="audio_001.wav",
+                                started_at="2026-04-03T10:01:00+00:00",
+                                finished_at="2026-04-03T10:01:01+00:00",
+                                duration_ms=500.0,
+                                status="success",
+                            ),
+                        ],
+                    ),
+                },
+                errors={},
+            )
+        )
+        mock_create_client.return_value = mock_tigerflow
+
+        response = await client.get(f"/api/jobs/{job_id}/results")
+
+        assert response.status_code == 200
+        results = response.json()
+        assert len(results) == 1
+        assert results[0]["status"] == "success"
+        assert results[0]["finished_at"] == "2026-04-03T10:01:01+00:00"
+
+    @patch("blackfish.server.asgi.create_tigerflow_client")
+    async def test_get_results_dedup_keeps_latest_reverse_order(
+        self,
+        mock_create_client,
+        client: AsyncTestClient,
+    ):
+        """Test dedup keeps latest even when it appears first in the list."""
+        from blackfish.server.jobs.client import (
+            TigerFlowReport,
+            TigerFlowReportStatus,
+            TigerFlowProgress,
+            TigerFlowPipelineProgress,
+            TigerFlowTaskMetrics,
+            TigerFlowFileMetric,
+        )
+
+        job_id = "2a7a8e62-40cc-4240-a825-463e5b11a81f"
+
+        mock_tigerflow = AsyncMock()
+        mock_tigerflow.report = AsyncMock(
+            return_value=TigerFlowReport(
+                status=TigerFlowReportStatus(running=False, pid=None),
+                progress=TigerFlowProgress(
+                    pipeline=TigerFlowPipelineProgress(
+                        finished=1, in_progress=0, staged=0, errored=0
+                    ),
+                    tasks=[],
+                ),
+                metrics={
+                    "transcribe": TigerFlowTaskMetrics(
+                        count=2,
+                        avg_ms=500.0,
+                        min_ms=500.0,
+                        max_ms=500.0,
+                        durations=[500.0, 500.0],
+                        files=[
+                            TigerFlowFileMetric(
+                                file="audio_001.wav",
+                                started_at="2026-04-03T10:01:00+00:00",
+                                finished_at="2026-04-03T10:01:01+00:00",
+                                duration_ms=500.0,
+                                status="success",
+                            ),
+                            TigerFlowFileMetric(
+                                file="audio_001.wav",
+                                started_at="2026-04-03T10:00:00+00:00",
+                                finished_at="2026-04-03T10:00:01+00:00",
+                                duration_ms=500.0,
+                                status="error",
+                            ),
+                        ],
+                    ),
+                },
+                errors={},
+            )
+        )
+        mock_create_client.return_value = mock_tigerflow
+
+        response = await client.get(f"/api/jobs/{job_id}/results")
+
+        assert response.status_code == 200
+        results = response.json()
+        assert len(results) == 1
+        assert results[0]["status"] == "success"
+        assert results[0]["finished_at"] == "2026-04-03T10:01:01+00:00"
+
+    @patch("blackfish.server.asgi.create_tigerflow_client")
     async def test_get_results_tigerflow_error(
         self,
         mock_create_client,
@@ -598,7 +859,9 @@ class TestGetJobResultsAPI:
 
         mock_tigerflow = AsyncMock()
         mock_tigerflow.report = AsyncMock(
-            side_effect=TigerFlowError("report", "cluster.example.com", "Connection refused")
+            side_effect=TigerFlowError(
+                "report", "cluster.example.com", "Connection refused"
+            )
         )
         mock_create_client.return_value = mock_tigerflow
 

--- a/lib/tests/api/test_jobs.py
+++ b/lib/tests/api/test_jobs.py
@@ -493,6 +493,113 @@ class TestStopBatchJobAPI:
         assert response.status_code == 401
 
 
+class TestGetJobResultsAPI:
+    """Test cases for the GET /api/jobs/{id}/results endpoint."""
+
+    @patch("blackfish.server.asgi.create_tigerflow_client")
+    async def test_get_results_success(
+        self,
+        mock_create_client,
+        client: AsyncTestClient,
+    ):
+        """Test fetching file-level results for a job."""
+        from blackfish.server.jobs.client import (
+            TigerFlowReport,
+            TigerFlowReportStatus,
+            TigerFlowProgress,
+            TigerFlowPipelineProgress,
+            TigerFlowTaskMetrics,
+            TigerFlowFileMetric,
+            TigerFlowErrorDetail,
+        )
+
+        job_id = "2a7a8e62-40cc-4240-a825-463e5b11a81f"
+
+        mock_tigerflow = AsyncMock()
+        mock_tigerflow.report = AsyncMock(
+            return_value=TigerFlowReport(
+                status=TigerFlowReportStatus(running=False, pid=None),
+                progress=TigerFlowProgress(
+                    pipeline=TigerFlowPipelineProgress(
+                        finished=2, in_progress=0, staged=0, errored=1
+                    ),
+                    tasks=[],
+                ),
+                metrics={
+                    "transcribe": TigerFlowTaskMetrics(
+                        count=2,
+                        avg_ms=1000.0,
+                        min_ms=500.0,
+                        max_ms=1500.0,
+                        durations=[500.0, 1500.0],
+                        files=[
+                            TigerFlowFileMetric(
+                                file="audio_001.wav",
+                                started_at="2026-04-03T10:00:00+00:00",
+                                finished_at="2026-04-03T10:00:01+00:00",
+                                duration_ms=1000.0,
+                                status="success",
+                            ),
+                            TigerFlowFileMetric(
+                                file="audio_002.wav",
+                                started_at="2026-04-03T10:00:01+00:00",
+                                finished_at="2026-04-03T10:00:02+00:00",
+                                duration_ms=1000.0,
+                                status="error",
+                            ),
+                        ],
+                    ),
+                },
+                errors={
+                    "transcribe": [
+                        TigerFlowErrorDetail(
+                            file="audio_002.wav",
+                            path="/data/output/.tigerflow/transcribe/audio_002.err",
+                            timestamp="2026-04-03T10:00:02+00:00",
+                            exception_type="RuntimeError",
+                            message="Decoding failed",
+                            traceback="Traceback ...",
+                        ),
+                    ],
+                },
+            )
+        )
+        mock_create_client.return_value = mock_tigerflow
+
+        response = await client.get(f"/api/jobs/{job_id}/results")
+
+        assert response.status_code == 200
+        results = response.json()
+        assert len(results) == 2
+
+        # Check success result
+        success = next(r for r in results if r["file"] == "audio_001.wav")
+        assert success["status"] == "success"
+        assert success["task"] == "transcribe"
+        assert success["output_file"] == "/data/output/transcribe/audio_001.json"
+        assert success["error"] is None
+
+        # Check error result
+        error = next(r for r in results if r["file"] == "audio_002.wav")
+        assert error["status"] == "error"
+        assert error["output_file"] is None
+        assert error["error"] == "Decoding failed"
+
+    async def test_get_results_not_found(self, client: AsyncTestClient):
+        """Test fetching results for a nonexistent job."""
+        nonexistent_id = "550e8400-e29b-41d4-a716-446655440000"
+        response = await client.get(f"/api/jobs/{nonexistent_id}/results")
+        assert response.status_code == 404
+
+    async def test_get_results_authentication_required(
+        self, no_auth_client: AsyncTestClient
+    ):
+        """Test that authentication is required for fetching results."""
+        job_id = "2a7a8e62-40cc-4240-a825-463e5b11a81f"
+        response = await no_auth_client.get(f"/api/jobs/{job_id}/results")
+        assert response.status_code == 401
+
+
 class TestCreateBatchJobAPI:
     """Test cases for the POST /api/jobs endpoint."""
 

--- a/lib/tests/api/test_jobs.py
+++ b/lib/tests/api/test_jobs.py
@@ -585,6 +585,29 @@ class TestGetJobResultsAPI:
         assert error["output_file"] is None
         assert error["error"] == "Decoding failed"
 
+    @patch("blackfish.server.asgi.create_tigerflow_client")
+    async def test_get_results_tigerflow_error(
+        self,
+        mock_create_client,
+        client: AsyncTestClient,
+    ):
+        """Test that TigerFlow errors return 500 with detail message."""
+        from blackfish.server.jobs.client import TigerFlowError
+
+        job_id = "2a7a8e62-40cc-4240-a825-463e5b11a81f"
+
+        mock_tigerflow = AsyncMock()
+        mock_tigerflow.report = AsyncMock(
+            side_effect=TigerFlowError("report", "cluster.example.com", "Connection refused")
+        )
+        mock_create_client.return_value = mock_tigerflow
+
+        response = await client.get(f"/api/jobs/{job_id}/results")
+
+        assert response.status_code == 500
+        body = response.json()
+        assert "Failed to fetch job results" in body["detail"]
+
     async def test_get_results_not_found(self, client: AsyncTestClient):
         """Test fetching results for a nonexistent job."""
         nonexistent_id = "550e8400-e29b-41d4-a716-446655440000"

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -155,7 +155,7 @@ def make_mock_report(
     pid: int | None = 12345,
     finished: int = 5,
     in_progress: int = 3,
-    staged: int = 2,
+    staged: int | None = 2,
     errored: int = 0,
 ) -> TigerFlowReport:
     """Create a TigerFlowReport for testing."""
@@ -199,13 +199,13 @@ class TestBatchJobUpdate:
         job = create_test_batch_job(status=BatchJobStatus.RUNNING)
         client = create_mock_client()
         client.report.return_value = make_mock_report(
-            running=False, pid=None, finished=5, in_progress=0, staged=0, errored=5
+            running=False, pid=None, finished=5, in_progress=0, staged=None, errored=5
         )
 
         result = await job.update(client)
 
         assert result == BatchJobStatus.STOPPED
-        assert job.staged == 0
+        assert job.staged == 0  # staged=None maps to 0 for stopped pipelines
         assert job.finished == 5
         assert job.errored == 5
 

--- a/web/src/lib/loaders.js
+++ b/web/src/lib/loaders.js
@@ -42,7 +42,7 @@ export const useModels = (profile, image = null) => {
 export const useJobs = (profile) => {
   const key = profile ? `jobs?profile=${profile.name}` : null;
   const { data, error, isLoading, isValidating, mutate } = useSWR(key, fetchJobs, {
-    refreshInterval: 30_000,
+    refreshInterval: 60_000,
   });
   return {
     jobs: data || [],
@@ -58,6 +58,9 @@ export const useJobResults = (jobId) => {
   const { data, error, isLoading, isValidating, mutate } = useSWR(
     key,
     () => fetchJobResults(jobId),
+    {
+      refreshInterval: 60_000,
+    },
   );
   return {
     results: data || [],

--- a/web/src/lib/loaders.js
+++ b/web/src/lib/loaders.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import useSWR from "swr";
-import { fetchModels, fetchServices, fetchProfiles, fetchFiles, fetchClusterStatus, fetchJobs } from "./requests";
+import { fetchModels, fetchServices, fetchProfiles, fetchFiles, fetchClusterStatus, fetchJobs, fetchJobResults } from "./requests";
 import { ServiceStatus } from "./util";
 import { useRemoteFileSystem } from "@/providers/RemoteFileSystemProvider";
 
@@ -46,6 +46,21 @@ export const useJobs = (profile) => {
   });
   return {
     jobs: data || [],
+    error: error,
+    isLoading: isLoading,
+    isRefreshing: isValidating,
+    mutate: mutate,
+  };
+};
+
+export const useJobResults = (jobId) => {
+  const key = jobId ? `jobs/${jobId}/results` : null;
+  const { data, error, isLoading, isValidating, mutate } = useSWR(
+    key,
+    () => fetchJobResults(jobId),
+  );
+  return {
+    results: data || [],
     error: error,
     isLoading: isLoading,
     isRefreshing: isValidating,

--- a/web/src/lib/requests.js
+++ b/web/src/lib/requests.js
@@ -293,6 +293,27 @@ export async function fetchJobs(path) {
   return res.json();
 }
 
+/** Fetch file-level results for a batch job. */
+export async function fetchJobResults(jobId) {
+  const res = await fetch(`${blackfishApiURL}/api/jobs/${jobId}/results`);
+  if (!res.ok) {
+    console.debug(`from fetchJobResults: failed to fetch results (status=${res.status})`);
+    let message = "Failed to fetch job results.";
+    try {
+      const body = await res.json();
+      if (body.detail) {
+        message = body.detail;
+      }
+    } catch {
+      // Ignore JSON parse errors
+    }
+    const error = new Error(message);
+    error.status = res.status;
+    throw error;
+  }
+  return res.json();
+}
+
 /** Fetch resource tiers and time constraints for a profile. */
 export async function fetchProfileResources(profileName) {
   const res = await fetch(`${blackfishApiURL}/api/profiles/${profileName}/resources`);

--- a/web/src/routes/jobs/components/JobDetailsPanel.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.jsx
@@ -8,14 +8,19 @@ import {
 } from "@heroicons/react/24/outline";
 import PropTypes from "prop-types";
 
-function StatusBadge({ status }) {
+function StatusBadge({ status, errored = 0 }) {
     const getStatusConfig = () => {
         switch (status) {
             case "running":
-                return {
+                return errored > 0 ? {
                     bg: "bg-yellow-50 dark:bg-yellow-900/30",
                     text: "text-yellow-700 dark:text-yellow-400",
                     ring: "ring-yellow-600/20 dark:ring-yellow-500/30",
+                    label: "Running",
+                } : {
+                    bg: "bg-green-50 dark:bg-green-900/30",
+                    text: "text-green-700 dark:text-green-400",
+                    ring: "ring-green-600/20 dark:ring-green-500/30",
                     label: "Running",
                 };
             case "broken":
@@ -47,6 +52,7 @@ function StatusBadge({ status }) {
 
 StatusBadge.propTypes = {
     status: PropTypes.string.isRequired,
+    errored: PropTypes.number,
 };
 
 function ProgressBar({ finished, staged, errored }) {
@@ -116,7 +122,7 @@ function JobDetailsPanel({ job, onStopJob, onDeleteJob, jobActionInProgress }) {
                     </p>
                 </div>
                 <div className="flex items-center gap-2">
-                    <StatusBadge status={job.status} />
+                    <StatusBadge status={job.status} errored={job.errored} />
                     {job.status === "running" && onStopJob && (
                         <button
                             type="button"

--- a/web/src/routes/jobs/components/JobDetailsPanel.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.jsx
@@ -205,7 +205,7 @@ function JobDetailsPanel({ job, onStopJob, onDeleteJob, jobActionInProgress }) {
                             Resource Config
                         </h4>
                     </div>
-                    <div className="grid grid-cols-2 gap-2 text-sm">
+                    <div className="space-y-2 text-sm">
                         {job.resources?.memory && (
                             <div className="flex justify-between">
                                 <span className="text-gray-500 dark:text-gray-400">Memory:</span>

--- a/web/src/routes/jobs/components/JobDetailsPanel.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.jsx
@@ -148,7 +148,9 @@ function JobDetailsPanel({ job, onStopJob, onDeleteJob, jobActionInProgress }) {
                     <span className="text-gray-500 dark:text-gray-400">Progress</span>
                     <div className="flex items-center gap-3 text-xs">
                         <span className="text-green-600 dark:text-green-400">{done} done</span>
-                        <span className="text-gray-500 dark:text-gray-400">{pending} staged</span>
+                        {job.status === "running" && pending > 0 && (
+                            <span className="text-gray-500 dark:text-gray-400">{pending} staged</span>
+                        )}
                         {failed > 0 && (
                             <span className="text-red-600 dark:text-red-400">{failed} failed</span>
                         )}

--- a/web/src/routes/jobs/components/JobDetailsPanel.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.jsx
@@ -8,39 +8,15 @@ import {
 } from "@heroicons/react/24/outline";
 import PropTypes from "prop-types";
 
-// Derive display status from API status and progress fields
-function deriveDisplayStatus(job) {
-    if (job.status === "running") return "running";
-    if (job.status === "broken") return "broken";
-    // status === "stopped"
-    if ((job.staged ?? 0) === 0 && (job.errored ?? 0) === 0) return "done";
-    if ((job.errored ?? 0) > 0) return "error";
-    return "stopped";
-}
-
-function StatusBadge({ displayStatus }) {
+function StatusBadge({ status }) {
     const getStatusConfig = () => {
-        switch (displayStatus) {
-            case "done":
-                return {
-                    bg: "bg-green-50 dark:bg-green-900/30",
-                    text: "text-green-700 dark:text-green-400",
-                    ring: "ring-green-600/20 dark:ring-green-500/30",
-                    label: "Done",
-                };
+        switch (status) {
             case "running":
                 return {
                     bg: "bg-yellow-50 dark:bg-yellow-900/30",
                     text: "text-yellow-700 dark:text-yellow-400",
                     ring: "ring-yellow-600/20 dark:ring-yellow-500/30",
                     label: "Running",
-                };
-            case "error":
-                return {
-                    bg: "bg-red-50 dark:bg-red-900/30",
-                    text: "text-red-700 dark:text-red-400",
-                    ring: "ring-red-600/20 dark:ring-red-500/30",
-                    label: "Error",
                 };
             case "broken":
                 return {
@@ -70,7 +46,7 @@ function StatusBadge({ displayStatus }) {
 }
 
 StatusBadge.propTypes = {
-    displayStatus: PropTypes.string.isRequired,
+    status: PropTypes.string.isRequired,
 };
 
 function ProgressBar({ finished, staged, errored }) {
@@ -140,7 +116,7 @@ function JobDetailsPanel({ job, onStopJob, onDeleteJob, jobActionInProgress }) {
                     </p>
                 </div>
                 <div className="flex items-center gap-2">
-                    <StatusBadge displayStatus={deriveDisplayStatus(job)} />
+                    <StatusBadge status={job.status} />
                     {job.status === "running" && onStopJob && (
                         <button
                             type="button"

--- a/web/src/routes/jobs/components/JobDetailsPanel.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.jsx
@@ -177,17 +177,17 @@ function JobDetailsPanel({ job, onStopJob, onDeleteJob, jobActionInProgress }) {
                     </div>
                     <div className="space-y-2 text-sm">
                         {job.input_dir && (
-                            <div>
+                            <div className="flex justify-between">
                                 <span className="text-gray-500 dark:text-gray-400">Input:</span>
-                                <span className="text-gray-900 dark:text-gray-100 text-xs font-mono ml-2 break-all">
+                                <span className="text-gray-900 dark:text-gray-100 text-xs font-mono ml-2 truncate" title={job.input_dir}>
                                     {job.input_dir}
                                 </span>
                             </div>
                         )}
                         {job.output_dir && (
-                            <div>
+                            <div className="flex justify-between">
                                 <span className="text-gray-500 dark:text-gray-400">Output:</span>
-                                <span className="text-gray-900 dark:text-gray-100 text-xs font-mono ml-2 break-all">
+                                <span className="text-gray-900 dark:text-gray-100 text-xs font-mono ml-2 truncate" title={job.output_dir}>
                                     {job.output_dir}
                                 </span>
                             </div>

--- a/web/src/routes/jobs/components/JobDetailsPanel.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.jsx
@@ -6,54 +6,8 @@ import {
     StopIcon,
     TrashIcon,
 } from "@heroicons/react/24/outline";
+import StatusBadge from "./StatusBadge";
 import PropTypes from "prop-types";
-
-function StatusBadge({ status, errored = 0 }) {
-    const getStatusConfig = () => {
-        switch (status) {
-            case "running":
-                return errored > 0 ? {
-                    bg: "bg-yellow-50 dark:bg-yellow-900/30",
-                    text: "text-yellow-700 dark:text-yellow-400",
-                    ring: "ring-yellow-600/20 dark:ring-yellow-500/30",
-                    label: "Running",
-                } : {
-                    bg: "bg-green-50 dark:bg-green-900/30",
-                    text: "text-green-700 dark:text-green-400",
-                    ring: "ring-green-600/20 dark:ring-green-500/30",
-                    label: "Running",
-                };
-            case "broken":
-                return {
-                    bg: "bg-orange-50 dark:bg-orange-900/30",
-                    text: "text-orange-700 dark:text-orange-400",
-                    ring: "ring-orange-600/20 dark:ring-orange-500/30",
-                    label: "Broken",
-                };
-            case "stopped":
-            default:
-                return {
-                    bg: "bg-gray-50 dark:bg-gray-700",
-                    text: "text-gray-600 dark:text-gray-400",
-                    ring: "ring-gray-500/10 dark:ring-gray-600",
-                    label: "Stopped",
-                };
-        }
-    };
-
-    const config = getStatusConfig();
-
-    return (
-        <span className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${config.bg} ${config.text} ${config.ring}`}>
-            {config.label}
-        </span>
-    );
-}
-
-StatusBadge.propTypes = {
-    status: PropTypes.string.isRequired,
-    errored: PropTypes.number,
-};
 
 function ProgressBar({ finished, staged, errored }) {
     const done = Number(finished) || 0;

--- a/web/src/routes/jobs/components/JobResultsTable.jsx
+++ b/web/src/routes/jobs/components/JobResultsTable.jsx
@@ -174,7 +174,7 @@ function JobResultsTable({
                                                         : "bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
                                                 }`}
                                             >
-                                                <td className="whitespace-nowrap py-3 pl-4 pr-3 text-left text-sm text-gray-900 dark:text-gray-100 sm:pl-6">
+                                                <td className="whitespace-nowrap py-3 pl-4 pr-3 text-left text-xs font-mono text-gray-900 dark:text-gray-100 sm:pl-6">
                                                     <div className="overflow-x-scroll">{result.input_file}</div>
                                                 </td>
                                                 <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-900 dark:text-gray-100">
@@ -188,7 +188,7 @@ function JobResultsTable({
                                                         <StatusIcon success={result.success} />
                                                     </div>
                                                 </td>
-                                                <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-900 dark:text-gray-100">
+                                                <td className="whitespace-nowrap py-3 px-3 text-left text-xs font-mono text-gray-900 dark:text-gray-100">
                                                     <div className="overflow-x-scroll">
                                                         {result.output_file ? result.output_file.split("/").pop() : "-"}
                                                     </div>

--- a/web/src/routes/jobs/components/JobResultsTable.jsx
+++ b/web/src/routes/jobs/components/JobResultsTable.jsx
@@ -6,6 +6,7 @@ import {
     XCircleIcon,
 } from "@heroicons/react/24/outline";
 import { lastModified } from "@/lib/util";
+import { assetPath } from "@/config";
 import Pagination from "@/components/Pagination";
 import PropTypes from "prop-types";
 
@@ -45,6 +46,8 @@ function JobResultsTable({
     onResultSelect,
     selectedResult,
     isLoading = false,
+    isRefreshing = false,
+    error = null,
     onRefresh = null,
 }) {
     const [currentPage, setCurrentPage] = useState(1);
@@ -121,7 +124,7 @@ function JobResultsTable({
                                                     title="Refresh"
                                                 >
                                                     <ArrowPathIcon
-                                                        className={`h-5 w-5 text-gray-900 dark:text-gray-100 hover:text-gray-400 ${isLoading ? "animate-spin" : ""}`}
+                                                        className={`h-5 w-5 text-gray-900 dark:text-gray-100 hover:text-gray-400 ${isLoading || isRefreshing ? "animate-spin" : ""}`}
                                                     />
                                                 </button>
                                             </div>
@@ -139,6 +142,19 @@ function JobResultsTable({
                                                 </tr>
                                             ))}
                                         </>
+                                    ) : error ? (
+                                        <tr>
+                                            <td colSpan={6} className="h-64">
+                                                <div className="font-light sm:text-sm text-center align-middle text-gray-600 dark:text-gray-400">
+                                                    <img
+                                                        className="h-16 mb-5 w-auto ml-auto mr-auto opacity-80 dark:invert"
+                                                        src={assetPath("/img/dead-fish.png")}
+                                                        alt="Loading error."
+                                                    />
+                                                    {error?.message || "Failed to load results."}
+                                                </div>
+                                            </td>
+                                        </tr>
                                     ) : results.length === 0 ? (
                                         <tr>
                                             <td colSpan={6} className="h-64">
@@ -212,6 +228,8 @@ JobResultsTable.propTypes = {
     onResultSelect: PropTypes.func.isRequired,
     selectedResult: PropTypes.object,
     isLoading: PropTypes.bool,
+    isRefreshing: PropTypes.bool,
+    error: PropTypes.object,
     onRefresh: PropTypes.func,
 };
 

--- a/web/src/routes/jobs/components/JobResultsTable.jsx
+++ b/web/src/routes/jobs/components/JobResultsTable.jsx
@@ -183,8 +183,10 @@ function JobResultsTable({
                                                 <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-500 dark:text-gray-400">
                                                     {result.started_at && result.finished_at ? formatElapsedTime(result.started_at, result.finished_at) : "-"}
                                                 </td>
-                                                <td className="whitespace-nowrap py-3 px-3 text-center">
-                                                    <StatusIcon success={result.success} />
+                                                <td className="whitespace-nowrap py-3 px-3">
+                                                    <div className="flex justify-center">
+                                                        <StatusIcon success={result.success} />
+                                                    </div>
                                                 </td>
                                                 <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-900 dark:text-gray-100">
                                                     <div className="overflow-x-scroll">

--- a/web/src/routes/jobs/components/JobResultsTable.jsx
+++ b/web/src/routes/jobs/components/JobResultsTable.jsx
@@ -45,6 +45,7 @@ function JobResultsTable({
     onResultSelect,
     selectedResult,
     isLoading = false,
+    onRefresh = null,
 }) {
     const [currentPage, setCurrentPage] = useState(1);
     const resultsPerPage = 20;
@@ -116,7 +117,7 @@ function JobResultsTable({
                                         >
                                             <div className="flex gap-2 justify-end">
                                                 <button
-                                                    onClick={() => {}}
+                                                    onClick={() => onRefresh?.()}
                                                     title="Refresh"
                                                 >
                                                     <ArrowPathIcon
@@ -211,6 +212,7 @@ JobResultsTable.propTypes = {
     onResultSelect: PropTypes.func.isRequired,
     selectedResult: PropTypes.object,
     isLoading: PropTypes.bool,
+    onRefresh: PropTypes.func,
 };
 
 export default JobResultsTable;

--- a/web/src/routes/jobs/components/JobResultsTable.jsx
+++ b/web/src/routes/jobs/components/JobResultsTable.jsx
@@ -188,7 +188,7 @@ function JobResultsTable({
                                                 </td>
                                                 <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-900 dark:text-gray-100">
                                                     <div className="overflow-x-scroll">
-                                                        {result.output_file || "-"}
+                                                        {result.output_file ? result.output_file.split("/").pop() : "-"}
                                                     </div>
                                                 </td>
                                                 <td className="whitespace-nowrap py-3 px-3 text-right">

--- a/web/src/routes/jobs/components/JobsContainer.jsx
+++ b/web/src/routes/jobs/components/JobsContainer.jsx
@@ -1,6 +1,6 @@
-import { useContext, useState } from "react";
+import { useContext, useState, useMemo } from "react";
 import { ProfileContext } from "@/components/ProfileSelect";
-import { useJobs } from "@/lib/loaders";
+import { useJobs, useJobResults } from "@/lib/loaders";
 import { stopJob, deleteJob } from "@/lib/requests";
 import JobsTable from "./JobsTable";
 import JobResultsTable from "./JobResultsTable";
@@ -168,6 +168,10 @@ function JobsContainer() {
 
     const jobs = useMockData ? MOCK_JOBS : apiJobs;
 
+    // Fetch real results when viewing results for a job (not in mock mode)
+    const fetchResultsForJobId = (!useMockData && viewingResults) ? selectedJobId : null;
+    const { results: apiResults, isLoading: isResultsLoading, mutate: mutateResults } = useJobResults(fetchResultsForJobId);
+
     // Derive selectedJob from jobs list - always stays in sync
     const selectedJob = selectedJobId && jobs ? jobs.find(j => j.id === selectedJobId) : null;
 
@@ -243,7 +247,21 @@ function JobsContainer() {
         }
     };
 
-    const jobResults = selectedJob ? MOCK_RESULTS[selectedJob.id] || [] : [];
+    // Map API results to the shape expected by JobResultsTable/ResultPreview
+    const jobResults = useMemo(() => {
+        if (useMockData) {
+            return selectedJob ? MOCK_RESULTS[selectedJob.id] || [] : [];
+        }
+        return apiResults.map((r) => ({
+            id: `${r.task}/${r.file}`,
+            input_file: r.file,
+            output_file: r.output_file,
+            started_at: r.started_at,
+            finished_at: r.finished_at,
+            success: r.status === "success",
+            error: r.error || null,
+        }));
+    }, [useMockData, selectedJob, apiResults]);
 
     // Determine what to show in right column
     const showResultPreview = selectedResult !== null;
@@ -258,6 +276,8 @@ function JobsContainer() {
                         onBack={handleBackToJobs}
                         onResultSelect={handleResultSelect}
                         selectedResult={selectedResult}
+                        isLoading={!useMockData && isResultsLoading}
+                        onRefresh={mutateResults}
                     />
                 ) : (
                     <JobsTable

--- a/web/src/routes/jobs/components/JobsContainer.jsx
+++ b/web/src/routes/jobs/components/JobsContainer.jsx
@@ -170,7 +170,7 @@ function JobsContainer() {
 
     // Fetch real results when viewing results for a job (not in mock mode)
     const fetchResultsForJobId = (!useMockData && viewingResults) ? selectedJobId : null;
-    const { results: apiResults, isLoading: isResultsLoading, mutate: mutateResults } = useJobResults(fetchResultsForJobId);
+    const { results: apiResults, error: resultsError, isLoading: isResultsLoading, isRefreshing: isResultsRefreshing, mutate: mutateResults } = useJobResults(fetchResultsForJobId);
 
     // Derive selectedJob from jobs list - always stays in sync
     const selectedJob = selectedJobId && jobs ? jobs.find(j => j.id === selectedJobId) : null;
@@ -277,6 +277,8 @@ function JobsContainer() {
                         onResultSelect={handleResultSelect}
                         selectedResult={selectedResult}
                         isLoading={!useMockData && isResultsLoading}
+                        isRefreshing={!useMockData && isResultsRefreshing}
+                        error={!useMockData ? resultsError : null}
                         onRefresh={mutateResults}
                     />
                 ) : (

--- a/web/src/routes/jobs/components/JobsContainer.jsx
+++ b/web/src/routes/jobs/components/JobsContainer.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState, useMemo } from "react";
+import { useContext, useState } from "react";
 import { ProfileContext } from "@/components/ProfileSelect";
 import { useJobs, useJobResults } from "@/lib/loaders";
 import { stopJob, deleteJob } from "@/lib/requests";
@@ -248,11 +248,9 @@ function JobsContainer() {
     };
 
     // Map API results to the shape expected by JobResultsTable/ResultPreview
-    const jobResults = useMemo(() => {
-        if (useMockData) {
-            return selectedJob ? MOCK_RESULTS[selectedJob.id] || [] : [];
-        }
-        return apiResults.map((r) => ({
+    const jobResults = useMockData
+        ? (selectedJob ? MOCK_RESULTS[selectedJob.id] || [] : [])
+        : apiResults.map((r) => ({
             id: `${r.task}/${r.file}`,
             input_file: r.file,
             output_file: r.output_file,
@@ -261,7 +259,6 @@ function JobsContainer() {
             success: r.status === "success",
             error: r.error || null,
         }));
-    }, [useMockData, selectedJob, apiResults]);
 
     // Determine what to show in right column
     const showResultPreview = selectedResult !== null;

--- a/web/src/routes/jobs/components/JobsTable.jsx
+++ b/web/src/routes/jobs/components/JobsTable.jsx
@@ -8,55 +8,8 @@ import {
 import { lastModified } from "@/lib/util";
 import Pagination from "@/components/Pagination";
 import { TASKS } from "./NewJobModal";
+import StatusBadge from "./StatusBadge";
 import PropTypes from "prop-types";
-
-// Derive display status from API status and progress fields
-function StatusBadge({ status, errored = 0 }) {
-    const getStatusConfig = () => {
-        switch (status) {
-            case "running":
-                return errored > 0 ? {
-                    bg: "bg-yellow-50 dark:bg-yellow-900/30",
-                    text: "text-yellow-700 dark:text-yellow-400",
-                    ring: "ring-yellow-600/20 dark:ring-yellow-500/30",
-                    label: "Running",
-                } : {
-                    bg: "bg-green-50 dark:bg-green-900/30",
-                    text: "text-green-700 dark:text-green-400",
-                    ring: "ring-green-600/20 dark:ring-green-500/30",
-                    label: "Running",
-                };
-            case "broken":
-                return {
-                    bg: "bg-orange-50 dark:bg-orange-900/30",
-                    text: "text-orange-700 dark:text-orange-400",
-                    ring: "ring-orange-600/20 dark:ring-orange-500/30",
-                    label: "Broken",
-                };
-            case "stopped":
-            default:
-                return {
-                    bg: "bg-gray-50 dark:bg-gray-700",
-                    text: "text-gray-600 dark:text-gray-400",
-                    ring: "ring-gray-500/10 dark:ring-gray-600",
-                    label: "Stopped",
-                };
-        }
-    };
-
-    const config = getStatusConfig();
-
-    return (
-        <span className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${config.bg} ${config.text} ${config.ring}`}>
-            {config.label}
-        </span>
-    );
-}
-
-StatusBadge.propTypes = {
-    status: PropTypes.string.isRequired,
-    errored: PropTypes.number,
-};
 
 function ProgressDisplay({ finished, staged, errored }) {
     const done = Number(finished) || 0;

--- a/web/src/routes/jobs/components/JobsTable.jsx
+++ b/web/src/routes/jobs/components/JobsTable.jsx
@@ -11,14 +11,19 @@ import { TASKS } from "./NewJobModal";
 import PropTypes from "prop-types";
 
 // Derive display status from API status and progress fields
-function StatusBadge({ status }) {
+function StatusBadge({ status, errored = 0 }) {
     const getStatusConfig = () => {
         switch (status) {
             case "running":
-                return {
+                return errored > 0 ? {
                     bg: "bg-yellow-50 dark:bg-yellow-900/30",
                     text: "text-yellow-700 dark:text-yellow-400",
                     ring: "ring-yellow-600/20 dark:ring-yellow-500/30",
+                    label: "Running",
+                } : {
+                    bg: "bg-green-50 dark:bg-green-900/30",
+                    text: "text-green-700 dark:text-green-400",
+                    ring: "ring-green-600/20 dark:ring-green-500/30",
                     label: "Running",
                 };
             case "broken":
@@ -50,6 +55,7 @@ function StatusBadge({ status }) {
 
 StatusBadge.propTypes = {
     status: PropTypes.string.isRequired,
+    errored: PropTypes.number,
 };
 
 function ProgressDisplay({ finished, staged, errored }) {
@@ -237,7 +243,7 @@ function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = fa
                                                     {lastModified(job.created_at)}
                                                 </td>
                                                 <td className="whitespace-nowrap py-3 px-3 text-left text-sm">
-                                                    <StatusBadge status={job.status} />
+                                                    <StatusBadge status={job.status} errored={job.errored} />
                                                 </td>
                                                 <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-900 dark:text-gray-100">
                                                     <ProgressDisplay

--- a/web/src/routes/jobs/components/JobsTable.jsx
+++ b/web/src/routes/jobs/components/JobsTable.jsx
@@ -11,38 +11,15 @@ import { TASKS } from "./NewJobModal";
 import PropTypes from "prop-types";
 
 // Derive display status from API status and progress fields
-function deriveDisplayStatus(job) {
-    if (job.status === "running") return "running";
-    if (job.status === "broken") return "broken";
-    // status === "stopped"
-    if ((job.staged ?? 0) === 0 && (job.errored ?? 0) === 0) return "done";
-    if ((job.errored ?? 0) > 0) return "error";
-    return "stopped";
-}
-
-function StatusBadge({ displayStatus }) {
+function StatusBadge({ status }) {
     const getStatusConfig = () => {
-        switch (displayStatus) {
-            case "done":
-                return {
-                    bg: "bg-green-50 dark:bg-green-900/30",
-                    text: "text-green-700 dark:text-green-400",
-                    ring: "ring-green-600/20 dark:ring-green-500/30",
-                    label: "Done",
-                };
+        switch (status) {
             case "running":
                 return {
                     bg: "bg-yellow-50 dark:bg-yellow-900/30",
                     text: "text-yellow-700 dark:text-yellow-400",
                     ring: "ring-yellow-600/20 dark:ring-yellow-500/30",
                     label: "Running",
-                };
-            case "error":
-                return {
-                    bg: "bg-red-50 dark:bg-red-900/30",
-                    text: "text-red-700 dark:text-red-400",
-                    ring: "ring-red-600/20 dark:ring-red-500/30",
-                    label: "Error",
                 };
             case "broken":
                 return {
@@ -72,7 +49,7 @@ function StatusBadge({ displayStatus }) {
 }
 
 StatusBadge.propTypes = {
-    displayStatus: PropTypes.string.isRequired,
+    status: PropTypes.string.isRequired,
 };
 
 function ProgressDisplay({ finished, staged, errored }) {
@@ -260,7 +237,7 @@ function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = fa
                                                     {lastModified(job.created_at)}
                                                 </td>
                                                 <td className="whitespace-nowrap py-3 px-3 text-left text-sm">
-                                                    <StatusBadge displayStatus={deriveDisplayStatus(job)} />
+                                                    <StatusBadge status={job.status} />
                                                 </td>
                                                 <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-900 dark:text-gray-100">
                                                     <ProgressDisplay

--- a/web/src/routes/jobs/components/ResultPreview.jsx
+++ b/web/src/routes/jobs/components/ResultPreview.jsx
@@ -29,7 +29,7 @@ function TruncatedPath({ path, maxWidth = "max-w-[14rem]" }) {
                     <CheckIcon className="h-3.5 w-3.5 text-green-500 flex-shrink-0" />
                 </>
             ) : (
-                <span className={`truncate ${maxWidth}`}>{path}</span>
+                <span className={`truncate ${maxWidth} text-xs font-mono`}>{path}</span>
             )}
         </span>
     );

--- a/web/src/routes/jobs/components/ResultPreview.jsx
+++ b/web/src/routes/jobs/components/ResultPreview.jsx
@@ -128,7 +128,7 @@ function OutputFilePreview({ file, profile = null }) {
                         </div>
                     ) : textContent ? (
                         <>
-                            <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 max-h-48 overflow-y-auto">
+                            <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 overflow-y-auto">
                                 <pre className="text-xs text-gray-900 dark:text-gray-100 whitespace-pre-wrap font-mono">
                                     {textContent.text}
                                 </pre>
@@ -188,7 +188,7 @@ function ResultPreview({ result, job, profile = null }) {
     }
 
     return (
-        <div className="bg-white dark:bg-gray-800 p-6">
+        <div className="bg-white dark:bg-gray-800 p-6 h-full flex flex-col">
             {/* Status Header */}
             <div className="flex items-center gap-3 mb-4">
                 {result.success ? (
@@ -216,16 +216,6 @@ function ResultPreview({ result, job, profile = null }) {
                     </span>
                 </div>
             </div>
-
-            {/* Output File Preview */}
-            {result.output_file && (
-                <div className="border-t border-gray-200 dark:border-gray-700 pt-4 mb-4">
-                    <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
-                        Output Preview
-                    </h4>
-                    <OutputFilePreview file={result.output_file} profile={profile} />
-                </div>
-            )}
 
             {/* Timing Information */}
             <div className="border-t border-gray-200 dark:border-gray-700 pt-4 mb-4">
@@ -258,11 +248,11 @@ function ResultPreview({ result, job, profile = null }) {
             {job && (
                 <div className="border-t border-gray-200 dark:border-gray-700 pt-4 mb-4">
                     <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
-                        Job Context
+                        Job
                     </h4>
                     <div className="space-y-2 text-sm">
                         <div className="flex justify-between">
-                            <span className="text-gray-500 dark:text-gray-400">Job:</span>
+                            <span className="text-gray-500 dark:text-gray-400">Name:</span>
                             <span className="text-gray-900 dark:text-gray-100 truncate ml-2" title={job.name}>
                                 {job.name}
                             </span>
@@ -283,7 +273,7 @@ function ResultPreview({ result, job, profile = null }) {
 
             {/* Error Message */}
             {!result.success && result.error && (
-                <div className="border-t border-gray-200 dark:border-gray-700 pt-4">
+                <div className="border-t border-gray-200 dark:border-gray-700 pt-4 mb-4">
                     <h4 className="text-sm font-medium text-red-600 dark:text-red-400 mb-2">
                         Error
                     </h4>
@@ -291,6 +281,18 @@ function ResultPreview({ result, job, profile = null }) {
                         <p className="text-sm text-red-700 dark:text-red-400">
                             {result.error}
                         </p>
+                    </div>
+                </div>
+            )}
+
+            {/* Output File Preview — at bottom, fills remaining space */}
+            {result.output_file && (
+                <div className="border-t border-gray-200 dark:border-gray-700 pt-4 flex-1 min-h-0 flex flex-col">
+                    <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
+                        Output Preview
+                    </h4>
+                    <div className="flex-1 min-h-0 overflow-y-auto">
+                        <OutputFilePreview file={result.output_file} profile={profile} />
                     </div>
                 </div>
             )}

--- a/web/src/routes/jobs/components/ResultPreview.jsx
+++ b/web/src/routes/jobs/components/ResultPreview.jsx
@@ -96,7 +96,7 @@ function OutputFilePreview({ file, profile = null }) {
                         <div className="rounded-md bg-red-50 dark:bg-red-900/20 p-4">
                             <p className="text-sm text-red-700 dark:text-red-400">{textError}</p>
                         </div>
-                    ) : (
+                    ) : textContent ? (
                         <>
                             <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 max-h-48 overflow-y-auto">
                                 <pre className="text-xs text-gray-900 dark:text-gray-100 whitespace-pre-wrap font-mono">
@@ -109,7 +109,7 @@ function OutputFilePreview({ file, profile = null }) {
                                 </p>
                             )}
                         </>
-                    )}
+                    ) : null}
                 </div>
             )}
 

--- a/web/src/routes/jobs/components/ResultPreview.jsx
+++ b/web/src/routes/jobs/components/ResultPreview.jsx
@@ -5,17 +5,21 @@ import {
     CheckIcon,
     XCircleIcon,
 } from "@heroicons/react/24/outline";
+import { blackfishApiURL } from "@/config";
+import { getFileType, truncateTextPreview } from "@/lib/fileApi";
+import PropTypes from "prop-types";
 
 function TruncatedPath({ path, maxWidth = "max-w-[14rem]" }) {
     const [copied, setCopied] = useState(false);
 
-    if (!path) return "-";
-
     const handleClick = useCallback(() => {
-        navigator.clipboard.writeText(path);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+        navigator.clipboard.writeText(path).then(() => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+        }).catch(() => {});
     }, [path]);
+
+    if (!path) return "-";
 
     return (
         <span
@@ -34,9 +38,11 @@ function TruncatedPath({ path, maxWidth = "max-w-[14rem]" }) {
         </span>
     );
 }
-import { blackfishApiURL } from "@/config";
-import { getFileType, truncateTextPreview } from "@/lib/fileApi";
-import PropTypes from "prop-types";
+
+TruncatedPath.propTypes = {
+    path: PropTypes.string,
+    maxWidth: PropTypes.string,
+};
 
 function formatDateTime(isoString) {
     if (!isoString) return "-";

--- a/web/src/routes/jobs/components/ResultPreview.jsx
+++ b/web/src/routes/jobs/components/ResultPreview.jsx
@@ -1,9 +1,39 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
     DocumentIcon,
     CheckCircleIcon,
+    CheckIcon,
     XCircleIcon,
 } from "@heroicons/react/24/outline";
+
+function TruncatedPath({ path, maxWidth = "max-w-[14rem]" }) {
+    const [copied, setCopied] = useState(false);
+
+    if (!path) return "-";
+
+    const handleClick = useCallback(() => {
+        navigator.clipboard.writeText(path);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+    }, [path]);
+
+    return (
+        <span
+            className="cursor-pointer inline-flex items-center gap-1"
+            title={path}
+            onClick={handleClick}
+        >
+            {copied ? (
+                <>
+                    <span className="text-green-600 dark:text-green-400">Copied</span>
+                    <CheckIcon className="h-3.5 w-3.5 text-green-500 flex-shrink-0" />
+                </>
+            ) : (
+                <span className={`truncate ${maxWidth}`}>{path}</span>
+            )}
+        </span>
+    );
+}
 import { blackfishApiURL } from "@/config";
 import { getFileType, truncateTextPreview } from "@/lib/fileApi";
 import PropTypes from "prop-types";
@@ -175,14 +205,14 @@ function ResultPreview({ result, job, profile = null }) {
             <div className="mb-4 space-y-2 text-sm">
                 <div className="flex justify-between">
                     <span className="text-gray-500 dark:text-gray-400">Input File:</span>
-                    <span className="text-gray-900 dark:text-gray-100 truncate ml-2" title={result.input_file}>
-                        {result.input_file}
+                    <span className="text-gray-900 dark:text-gray-100 ml-2">
+                        <TruncatedPath path={result.input_file} />
                     </span>
                 </div>
                 <div className="flex justify-between">
                     <span className="text-gray-500 dark:text-gray-400">Output File:</span>
-                    <span className="text-gray-900 dark:text-gray-100 truncate ml-2" title={result.output_file || "-"}>
-                        {result.output_file || "-"}
+                    <span className="text-gray-900 dark:text-gray-100 ml-2">
+                        <TruncatedPath path={result.output_file} maxWidth="max-w-[22rem]" />
                     </span>
                 </div>
             </div>

--- a/web/src/routes/jobs/components/StatusBadge.jsx
+++ b/web/src/routes/jobs/components/StatusBadge.jsx
@@ -1,0 +1,50 @@
+import PropTypes from "prop-types";
+
+function StatusBadge({ status, errored = 0 }) {
+    const getStatusConfig = () => {
+        switch (status) {
+            case "running":
+                return errored > 0 ? {
+                    bg: "bg-yellow-50 dark:bg-yellow-900/30",
+                    text: "text-yellow-700 dark:text-yellow-400",
+                    ring: "ring-yellow-600/20 dark:ring-yellow-500/30",
+                    label: "Running",
+                } : {
+                    bg: "bg-green-50 dark:bg-green-900/30",
+                    text: "text-green-700 dark:text-green-400",
+                    ring: "ring-green-600/20 dark:ring-green-500/30",
+                    label: "Running",
+                };
+            case "broken":
+                return {
+                    bg: "bg-orange-50 dark:bg-orange-900/30",
+                    text: "text-orange-700 dark:text-orange-400",
+                    ring: "ring-orange-600/20 dark:ring-orange-500/30",
+                    label: "Broken",
+                };
+            case "stopped":
+            default:
+                return {
+                    bg: "bg-gray-50 dark:bg-gray-700",
+                    text: "text-gray-600 dark:text-gray-400",
+                    ring: "ring-gray-500/10 dark:ring-gray-600",
+                    label: "Stopped",
+                };
+        }
+    };
+
+    const config = getStatusConfig();
+
+    return (
+        <span className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${config.bg} ${config.text} ${config.ring}`}>
+            {config.label}
+        </span>
+    );
+}
+
+StatusBadge.propTypes = {
+    status: PropTypes.string.isRequired,
+    errored: PropTypes.number,
+};
+
+export default StatusBadge;


### PR DESCRIPTION
## Summary

Adds a new API endpoint and frontend wiring to display per-file results from batch jobs, using the TigerFlow report metrics.

- Add `GET /api/jobs/{id}/results` endpoint that fetches file-level metrics from `TigerFlowClient.report()`, flattens across tasks, constructs output file paths, and joins error messages
- Add `fetchJobResults()` and `useJobResults()` SWR hook on the frontend
- Wire `JobsContainer` to fetch real results when not using mock data
- Wire refresh button in `JobResultsTable`
- Add API tests for the new endpoint (success, not found, auth required)
- Update coverage badge

**Depends on:** #232

## Test plan

- [x] `TestGetJobResultsAPI` — validates response shape, output path construction, error message joining, 404, and auth
- [x] Frontend renders results table with real data shape (verified mock toggle preserved)
- [x] Refresh button triggers SWR revalidation