### PR TITLE
fix(web): fix file browsing for Slurm-localhost profiles

### DIFF
--- a/web/src/components/FileManager.jsx
+++ b/web/src/components/FileManager.jsx
@@ -39,10 +39,17 @@ function FileManager({
 
     const { files, error, isLoading, refresh, isConnected, homeDir } = useFileSystem(path, profile);
 
-    // Update path when home directory changes
+    // Reset path when profile changes
     useEffect(() => {
-        setPath(homeDir);
-    }, [homeDir]);
+        setPath(null);
+    }, [profile?.name]);
+
+    // Initialize path from home directory (once per profile)
+    useEffect(() => {
+        if (homeDir && path === null) {
+            setPath(homeDir);
+        }
+    }, [homeDir, path]);
 
     // Auto-dismiss success notifications after 5s. The effect cleanup also
     // cancels the timer on unmount and when a new success message arrives

--- a/web/src/components/FileSelectModal.jsx
+++ b/web/src/components/FileSelectModal.jsx
@@ -9,6 +9,7 @@ import {
 import { XMarkIcon, ArrowPathIcon } from "@heroicons/react/24/outline";
 import { useFileSystem } from "@/lib/loaders";
 import { useRemoteFileSystem } from "@/providers/RemoteFileSystemProvider";
+import { isRemoteProfile } from "@/lib/util";
 import DirectoryInput from "@/components/DirectoryInput";
 import FilterInput from "@/components/FilterInput";
 import FileManagerTable from "@/components/FileManagerTable";
@@ -144,8 +145,8 @@ function FileSelectModal({
                   </button>
                 </div>
 
-                {/* Connection status */}
-                {profile && (
+                {/* Connection status (remote profiles only) */}
+                {isRemoteProfile(profile) && (
                   <div className="px-4 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
                     <div className="flex items-center gap-1.5">
                       <span

--- a/web/src/lib/loaders.js
+++ b/web/src/lib/loaders.js
@@ -197,8 +197,8 @@ export const useFileSystem = (path, profile = null) => {
   }, [isRemote, path, isConnected, listDir]);
 
   // SWR hook for local profiles (only runs when not remote)
-  // Uses ~ as default to fetch home directory when path is null
-  const localKey = !isRemote ? `files?path=${path ?? "~"}` : null;
+  // Uses ~ as default to fetch home directory when path is null or empty
+  const localKey = !isRemote ? `files?path=${path || "~"}` : null;
   const localFs = useSWR(localKey, fetchFiles);
 
   // Return appropriate source based on profile type

--- a/web/src/lib/loaders.js
+++ b/web/src/lib/loaders.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import useSWR from "swr";
 import { fetchModels, fetchServices, fetchProfiles, fetchFiles, fetchClusterStatus, fetchJobs, fetchJobResults } from "./requests";
 import { ServiceStatus, isRemoteProfile } from "./util";
@@ -134,11 +134,18 @@ export const useFileSystem = (path, profile = null) => {
   const [remoteError, setRemoteError] = useState(null);
   const [remoteLoading, setRemoteLoading] = useState(false);
 
+  // Stable home directory for local profiles. Captured once from the first
+  // successful fetch (path defaults to "~") and held stable across navigations.
+  // The remote path gets homeDir from the WS "connected" message which is
+  // already stable; this ref gives the local path the same behavior.
+  const localHomeDirRef = useRef(null);
+
   // Clear state when profile changes
   useEffect(() => {
     setRemoteFiles(null);
     setRemoteError(null);
     setRemoteLoading(false);
+    localHomeDirRef.current = null;
   }, [profile?.name]);
 
   // Also clear when connection drops
@@ -201,6 +208,13 @@ export const useFileSystem = (path, profile = null) => {
   const localKey = !isRemote ? `files?path=${path || "~"}` : null;
   const localFs = useSWR(localKey, fetchFiles);
 
+  // Capture home dir from the first local fetch (when path defaults to "~").
+  // Only set once per profile — subsequent navigations change localFs.data.path
+  // but should not change homeDir.
+  if (!isRemote && localFs.data?.path && !localHomeDirRef.current) {
+    localHomeDirRef.current = localFs.data.path;
+  }
+
   // Return appropriate source based on profile type
   if (isRemote) {
     return {
@@ -219,7 +233,7 @@ export const useFileSystem = (path, profile = null) => {
     isLoading: localFs.isLoading,
     refresh: localFs.mutate,
     isConnected: true, // Local is always "connected"
-    homeDir: localFs.data?.path ?? null,
+    homeDir: localHomeDirRef.current,
   };
 }
 

--- a/web/src/lib/loaders.js
+++ b/web/src/lib/loaders.js
@@ -203,8 +203,9 @@ export const useFileSystem = (path, profile = null) => {
       });
   }, [isRemote, path, isConnected, listDir]);
 
-  // SWR hook for local profiles (only runs when not remote)
-  // Uses ~ as default to fetch home directory when path is null or empty
+  // SWR hook for local profiles (only runs when not remote).
+  // Uses || (not ??) so that both null and "" default to "~" — callers
+  // like NewJobModal initialize path state to "" which is not nullish.
   const localKey = !isRemote ? `files?path=${path || "~"}` : null;
   const localFs = useSWR(localKey, fetchFiles);
 

--- a/web/src/lib/util.js
+++ b/web/src/lib/util.js
@@ -235,6 +235,15 @@ export function formattedTimeInterval(refTime, currentTime) {
 };
 
 /**
+ * Whether a profile is a Slurm profile (local, localhost, or remote).
+ * @param {object|null} profile
+ * @return {boolean}
+ */
+export function isSlurmProfile(profile) {
+  return profile?.schema === "slurm";
+}
+
+/**
  * Whether a profile should be treated as "remote" for file I/O and other
  * non-scheduling purposes. A Slurm profile with host=localhost is scheduled
  * via sbatch but its filesystem is the same as the server's, so it should

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -28,7 +28,7 @@ import DirectoryBrowser from "@/components/DirectoryBrowser";
 import { useModels } from "@/lib/loaders";
 import { useRemoteFileSystem } from "@/providers/RemoteFileSystemProvider";
 import { fetchProfileResources, fetchModelSizeFromHub, createJob } from "@/lib/requests";
-import { selectTierByModelSize } from "@/lib/util";
+import { selectTierByModelSize, isRemoteProfile } from "@/lib/util";
 import PropTypes from "prop-types";
 
 // Task definitions - each task maps to a TigerFlow task type
@@ -420,7 +420,7 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
 
   // Remote file system connection state
   const { isConnected, error: connectionError } = useRemoteFileSystem();
-  const isRemote = profile && profile.schema !== "local";
+  const isRemote = isRemoteProfile(profile);
 
   // Stepper state
   const [currentStep, setCurrentStep] = useState(0);

--- a/web/src/routes/jobs/components/ResultPreview.jsx
+++ b/web/src/routes/jobs/components/ResultPreview.jsx
@@ -7,6 +7,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { blackfishApiURL } from "@/config";
 import { getFileType, truncateTextPreview } from "@/lib/fileApi";
+import { isRemoteProfile } from "@/lib/util";
 import PropTypes from "prop-types";
 
 function TruncatedPath({ path, maxWidth = "max-w-[14rem]" }) {
@@ -74,7 +75,7 @@ function OutputFilePreview({ file, profile = null }) {
     const [textError, setTextError] = useState(null);
 
     const fileType = file ? getFileType(file) : null;
-    const profileParam = profile && profile.schema !== "local"
+    const profileParam = isRemoteProfile(profile)
         ? `&profile=${encodeURIComponent(profile.name)}`
         : "";
 

--- a/web/src/routes/text-generation/components/AttachmentMenu.jsx
+++ b/web/src/routes/text-generation/components/AttachmentMenu.jsx
@@ -5,7 +5,6 @@ import {
   ComputerDesktopIcon,
   ServerIcon,
 } from "@heroicons/react/24/outline";
-import { isRemoteProfile } from "@/lib/util";
 import PropTypes from "prop-types";
 
 const DEFAULT_MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
@@ -45,7 +44,7 @@ function AttachmentMenu({
   onError,
 }) {
   const fileInputRef = useRef(null);
-  const isRemote = isRemoteProfile(profile);
+  const hasServerFiles = profile?.schema === "slurm";
 
   const handleFileInputChange = (event) => {
     const files = Array.from(event.target.files || []);
@@ -114,7 +113,7 @@ function AttachmentMenu({
               )}
             </MenuItem>
 
-            {isRemote && (
+            {hasServerFiles && (
               <MenuItem>
                 {({ active }) => (
                   <button
@@ -130,7 +129,7 @@ function AttachmentMenu({
                       className="mr-2 h-4 w-4 text-gray-400 dark:text-gray-500 group-hover:text-gray-500 dark:group-hover:text-gray-400"
                       aria-hidden="true"
                     />
-                    Select from remote
+                    Select from server
                   </button>
                 )}
               </MenuItem>

--- a/web/src/routes/text-generation/components/AttachmentMenu.jsx
+++ b/web/src/routes/text-generation/components/AttachmentMenu.jsx
@@ -5,6 +5,7 @@ import {
   ComputerDesktopIcon,
   ServerIcon,
 } from "@heroicons/react/24/outline";
+import { isSlurmProfile } from "@/lib/util";
 import PropTypes from "prop-types";
 
 const DEFAULT_MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
@@ -44,7 +45,7 @@ function AttachmentMenu({
   onError,
 }) {
   const fileInputRef = useRef(null);
-  const hasServerFiles = profile?.schema === "slurm";
+  const hasServerFiles = isSlurmProfile(profile);
 
   const handleFileInputChange = (event) => {
     const files = Array.from(event.target.files || []);

--- a/web/src/routes/text-generation/components/AttachmentMenu.test.jsx
+++ b/web/src/routes/text-generation/components/AttachmentMenu.test.jsx
@@ -1,0 +1,42 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import AttachmentMenu from "./AttachmentMenu";
+
+describe("AttachmentMenu", () => {
+  const defaultProps = {
+    accept: "image/*",
+    onBrowserUpload: vi.fn(),
+    onRemoteSelect: vi.fn(),
+    onError: vi.fn(),
+  };
+
+  async function openMenu(profile) {
+    const user = userEvent.setup();
+    const result = render(<AttachmentMenu {...defaultProps} profile={profile} />);
+    const button = result.getByRole("button", { name: /attach/i });
+    await user.click(button);
+    return result;
+  }
+
+  it("hides server button for a local profile", async () => {
+    const profile = { name: "local", schema: "local", home_dir: "/home/u", cache_dir: "/cache" };
+    const { queryByText } = await openMenu(profile);
+    expect(queryByText("Upload from computer")).toBeTruthy();
+    expect(queryByText("Select from server")).toBeNull();
+  });
+
+  it("shows server button for a Slurm-localhost profile", async () => {
+    const profile = { name: "ondemand", schema: "slurm", host: "localhost", user: "u", home_dir: "/home/u", cache_dir: "/cache" };
+    const { queryByText } = await openMenu(profile);
+    expect(queryByText("Upload from computer")).toBeTruthy();
+    expect(queryByText("Select from server")).toBeTruthy();
+  });
+
+  it("shows server button for a remote Slurm profile", async () => {
+    const profile = { name: "della", schema: "slurm", host: "della.princeton.edu", user: "u", home_dir: "/home/u", cache_dir: "/cache" };
+    const { queryByText } = await openMenu(profile);
+    expect(queryByText("Upload from computer")).toBeTruthy();
+    expect(queryByText("Select from server")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Two fixes for file browsing under Slurm-localhost (Open OnDemand), plus regression tests:

- **#264** — Server file browsing broken across text-gen and batch jobs. Default empty path to `"~"` in `useFileSystem` (`||` instead of `??`), show "Select from server" button for all Slurm profiles, gate connection status bars on `isRemoteProfile`, replace remaining Pattern B checks in `NewJobModal` and `ResultPreview`. Zero `schema !== "local"` checks remain in the frontend.
- **#265** — File manager snaps back to home directory on navigation. Stabilize `homeDir` on the local SWR path via a ref (captured once from initial fetch, not updated on navigation), guard the `FileManager` effect so it initializes path once per profile instead of overriding on every `homeDir` change, and reset path on profile switch.

Closes #264, closes #265.

## Test plan

- [x] `npm run lint` — clean (one pre-existing warning)
- [x] `npm test` — 281/281 passing (3 new: `AttachmentMenu` button visibility for local, Slurm-localhost, and remote profiles)
- [x] Manual: Files page — navigate into subdirectories, confirm no snap-back to home
- [x] Manual: Files page — switch profiles, confirm path resets to new profile's home
- [ ] Manual: Text-gen — open attachment menu with Slurm-localhost profile, confirm "Select from server" button appears
- [ ] Manual: Batch jobs — open new job modal with Slurm-localhost profile, confirm input/output directory browsers load the home directory