### PR TITLE
release: v1.0.0a1

### DIFF
--- a/lib/docs/assets/img/coverage.svg
+++ b/lib/docs/assets/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">67%</text>
-        <text x="80" y="14">67%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">66%</text>
+        <text x="80" y="14">66%</text>
     </g>
 </svg>

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "blackfish-ai"
-version = "1.0.0a0"
+version = "1.0.0a1"
 description = "An open-source AI-as-a-Service platform."
 readme = "README.md"
 license = "MIT"

--- a/lib/uv.lock
+++ b/lib/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blackfish-ai"
-version = "1.0.0a0"
+version = "1.0.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blackfish-ui",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blackfish-ui",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0-alpha.1",
       "dependencies": {
         "@headlessui/react": "^2.1",
         "@heroicons/react": "^2.0.18",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blackfish-ui",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/web/src/components/SettingsSlideOver.jsx
+++ b/web/src/components/SettingsSlideOver.jsx
@@ -764,7 +764,7 @@ function AppConfigSection() {
         HOME_DIR: "/deep/blue/sea/.blackfish",
         DEBUG: true,
         CONTAINER_PROVIDER: "docker",
-        VERSION: "1.0.0a0-whale",
+        VERSION: "1.0.0a1-whale",
       });
       setLoading(false);
       return;


### PR DESCRIPTION
## Summary

Second alpha of the v1.0 line. Narrow scope — bundles two Open OnDemand bug fixes that landed on main since v1.0.0a0, plus routine release hygiene:

- **#259**: `fix(web): treat Slurm-localhost profile as local for file I/O`. Introduces an `isRemoteProfile` helper so Slurm profiles with `host=localhost` hit the local `/api/files` / `/api/image` / `/api/text` / `/api/audio` endpoints instead of opening an SFTP-over-WebSocket connection back to themselves. Unblocks the file manager under Open OnDemand.
- **#260**: `fix(web): use isRemoteProfile for text-generation file attachments`. Applies the same helper to the three remaining text-generation attachment call sites (`fetchRemoteText`, `ImageAttachment`, `AttachmentMenu`).
- **Version bumps**: `lib` → `1.0.0a1`, `web` → `1.0.0-alpha.1`; `uv.lock` and `package-lock.json` refreshed; dev-mode fake version in `SettingsSlideOver` updated.
- **Coverage badge refresh**: badge was stale at 67% since before `v1.0.0a0`; regenerated to current 66%. `lib` has zero code changes in this alpha, so the drift predates this release.

No backend changes. Both fixes are frontend-only and resolve the symptoms on OnDemand by avoiding the broken remote-file code paths rather than modifying them.

## Test plan

- [x] `cd lib && uv run pytest` — 751 passed, 8 skipped
- [x] `cd web && npm run lint` — 0 errors (one pre-existing react-hooks warning unchanged from `a0`)
- [x] `cd web && npm test` — 35 files / 278 tests pass
- [x] `cd lib && uv run coverage-badge -o docs/assets/img/coverage.svg -f` — badge regenerated
- [ ] Manual verification on Open OnDemand after release publishes to PyPI:
  - [ ] File manager opens and lists home directory with a Slurm-localhost profile (no WebSocket timeout)
  - [ ] Upload, preview, and delete a file via the file manager
  - [ ] Attach a text file and an image via the text-generation flow
  - [ ] Confirm a remote (non-localhost) Slurm profile still uses the SFTP path unchanged
