### PR TITLE
release: v1.0.0a2

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "blackfish-ai"
-version = "1.0.0a1"
+version = "1.0.0a2"
 description = "An open-source AI-as-a-Service platform."
 readme = "README.md"
 license = "MIT"

--- a/lib/uv.lock
+++ b/lib/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blackfish-ai"
-version = "1.0.0a1"
+version = "1.0.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blackfish-ui",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blackfish-ui",
-      "version": "1.0.0-alpha.1",
+      "version": "1.0.0-alpha.2",
       "dependencies": {
         "@headlessui/react": "^2.1",
         "@heroicons/react": "^2.0.18",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blackfish-ui",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/web/src/components/SettingsSlideOver.jsx
+++ b/web/src/components/SettingsSlideOver.jsx
@@ -764,7 +764,7 @@ function AppConfigSection() {
         HOME_DIR: "/deep/blue/sea/.blackfish",
         DEBUG: true,
         CONTAINER_PROVIDER: "docker",
-        VERSION: "1.0.0a1-whale",
+        VERSION: "1.0.0a2-whale",
       });
       setLoading(false);
       return;


### PR DESCRIPTION
## Summary

Third alpha of the v1.0 line. Bundles #266 — two file browsing fixes for Slurm-localhost (Open OnDemand):

- **#264** — Server file browsing broken across text-gen and batch jobs. Empty path now defaults to `"~"` in `useFileSystem`, "Select from server" button shows for all Slurm profiles via `isSlurmProfile` helper, connection status bars gated on `isRemoteProfile`, remaining `schema !== "local"` Pattern B checks replaced. Zero raw schema checks remain in the frontend.
- **#265** — File manager snapped back to home directory on navigation. `homeDir` stabilized on the local SWR path via a ref, `FileManager` effect guarded to initialize once per profile, path resets on profile switch.

No backend changes.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 281/281 passing
- [ ] Manual verification on OnDemand after PyPI publish