### PR TITLE
fix(web): treat Slurm-localhost profile as local for file I/O

### DIFF
--- a/web/src/components/DirectoryBrowser.jsx
+++ b/web/src/components/DirectoryBrowser.jsx
@@ -4,6 +4,7 @@ import { useFileSystem } from "@/lib/loaders";
 import DirectoryInput from "@/components/DirectoryInput";
 import FilterInput from "@/components/FilterInput";
 import FileManagerTable from "@/components/FileManagerTable";
+import { isRemoteProfile } from "@/lib/util";
 import PropTypes from "prop-types";
 
 /**
@@ -27,7 +28,7 @@ function DirectoryBrowser({
   const { files, error: fsError, isLoading, refresh, homeDir, isConnected } = useFileSystem(value, profile);
 
   // Determine if this is a remote profile
-  const isRemote = profile && profile.schema !== "local";
+  const isRemote = isRemoteProfile(profile);
 
   // Set path to homeDir when it becomes available (if no value)
   useEffect(() => {

--- a/web/src/components/FileManager.jsx
+++ b/web/src/components/FileManager.jsx
@@ -12,6 +12,7 @@ import FilterInput from "@/components/FilterInput";
 import FileUploadDialog from "@/components/FileUploadDialog";
 import FileDeleteDialog from "@/components/FileDeleteDialog";
 import { getFileType } from "@/lib/fileApi";
+import { isRemoteProfile } from "@/lib/util";
 import PropTypes from "prop-types";
 
 /** File Manager component with CRUD operations. */
@@ -25,7 +26,7 @@ function FileManager({
     status,
     profile = null,
 }) {
-    const isRemote = profile && profile.schema !== "local";
+    const isRemote = isRemoteProfile(profile);
     const { reconnect, isConnecting, error: connectionError } = useRemoteFileSystem();
     const [path, setPath] = useState(null);
     const [query, setQuery] = useState("");

--- a/web/src/components/FilePreview.jsx
+++ b/web/src/components/FilePreview.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { blackfishApiURL } from "@/config";
 import { DocumentIcon } from "@heroicons/react/24/outline";
 import Alert from "@/components/Alert";
-import { fileSize } from "@/lib/util";
+import { fileSize, isRemoteProfile } from "@/lib/util";
 import { MAX_PREVIEW_SIZE, truncateTextPreview } from "@/lib/fileApi";
 import PropTypes from "prop-types";
 
@@ -12,7 +12,7 @@ function FilePreview({ file, profile = null }) {
     const [textLoading, setTextLoading] = useState(false);
     const [textError, setTextError] = useState(null);
 
-    const profileParam = profile && profile.schema !== "local"
+    const profileParam = isRemoteProfile(profile)
         ? `&profile=${encodeURIComponent(profile.name)}`
         : "";
 

--- a/web/src/lib/fileApi.js
+++ b/web/src/lib/fileApi.js
@@ -1,4 +1,5 @@
 import { blackfishApiURL } from "@/config";
+import { isRemoteProfile } from "@/lib/util";
 
 /** Maximum file size (in bytes) for preview. Files larger than this are skipped. */
 export const MAX_PREVIEW_SIZE = 5 * 1024 * 1024; // 5 MB
@@ -88,7 +89,7 @@ export async function uploadFile(filePath, file, profile = null) {
     formData.append("file", file);
 
     let url = `${blackfishApiURL}${endpoint}`;
-    if (profile && profile.schema !== "local") {
+    if (isRemoteProfile(profile)) {
         url += `?profile=${encodeURIComponent(profile.name)}`;
     }
 
@@ -113,7 +114,7 @@ export async function replaceFile(filePath, newFile, profile = null) {
     formData.append("file", newFile);
 
     let url = `${blackfishApiURL}${endpoint}`;
-    if (profile && profile.schema !== "local") {
+    if (isRemoteProfile(profile)) {
         url += `?profile=${encodeURIComponent(profile.name)}`;
     }
 
@@ -128,7 +129,7 @@ export async function deleteFile(filePath, profile = null) {
 
     const endpoint = getUploadEndpoint(fileType);
     let url = `${blackfishApiURL}${endpoint}?path=${encodeURIComponent(filePath)}`;
-    if (profile && profile.schema !== "local") {
+    if (isRemoteProfile(profile)) {
         url += `&profile=${encodeURIComponent(profile.name)}`;
     }
 

--- a/web/src/lib/fileApi.test.js
+++ b/web/src/lib/fileApi.test.js
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { uploadFile, replaceFile, deleteFile } from "@/lib/fileApi";
+
+const BASE_URL = "http://localhost:8000";
+
+const LOCAL_PROFILE = {
+  name: "local",
+  schema: "local",
+  home_dir: "/home/u",
+  cache_dir: "/cache",
+};
+
+const SLURM_LOCALHOST_PROFILE = {
+  name: "ondemand",
+  schema: "slurm",
+  host: "localhost",
+  user: "u",
+  home_dir: "/home/u/.blackfish-ondemand",
+  cache_dir: "/cache",
+};
+
+const SLURM_REMOTE_PROFILE = {
+  name: "della",
+  schema: "slurm",
+  host: "della.princeton.edu",
+  user: "u",
+  home_dir: "/home/u/.blackfish",
+  cache_dir: "/cache",
+};
+
+function makeOkResponse() {
+  return {
+    ok: true,
+    json: async () => ({}),
+    text: async () => "",
+  };
+}
+
+describe("fileApi URL construction", () => {
+  let fetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => makeOkResponse());
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("uploadFile", () => {
+    it("omits profile param for null profile", async () => {
+      const file = new File([], "test.png", { type: "image/png" });
+      await uploadFile("/tmp/test.png", file, null);
+      expect(fetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/api/image`);
+    });
+
+    it("omits profile param for a local profile", async () => {
+      const file = new File([], "test.png", { type: "image/png" });
+      await uploadFile("/tmp/test.png", file, LOCAL_PROFILE);
+      expect(fetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/api/image`);
+    });
+
+    it("omits profile param for a Slurm-localhost profile", async () => {
+      const file = new File([], "test.png", { type: "image/png" });
+      await uploadFile("/tmp/test.png", file, SLURM_LOCALHOST_PROFILE);
+      expect(fetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/api/image`);
+    });
+
+    it("includes profile param for a remote Slurm profile", async () => {
+      const file = new File([], "test.png", { type: "image/png" });
+      await uploadFile("/tmp/test.png", file, SLURM_REMOTE_PROFILE);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        `${BASE_URL}/api/image?profile=della`
+      );
+    });
+  });
+
+  describe("replaceFile", () => {
+    it("omits profile param for null profile", async () => {
+      const file = new File([], "new.png", { type: "image/png" });
+      await replaceFile("/tmp/test.png", file, null);
+      expect(fetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/api/image`);
+    });
+
+    it("omits profile param for a local profile", async () => {
+      const file = new File([], "new.png", { type: "image/png" });
+      await replaceFile("/tmp/test.png", file, LOCAL_PROFILE);
+      expect(fetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/api/image`);
+    });
+
+    it("omits profile param for a Slurm-localhost profile", async () => {
+      const file = new File([], "new.png", { type: "image/png" });
+      await replaceFile("/tmp/test.png", file, SLURM_LOCALHOST_PROFILE);
+      expect(fetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/api/image`);
+    });
+
+    it("includes profile param for a remote Slurm profile", async () => {
+      const file = new File([], "new.png", { type: "image/png" });
+      await replaceFile("/tmp/test.png", file, SLURM_REMOTE_PROFILE);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        `${BASE_URL}/api/image?profile=della`
+      );
+    });
+  });
+
+  describe("deleteFile", () => {
+    it("omits profile param for null profile", async () => {
+      await deleteFile("/tmp/test.png", null);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        `${BASE_URL}/api/image?path=${encodeURIComponent("/tmp/test.png")}`
+      );
+    });
+
+    it("omits profile param for a local profile", async () => {
+      await deleteFile("/tmp/test.png", LOCAL_PROFILE);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        `${BASE_URL}/api/image?path=${encodeURIComponent("/tmp/test.png")}`
+      );
+    });
+
+    it("omits profile param for a Slurm-localhost profile", async () => {
+      await deleteFile("/tmp/test.png", SLURM_LOCALHOST_PROFILE);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        `${BASE_URL}/api/image?path=${encodeURIComponent("/tmp/test.png")}`
+      );
+    });
+
+    it("includes profile param for a remote Slurm profile", async () => {
+      await deleteFile("/tmp/test.png", SLURM_REMOTE_PROFILE);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        `${BASE_URL}/api/image?path=${encodeURIComponent("/tmp/test.png")}&profile=della`
+      );
+    });
+  });
+});

--- a/web/src/lib/loaders.js
+++ b/web/src/lib/loaders.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import useSWR from "swr";
 import { fetchModels, fetchServices, fetchProfiles, fetchFiles, fetchClusterStatus, fetchJobs, fetchJobResults } from "./requests";
-import { ServiceStatus } from "./util";
+import { ServiceStatus, isRemoteProfile } from "./util";
 import { useRemoteFileSystem } from "@/providers/RemoteFileSystemProvider";
 
 
@@ -124,7 +124,7 @@ export const useProfiles = () => {
 
 export const useFileSystem = (path, profile = null) => {
   // Determine if this is a remote profile
-  const isRemote = profile && profile.schema !== "local";
+  const isRemote = isRemoteProfile(profile);
 
   // Get remote file system from context
   const remoteFs = useRemoteFileSystem();

--- a/web/src/lib/util.js
+++ b/web/src/lib/util.js
@@ -244,7 +244,7 @@ export function formattedTimeInterval(refTime, currentTime) {
  */
 export function isRemoteProfile(profile) {
   return Boolean(
-    profile?.schema === "slurm" && profile?.host && profile.host !== "localhost"
+    profile?.schema === "slurm" && profile.host && profile.host !== "localhost"
   );
 }
 

--- a/web/src/lib/util.js
+++ b/web/src/lib/util.js
@@ -235,6 +235,20 @@ export function formattedTimeInterval(refTime, currentTime) {
 };
 
 /**
+ * Whether a profile should be treated as "remote" for file I/O and other
+ * non-scheduling purposes. A Slurm profile with host=localhost is scheduled
+ * via sbatch but its filesystem is the same as the server's, so it should
+ * be treated as local for file access.
+ * @param {object|null} profile
+ * @return {boolean}
+ */
+export function isRemoteProfile(profile) {
+  return Boolean(
+    profile?.schema === "slurm" && profile?.host && profile.host !== "localhost"
+  );
+}
+
+/**
  * Is a service running.
  * @param {object} service
  * @param {string|null} service.status

--- a/web/src/lib/util.test.js
+++ b/web/src/lib/util.test.js
@@ -10,6 +10,7 @@ import {
   fileSize,
   lastModified,
   formattedTimeInterval,
+  isRemoteProfile,
   isServiceRunning,
   selectTierByModelSize
 } from "@/lib/util";
@@ -180,6 +181,79 @@ describe("Utils", () => {
       .toBe("7 days 0 min");
     expect(formattedTimeInterval(baseTime, new Date("2025-07-04T15:30:00.000Z")))
       .toBe("30 days 30 min");
+  });
+
+  describe("isRemoteProfile", () => {
+    it("returns false for null or undefined", () => {
+      expect(isRemoteProfile(null)).toBe(false);
+      expect(isRemoteProfile(undefined)).toBe(false);
+    });
+
+    it("returns false for an empty object", () => {
+      expect(isRemoteProfile({})).toBe(false);
+    });
+
+    it("returns false for a LocalProfile", () => {
+      expect(
+        isRemoteProfile({
+          name: "local",
+          schema: "local",
+          home_dir: "/home/u",
+          cache_dir: "/cache",
+        })
+      ).toBe(false);
+    });
+
+    it("returns false for a Slurm profile with host=localhost (OnDemand case)", () => {
+      expect(
+        isRemoteProfile({
+          name: "ondemand",
+          schema: "slurm",
+          host: "localhost",
+          user: "u",
+          home_dir: "/home/u/.blackfish-ondemand",
+          cache_dir: "/cache",
+        })
+      ).toBe(false);
+    });
+
+    it("returns true for a Slurm profile with a remote host", () => {
+      expect(
+        isRemoteProfile({
+          name: "della",
+          schema: "slurm",
+          host: "della.princeton.edu",
+          user: "u",
+          home_dir: "/home/u/.blackfish",
+          cache_dir: "/cache",
+        })
+      ).toBe(true);
+    });
+
+    it("returns false for a Slurm profile with no host", () => {
+      expect(
+        isRemoteProfile({
+          name: "bad",
+          schema: "slurm",
+          user: "u",
+          home_dir: "/home/u",
+          cache_dir: "/cache",
+        })
+      ).toBe(false);
+    });
+
+    it("returns false for a Slurm profile with an empty host", () => {
+      expect(
+        isRemoteProfile({
+          name: "bad",
+          schema: "slurm",
+          host: "",
+          user: "u",
+          home_dir: "/home/u",
+          cache_dir: "/cache",
+        })
+      ).toBe(false);
+    });
   });
 
   test("IsServiceRunning", () => {

--- a/web/src/providers/RemoteFileSystemProvider.jsx
+++ b/web/src/providers/RemoteFileSystemProvider.jsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useEffect, useCallback, useRef } from "react";
 import { ProfileContext } from "@/components/ProfileSelect";
+import { isRemoteProfile } from "@/lib/util";
 import { blackfishApiURL } from "@/config";
 import PropTypes from "prop-types";
 
@@ -82,7 +83,7 @@ function RemoteFileSystemProvider({ children }) {
 
     const connect = useCallback(() => {
         const profileToConnect = currentProfileRef.current;
-        if (!profileToConnect || profileToConnect.schema === "local") {
+        if (!isRemoteProfile(profileToConnect)) {
             return;
         }
 
@@ -224,7 +225,7 @@ function RemoteFileSystemProvider({ children }) {
             return;
         }
 
-        const isRemote = profile && profile.schema !== "local";
+        const isRemote = isRemoteProfile(profile);
         currentProfileRef.current = profile;
 
         // Always disconnect first when profile changes


### PR DESCRIPTION
## Summary

- Add an `isRemoteProfile` helper in `web/src/lib/util.js` that distinguishes a Slurm profile with `host=localhost` from a true remote Slurm cluster — the former dispatches jobs via `sbatch` locally but shares the server's filesystem, so file I/O should stay local.
- Use the helper in every file I/O code path (`RemoteFileSystemProvider`, `useFileSystem`, `fileApi`, `FileManager`, `DirectoryBrowser`, `FilePreview`) so Slurm-localhost profiles hit the local `/api/files`, `/api/image`, `/api/text`, `/api/audio` endpoints instead of opening an SFTP connection back to themselves.
- Add unit tests for the helper (7 cases) and URL construction in `fileApi` (12 cases across `uploadFile` / `replaceFile` / `deleteFile` × 4 profile shapes), codifying the Slurm-localhost regression guard.

Closes #256.

## Test plan

- [x] `npm run lint` — clean (one pre-existing warning in `ImageAttachment.jsx` unrelated to this change)
- [x] `npm test` — 274/274 passing (19 new)
- [ ] Manual: on Open OnDemand with a Slurm profile where `host=localhost`, open the file manager and verify it shows the home directory without a WebSocket/SFTP timeout
- [ ] Manual: upload, preview, and delete a file from the file manager under the same profile
- [ ] Manual: confirm a remote Slurm profile (non-localhost host) still uses the SFTP-over-WebSocket path as before
