### PR TITLE
fix(web): use isRemoteProfile for text-generation file attachments

### DIFF
--- a/web/src/routes/text-generation/components/AttachmentMenu.jsx
+++ b/web/src/routes/text-generation/components/AttachmentMenu.jsx
@@ -5,6 +5,7 @@ import {
   ComputerDesktopIcon,
   ServerIcon,
 } from "@heroicons/react/24/outline";
+import { isRemoteProfile } from "@/lib/util";
 import PropTypes from "prop-types";
 
 const DEFAULT_MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
@@ -44,7 +45,7 @@ function AttachmentMenu({
   onError,
 }) {
   const fileInputRef = useRef(null);
-  const isRemote = profile && profile.schema !== "local";
+  const isRemote = isRemoteProfile(profile);
 
   const handleFileInputChange = (event) => {
     const files = Array.from(event.target.files || []);

--- a/web/src/routes/text-generation/components/ImageAttachment.jsx
+++ b/web/src/routes/text-generation/components/ImageAttachment.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { blackfishApiURL } from "@/config";
+import { isRemoteProfile } from "@/lib/util";
 import { blobToBase64 } from "../lib/imageUtils";
 import PropTypes from "prop-types";
 
@@ -44,10 +45,9 @@ function ImageAttachment({ image, onRemove, onError, onLoad, index }) {
           // No need to cache base64 for browser files - we can convert on submit
         } else if (image.source === "remote") {
           // Remote file - fetch via API with progress tracking
-          const profileParam =
-            image.profile && image.profile.schema !== "local"
-              ? `&profile=${encodeURIComponent(image.profile.name)}`
-              : "";
+          const profileParam = isRemoteProfile(image.profile)
+            ? `&profile=${encodeURIComponent(image.profile.name)}`
+            : "";
           const url = `${blackfishApiURL}/api/image?path=${encodeURIComponent(image.path)}${profileParam}`;
 
           const response = await fetch(url);

--- a/web/src/routes/text-generation/lib/fileUtils.js
+++ b/web/src/routes/text-generation/lib/fileUtils.js
@@ -3,6 +3,7 @@
  */
 
 import { blackfishApiURL } from "@/config";
+import { isRemoteProfile } from "@/lib/util";
 
 /**
  * Supported text file extensions for attachments.
@@ -72,10 +73,9 @@ export function readFileAsText(file) {
  * @returns {Promise<string>} The file content as text.
  */
 export async function fetchRemoteText(path, profile) {
-  const profileParam =
-    profile && profile.schema !== "local"
-      ? `&profile=${encodeURIComponent(profile.name)}`
-      : "";
+  const profileParam = isRemoteProfile(profile)
+    ? `&profile=${encodeURIComponent(profile.name)}`
+    : "";
   const url = `${blackfishApiURL}/api/text?path=${encodeURIComponent(path)}${profileParam}`;
 
   const response = await fetch(url);

--- a/web/src/routes/text-generation/lib/fileUtils.test.js
+++ b/web/src/routes/text-generation/lib/fileUtils.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { fetchRemoteText } from "./fileUtils";
+
+const BASE_URL = "http://localhost:8000";
+
+const LOCAL_PROFILE = {
+  name: "local",
+  schema: "local",
+  home_dir: "/home/u",
+  cache_dir: "/cache",
+};
+
+const SLURM_LOCALHOST_PROFILE = {
+  name: "ondemand",
+  schema: "slurm",
+  host: "localhost",
+  user: "u",
+  home_dir: "/home/u/.blackfish-ondemand",
+  cache_dir: "/cache",
+};
+
+const SLURM_REMOTE_PROFILE = {
+  name: "della",
+  schema: "slurm",
+  host: "della.princeton.edu",
+  user: "u",
+  home_dir: "/home/u/.blackfish",
+  cache_dir: "/cache",
+};
+
+function makeOkResponse(text = "") {
+  return {
+    ok: true,
+    status: 200,
+    text: async () => text,
+  };
+}
+
+describe("fetchRemoteText URL construction", () => {
+  let fetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => makeOkResponse("contents"));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("omits profile param for null profile", async () => {
+    await fetchRemoteText("/tmp/notes.md", null);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      `${BASE_URL}/api/text?path=${encodeURIComponent("/tmp/notes.md")}`
+    );
+  });
+
+  it("omits profile param for a local profile", async () => {
+    await fetchRemoteText("/tmp/notes.md", LOCAL_PROFILE);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      `${BASE_URL}/api/text?path=${encodeURIComponent("/tmp/notes.md")}`
+    );
+  });
+
+  it("omits profile param for a Slurm-localhost profile", async () => {
+    await fetchRemoteText("/tmp/notes.md", SLURM_LOCALHOST_PROFILE);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      `${BASE_URL}/api/text?path=${encodeURIComponent("/tmp/notes.md")}`
+    );
+  });
+
+  it("includes profile param for a remote Slurm profile", async () => {
+    await fetchRemoteText("/tmp/notes.md", SLURM_REMOTE_PROFILE);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      `${BASE_URL}/api/text?path=${encodeURIComponent("/tmp/notes.md")}&profile=della`
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Apply the `isRemoteProfile` helper (introduced in #259) to the three text-generation file-attachment call sites (`fetchRemoteText`, `ImageAttachment`, `AttachmentMenu`) so Slurm-localhost profiles hit the local `/api/text` and `/api/image` endpoints instead of passing themselves as a remote profile.
- Add `fileUtils.test.js` covering URL construction for `fetchRemoteText` × 4 profile shapes (null, local, Slurm-localhost, Slurm-remote), mirroring the `fileApi.test.js` pattern from #259.

Closes #258.

## Test plan

- [x] `npm run lint` — clean (one pre-existing warning in `ImageAttachment.jsx:118` unrelated to this change)
- [x] `npm test` — 278/278 passing (4 new)
- [ ] Manual: on OnDemand with a Slurm-localhost profile, open text generation, attach a text file from the browser picker, confirm it loads without a 400
- [ ] Manual: on OnDemand with a Slurm-localhost profile, attach a remote image via the text-generation flow and confirm it renders
- [ ] Manual: on a remote (non-localhost) Slurm profile, confirm attachments still work unchanged
