### PR TITLE
fix(lib): rewrite tigerflow jobs migration as drop+recreate

### DIFF
--- a/lib/.pre-commit-config.yaml
+++ b/lib/.pre-commit-config.yaml
@@ -22,17 +22,17 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.11.1
+    rev: v2.21.1
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
+    rev: v0.15.10
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v1.20.1
     hooks:
       - id: mypy
         files: ^(lib/src/)
@@ -63,7 +63,7 @@ repos:
             "yaspin>=3.1",
           ]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         args: ["--skip", "*.test.js,*.js.snap,*-lock.json"]

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -76,11 +76,9 @@ contract = [
   "tigerflow-ml @ git+https://github.com/princeton-ddss/tigerflow-ml.git",
 ]
 
-[tool.hatch.build.targets.wheel]
-packages = [ "src/blackfish" ]
-
-[tool.hatch.build]
-artifacts = [ "src/blackfish/build/**" ]
+[tool.hatch]
+build.artifacts = [ "src/blackfish/build/**" ]
+build.targets.wheel.packages = [ "src/blackfish" ]
 
 [tool.pyproject-fmt]
 max_supported_python = "3.13"

--- a/lib/src/blackfish/server/db/migrations/versions/2026-02-10_tigerflow_batch_jobs_a1b2c3d4e5f6.py
+++ b/lib/src/blackfish/server/db/migrations/versions/2026-02-10_tigerflow_batch_jobs_a1b2c3d4e5f6.py
@@ -1,12 +1,12 @@
 # type: ignore
 """TigerFlow batch jobs schema
 
-Replace batch job schema for TigerFlow-based execution.
-
-- Add: task, revision, input_dir, output_dir, params, resources, pid, max_workers
-- Rename: ntotal->staged, nsuccess->finished, nfail->errored
-- Remove: pipeline, job_id, scheduler, provider, mount
-- Keep: cache_dir (exists in both old and new schema)
+Replaces the v0.5 `jobs` table (which tracked speech_recognition jobs) with a
+fresh table for TigerFlow-based batch jobs. The two schemas represent
+semantically different entities, so we drop and recreate rather than juggling
+columns: v0.5 rows have no meaningful interpretation as v1.0 TigerFlow jobs,
+and preserving row continuity would leave zombie records with NULL in fields
+that v1.0 treats as required (task, input_dir, output_dir).
 
 Revision ID: a1b2c3d4e5f6
 Revises: 27b628a63d4e
@@ -71,63 +71,75 @@ def downgrade() -> None:
 def schema_upgrades() -> None:
     """schema upgrade migrations go here."""
 
-    with op.batch_alter_table("jobs", schema=None) as batch_op:
-        # Add new columns for TigerFlow
-        batch_op.add_column(sa.Column("task", sa.String(), nullable=True))
-        batch_op.add_column(sa.Column("revision", sa.String(), nullable=True))
-        batch_op.add_column(sa.Column("input_dir", sa.String(), nullable=True))
-        batch_op.add_column(sa.Column("output_dir", sa.String(), nullable=True))
-        batch_op.add_column(sa.Column("params", sa.JSON(), nullable=True))
-        batch_op.add_column(sa.Column("resources", sa.JSON(), nullable=True))
-        batch_op.add_column(sa.Column("pid", sa.String(), nullable=True))
-        batch_op.add_column(
-            sa.Column("max_workers", sa.Integer(), nullable=False, server_default="1")
-        )
-        batch_op.add_column(sa.Column("tigerflow_version", sa.String(), nullable=True))
-        batch_op.add_column(
-            sa.Column("tigerflow_ml_version", sa.String(), nullable=True)
-        )
-
-        # Rename progress columns
-        batch_op.alter_column("ntotal", new_column_name="staged")
-        batch_op.alter_column("nsuccess", new_column_name="finished")
-        batch_op.alter_column("nfail", new_column_name="errored")
-
-        # Remove old columns
-        batch_op.drop_column("pipeline")
-        batch_op.drop_column("job_id")
-        batch_op.drop_column("scheduler")
-        batch_op.drop_column("provider")
-        batch_op.drop_column("mount")
+    # Drop the v0.5 table (speech_recognition job shape) and create a fresh
+    # one with the v1.0 TigerFlow batch job shape. Any existing v0.5 rows are
+    # discarded by design — they were tied to ephemeral services and have no
+    # meaningful representation under the new schema. Required columns
+    # (task, input_dir, output_dir, etc.) are declared NOT NULL to match the
+    # BatchJob ORM in lib/src/blackfish/server/jobs/base.py.
+    op.drop_table("jobs")
+    op.create_table(
+        "jobs",
+        sa.Column("id", sa.GUID(length=16), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("task", sa.String(), nullable=False),
+        sa.Column("repo_id", sa.String(), nullable=False),
+        sa.Column("revision", sa.String(), nullable=True),
+        sa.Column("input_dir", sa.String(), nullable=False),
+        sa.Column("output_dir", sa.String(), nullable=False),
+        sa.Column("cache_dir", sa.String(), nullable=True),
+        sa.Column("params", sa.JSON(), nullable=True),
+        sa.Column("resources", sa.JSON(), nullable=True),
+        sa.Column("max_workers", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("profile", sa.String(), nullable=False),
+        sa.Column("user", sa.String(), nullable=True),
+        sa.Column("host", sa.String(), nullable=True),
+        sa.Column("home_dir", sa.String(), nullable=True),
+        sa.Column("status", sa.String(), nullable=True),
+        sa.Column("pid", sa.String(), nullable=True),
+        sa.Column("staged", sa.Integer(), nullable=True),
+        sa.Column("finished", sa.Integer(), nullable=True),
+        sa.Column("errored", sa.Integer(), nullable=True),
+        sa.Column("tigerflow_version", sa.String(), nullable=True),
+        sa.Column("tigerflow_ml_version", sa.String(), nullable=True),
+        sa.Column("sa_orm_sentinel", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTimeUTC(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTimeUTC(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_jobs")),
+    )
 
 
 def schema_downgrades() -> None:
     """schema downgrade migrations go here."""
 
-    with op.batch_alter_table("jobs", schema=None) as batch_op:
-        # Restore old columns
-        batch_op.add_column(sa.Column("pipeline", sa.String(), nullable=True))
-        batch_op.add_column(sa.Column("job_id", sa.String(), nullable=True))
-        batch_op.add_column(sa.Column("scheduler", sa.String(), nullable=True))
-        batch_op.add_column(sa.Column("provider", sa.String(), nullable=True))
-        batch_op.add_column(sa.Column("mount", sa.String(), nullable=True))
-
-        # Rename progress columns back
-        batch_op.alter_column("staged", new_column_name="ntotal")
-        batch_op.alter_column("finished", new_column_name="nsuccess")
-        batch_op.alter_column("errored", new_column_name="nfail")
-
-        # Remove new columns
-        batch_op.drop_column("task")
-        batch_op.drop_column("revision")
-        batch_op.drop_column("input_dir")
-        batch_op.drop_column("output_dir")
-        batch_op.drop_column("params")
-        batch_op.drop_column("resources")
-        batch_op.drop_column("pid")
-        batch_op.drop_column("max_workers")
-        batch_op.drop_column("tigerflow_version")
-        batch_op.drop_column("tigerflow_ml_version")
+    # Symmetric with schema_upgrades: drop the v1.0 table and recreate the
+    # v0.5 shape (as originally defined in 4dfd6eed368a_create_batch_jobs).
+    # Any v1.0 rows are discarded by design.
+    op.drop_table("jobs")
+    op.create_table(
+        "jobs",
+        sa.Column("id", sa.GUID(length=16), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("pipeline", sa.String(), nullable=False),
+        sa.Column("repo_id", sa.String(), nullable=False),
+        sa.Column("profile", sa.String(), nullable=False),
+        sa.Column("user", sa.String(), nullable=True),
+        sa.Column("host", sa.String(), nullable=True),
+        sa.Column("home_dir", sa.String(), nullable=True),
+        sa.Column("cache_dir", sa.String(), nullable=True),
+        sa.Column("job_id", sa.String(), nullable=True),
+        sa.Column("status", sa.String(), nullable=True),
+        sa.Column("ntotal", sa.String(), nullable=True),
+        sa.Column("nsuccess", sa.String(), nullable=True),
+        sa.Column("nfail", sa.String(), nullable=True),
+        sa.Column("scheduler", sa.String(), nullable=True),
+        sa.Column("provider", sa.String(), nullable=True),
+        sa.Column("mount", sa.String(), nullable=True),
+        sa.Column("sa_orm_sentinel", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTimeUTC(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTimeUTC(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_service")),
+    )
 
 
 def data_upgrades() -> None:

--- a/lib/tests/unit/test_migrations.py
+++ b/lib/tests/unit/test_migrations.py
@@ -1,0 +1,324 @@
+"""Tests for database migrations.
+
+These tests exercise individual migration functions against a temp SQLite
+database using alembic's programmatic API. They don't boot the full alembic
+environment (env.py), so they're fast and self-contained.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+import sqlalchemy as sa
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+MIGRATIONS_DIR = (
+    Path(__file__).resolve().parents[2] / "src/blackfish/server/db/migrations/versions"
+)
+
+
+def load_migration(filename: str) -> Any:
+    """Load a migration module directly from its file path."""
+    path = MIGRATIONS_DIR / filename
+    spec = importlib.util.spec_from_file_location(f"_test_mig_{filename}", path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def engine() -> Iterator[Engine]:
+    """Temp SQLite engine, cleaned up after the test."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        yield create_engine(f"sqlite:///{db_path}")
+    finally:
+        Path(db_path).unlink(missing_ok=True)
+
+
+def _create_v05_jobs_table(conn: sa.Connection) -> None:
+    """Create the v0.5 jobs table shape from 4dfd6eed368a_create_batch_jobs."""
+    conn.execute(
+        text(
+            """
+            CREATE TABLE jobs (
+                id BLOB NOT NULL,
+                name VARCHAR NOT NULL,
+                pipeline VARCHAR NOT NULL,
+                repo_id VARCHAR NOT NULL,
+                profile VARCHAR NOT NULL,
+                user VARCHAR,
+                host VARCHAR,
+                home_dir VARCHAR,
+                cache_dir VARCHAR,
+                job_id VARCHAR,
+                status VARCHAR,
+                ntotal VARCHAR,
+                nsuccess VARCHAR,
+                nfail VARCHAR,
+                scheduler VARCHAR,
+                provider VARCHAR,
+                mount VARCHAR,
+                sa_orm_sentinel INTEGER,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                CONSTRAINT pk_service PRIMARY KEY (id)
+            )
+            """
+        )
+    )
+
+
+def _get_columns(conn: sa.Connection, table: str) -> dict[str, dict[str, Any]]:
+    """Return column metadata from SQLite's PRAGMA table_info."""
+    rows = conn.execute(text(f"PRAGMA table_info({table})")).mappings().all()
+    return {r["name"]: dict(r) for r in rows}
+
+
+class TestTigerFlowBatchJobsMigration:
+    """Tests for 2026-02-10_tigerflow_batch_jobs (revision a1b2c3d4e5f6).
+
+    This migration replaces the v0.5 speech_recognition `jobs` shape with a
+    fresh v1.0 TigerFlow batch job shape. The two schemas represent different
+    entities, so it drops and recreates the table — any v0.5 rows are
+    discarded by design (they'd be zombies under the new schema: NULL in
+    fields v1.0 treats as required).
+    """
+
+    FILENAME = "2026-02-10_tigerflow_batch_jobs_a1b2c3d4e5f6.py"
+
+    def test_upgrade_replaces_v05_table_and_drops_rows(self, engine: Engine) -> None:
+        """Upgrade drops v0.5 rows and recreates the table with v1.0 shape."""
+        with engine.connect() as conn:
+            _create_v05_jobs_table(conn)
+            # Seed a v0.5-shaped row that would become a zombie under the
+            # old rename-in-place approach.
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO jobs (
+                        id, name, pipeline, repo_id, profile,
+                        created_at, updated_at
+                    ) VALUES (
+                        X'00000000000000000000000000000001',
+                        'old-job',
+                        'speech_recognition',
+                        'openai/whisper-tiny',
+                        'default',
+                        '2024-01-01 00:00:00',
+                        '2024-01-01 00:00:00'
+                    )
+                    """
+                )
+            )
+            conn.commit()
+            assert conn.execute(text("SELECT COUNT(*) FROM jobs")).scalar() == 1
+
+            migration = load_migration(self.FILENAME)
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.schema_upgrades()
+            conn.commit()
+
+            # The v0.5 row is gone (drop + recreate discards it by design).
+            assert conn.execute(text("SELECT COUNT(*) FROM jobs")).scalar() == 0
+
+            cols = _get_columns(conn, "jobs")
+
+            # v1.0 required columns present and NOT NULL.
+            required = [
+                "id",
+                "name",
+                "task",
+                "repo_id",
+                "input_dir",
+                "output_dir",
+                "profile",
+                "max_workers",
+                "created_at",
+                "updated_at",
+            ]
+            for col in required:
+                assert col in cols, f"missing required column {col!r}"
+                assert cols[col]["notnull"] == 1, (
+                    f"{col!r} should be NOT NULL, got {cols[col]}"
+                )
+
+            # v1.0 optional columns present.
+            optional = [
+                "revision",
+                "cache_dir",
+                "params",
+                "resources",
+                "user",
+                "host",
+                "home_dir",
+                "status",
+                "pid",
+                "staged",
+                "finished",
+                "errored",
+                "tigerflow_version",
+                "tigerflow_ml_version",
+                "sa_orm_sentinel",
+            ]
+            for col in optional:
+                assert col in cols, f"missing optional column {col!r}"
+
+            # Progress counters are Integer now, not String. Fixes a latent
+            # shape mismatch where the ORM expects int but v0.5 created
+            # these columns as VARCHAR.
+            for int_col in ("staged", "finished", "errored"):
+                assert "INT" in cols[int_col]["type"].upper(), (
+                    f"{int_col!r} should be Integer, got {cols[int_col]['type']!r}"
+                )
+
+            # v0.5-only columns are gone.
+            dropped = [
+                "pipeline",
+                "job_id",
+                "scheduler",
+                "provider",
+                "mount",
+                "ntotal",
+                "nsuccess",
+                "nfail",
+            ]
+            for col in dropped:
+                assert col not in cols, f"{col!r} should have been dropped"
+
+    def test_upgrade_on_empty_v05_table_succeeds(self, engine: Engine) -> None:
+        """Upgrade should succeed on a fresh install (empty jobs table)."""
+        with engine.connect() as conn:
+            _create_v05_jobs_table(conn)
+            conn.commit()
+
+            migration = load_migration(self.FILENAME)
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.schema_upgrades()
+            conn.commit()
+
+            assert conn.execute(text("SELECT COUNT(*) FROM jobs")).scalar() == 0
+            cols = _get_columns(conn, "jobs")
+            assert "task" in cols
+            assert "pipeline" not in cols
+
+    def test_downgrade_restores_v05_shape(self, engine: Engine) -> None:
+        """Downgrade drops the v1.0 table and recreates the v0.5 shape."""
+        with engine.connect() as conn:
+            _create_v05_jobs_table(conn)
+            conn.commit()
+
+            migration = load_migration(self.FILENAME)
+
+            # Upgrade first so we're in the v1.0 state.
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.schema_upgrades()
+            conn.commit()
+
+            # Seed a v1.0-shaped row that should be discarded on downgrade.
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO jobs (
+                        id, name, task, repo_id, input_dir, output_dir,
+                        profile, max_workers, created_at, updated_at
+                    ) VALUES (
+                        X'00000000000000000000000000000002',
+                        'new-job', 'transcribe', 'openai/whisper-tiny',
+                        '/in', '/out', 'default', 1,
+                        '2026-02-10 00:00:00', '2026-02-10 00:00:00'
+                    )
+                    """
+                )
+            )
+            conn.commit()
+            assert conn.execute(text("SELECT COUNT(*) FROM jobs")).scalar() == 1
+
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.schema_downgrades()
+            conn.commit()
+
+            assert conn.execute(text("SELECT COUNT(*) FROM jobs")).scalar() == 0
+            cols = _get_columns(conn, "jobs")
+
+            # v0.5 required columns are back and NOT NULL.
+            for col in (
+                "id",
+                "name",
+                "pipeline",
+                "repo_id",
+                "profile",
+                "created_at",
+                "updated_at",
+            ):
+                assert col in cols, f"missing v0.5 column {col!r}"
+                assert cols[col]["notnull"] == 1
+
+            # v0.5 nullable columns are back.
+            for col in (
+                "job_id",
+                "scheduler",
+                "provider",
+                "mount",
+                "ntotal",
+                "nsuccess",
+                "nfail",
+            ):
+                assert col in cols, f"missing v0.5 column {col!r}"
+
+            # v1.0-only columns are gone.
+            for col in (
+                "task",
+                "input_dir",
+                "output_dir",
+                "max_workers",
+                "staged",
+                "finished",
+                "errored",
+                "tigerflow_version",
+                "tigerflow_ml_version",
+            ):
+                assert col not in cols, f"v1.0 column {col!r} should have been dropped"
+
+    def test_upgrade_then_downgrade_is_reversible(self, engine: Engine) -> None:
+        """Round-trip upgrade + downgrade leaves the schema at the v0.5 shape."""
+        with engine.connect() as conn:
+            _create_v05_jobs_table(conn)
+            conn.commit()
+
+            before = _get_columns(conn, "jobs")
+
+            migration = load_migration(self.FILENAME)
+
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.schema_upgrades()
+            conn.commit()
+
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.schema_downgrades()
+            conn.commit()
+
+            after = _get_columns(conn, "jobs")
+
+            # Column sets match (schema round-trips cleanly).
+            assert set(before) == set(after)
+            # Nullability matches for every column.
+            for name in before:
+                assert before[name]["notnull"] == after[name]["notnull"], (
+                    f"nullability mismatch on {name!r} after round-trip"
+                )


### PR DESCRIPTION
## Summary

- Rewrites the `2026-02-10_tigerflow_batch_jobs` migration as a clean `drop_table` + `create_table` in both directions, instead of the rename-in-place approach that left v0.5 rows as zombies under the v1.0 schema (NULL in required fields like `task`, `input_dir`, `output_dir`).
- Incidentally fixes two latent issues the rename-in-place approach was masking: required columns (`task`, `input_dir`, `output_dir`, `profile`, `max_workers`) are now `NOT NULL` at the DB level to match the `BatchJob` ORM, and progress counters (`staged`, `finished`, `errored`) are now `Integer` instead of the `String` they inherited from v0.5's `ntotal`/`nsuccess`/`nfail`.
- Adds `lib/tests/unit/test_migrations.py` with four focused tests (upgrade with zombie row, upgrade on empty table, downgrade restores v0.5 shape, round-trip reversibility).

The second commit (`chore(lib): autoupdate pre-commit hook revisions`) is a side effect of running `just lint` per the project's justfile, which invokes `pre-commit autoupdate` before running hooks.

## Context

The v0.5 `jobs` table tracked speech_recognition jobs; the v1.0 `jobs` table tracks TigerFlow batch jobs. These are semantically different entities, so there's no meaningful row continuity to preserve — any surviving v0.5 row would be a broken record under v1.0. The drop+recreate approach is honest about the entity change and eliminates zombies by design rather than by patchwork `DELETE`.

No FK constraints reference `jobs.id`, so drop+recreate is safe.

## Test plan

- [x] `uv run just lint` — pre-commit green
- [x] `uv run just test` — 751 passed, 8 skipped (includes 4 new migration tests)
- [x] New unit tests exercise `schema_upgrades` and `schema_downgrades` directly against a temp SQLite DB using alembic's `Operations.context` pattern — no full install/upgrade cycle needed.
- [x] CI green on push

Closes #246