### PR TITLE
fix(lib): allow model download and update for Slurm-localhost profiles

### DIFF
--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -2249,7 +2249,7 @@ async def update_model(
         raise NotFoundException(detail=f"Profile {model.profile} not found")
 
     # 3. Only support local profiles for now
-    if not isinstance(profile, LocalProfile):
+    if not profile.is_local():
         return ModelUpdateResponse(
             model_id=str(model.id),
             status="error",
@@ -2473,7 +2473,7 @@ async def download_model(
     profile = next((p for p in profiles if p.name == data.profile), None)
     if profile is None:
         raise NotFoundException(detail=f"Profile '{data.profile}' not found")
-    if not isinstance(profile, LocalProfile):
+    if not profile.is_local():
         raise ValidationException(detail="Downloads only supported for local profiles")
 
     # Validate model exists on HuggingFace Hub before starting download
@@ -3385,7 +3385,7 @@ async def resume_incomplete_downloads(app: Litestar) -> None:
                     task.error_message = f"Profile {task.profile} not found"
                     continue
 
-                if not isinstance(profile, LocalProfile):
+                if not profile.is_local():
                     logger.warning(
                         f"Profile {task.profile} is not local, marking task {task.id} as failed"
                     )

--- a/lib/tests/api/test_models.py
+++ b/lib/tests/api/test_models.py
@@ -681,6 +681,30 @@ class TestDownloadModelAPI:
         response = await client.post("/api/models/download", json=data)
         assert response.status_code == 404
 
+    async def test_download_model_rejected_for_remote_slurm_profile(
+        self, client: AsyncTestClient
+    ):
+        """Test download rejected for a remote Slurm profile."""
+        data = {"repo_id": "test/model", "profile": "hpc"}
+        response = await client.post("/api/models/download", json=data)
+        assert response.status_code == 400
+        assert (
+            "Downloads only supported for local profiles" in response.json()["detail"]
+        )
+
+    @patch("blackfish.server.asgi.hf_model_info")
+    @patch("blackfish.server.asgi._run_download_task")
+    async def test_download_model_accepted_for_slurm_localhost_profile(
+        self,
+        mock_run_task: AsyncMock,
+        mock_model_info: MagicMock,
+        client: AsyncTestClient,
+    ):
+        """Test download accepted for a Slurm profile with host=localhost."""
+        data = {"repo_id": "test/model", "profile": "ondemand"}
+        response = await client.post("/api/models/download", json=data)
+        assert response.status_code == 201
+
     async def test_download_model_invalid_repo_id_format(self, client: AsyncTestClient):
         """Test download with invalid repo_id format returns 400."""
         invalid_repo_ids = [
@@ -1204,22 +1228,30 @@ class TestUpdateModelAPI:
         assert result["status"] == "error"
         assert "Failed to download update" in result["message"]
 
-    async def test_update_model_slurm_profile(
+    async def test_update_model_rejected_for_remote_slurm_profile(
         self, client: AsyncTestClient, session: AsyncSession
     ):
-        """Test that update returns error for non-local (Slurm) profiles."""
-        # Use model with test-slurm profile (id 0022468b is "test" profile)
-        # Need to check if test-slurm model exists in fixtures
-        # The fixtures have "test" profile models, need to check profiles.cfg
-        # For now, let's use the "test" profile model with openai/whisper-tiny
-        # This tests when profile doesn't exist scenario
-        model_id = "0022468b-3182-4381-a76a-25d06248398f"
-
+        """Test that update returns error for a remote Slurm profile."""
+        model_id = "b2c3d4e5-f6a7-8901-bcde-f12345678901"  # profile="hpc"
         response = await client.put(f"/api/models/{model_id}")
+        assert response.status_code == 200
+        result = response.json()
+        assert result["status"] == "error"
+        assert "Update only supported for local profiles" in result["message"]
 
-        # Should return 404 because "test" profile doesn't exist in profiles.cfg
-        # (only "default" exists based on test fixtures)
-        assert response.status_code == 404
+    @patch("huggingface_hub.model_info")
+    async def test_update_model_accepted_for_slurm_localhost_profile(
+        self, mock_model_info, client: AsyncTestClient, session: AsyncSession
+    ):
+        """Test that update works for a Slurm profile with host=localhost."""
+        model_id = "c3d4e5f6-a7b8-9012-cdef-123456789012"  # profile="ondemand"
+        mock_info = AsyncMock()
+        mock_info.sha = "1"  # Same revision — triggers "up_to_date"
+        mock_model_info.return_value = mock_info
+        response = await client.put(f"/api/models/{model_id}")
+        assert response.status_code == 200
+        result = response.json()
+        assert result["status"] == "up_to_date"
 
     @patch("huggingface_hub.model_info")
     async def test_update_model_already_have_latest_in_another_row(

--- a/lib/tests/api/test_models.py
+++ b/lib/tests/api/test_models.py
@@ -704,6 +704,10 @@ class TestDownloadModelAPI:
         data = {"repo_id": "test/model", "profile": "ondemand"}
         response = await client.post("/api/models/download", json=data)
         assert response.status_code == 201
+        result = response.json()
+        assert "task_id" in result
+        assert result["status"] == "pending"
+        assert result["repo_id"] == "test/model"
 
     async def test_download_model_invalid_repo_id_format(self, client: AsyncTestClient):
         """Test download with invalid repo_id format returns 400."""
@@ -1229,7 +1233,7 @@ class TestUpdateModelAPI:
         assert "Failed to download update" in result["message"]
 
     async def test_update_model_rejected_for_remote_slurm_profile(
-        self, client: AsyncTestClient, session: AsyncSession
+        self, client: AsyncTestClient
     ):
         """Test that update returns error for a remote Slurm profile."""
         model_id = "b2c3d4e5-f6a7-8901-bcde-f12345678901"  # profile="hpc"
@@ -1241,11 +1245,11 @@ class TestUpdateModelAPI:
 
     @patch("huggingface_hub.model_info")
     async def test_update_model_accepted_for_slurm_localhost_profile(
-        self, mock_model_info, client: AsyncTestClient, session: AsyncSession
+        self, mock_model_info, client: AsyncTestClient
     ):
         """Test that update works for a Slurm profile with host=localhost."""
         model_id = "c3d4e5f6-a7b8-9012-cdef-123456789012"  # profile="ondemand"
-        mock_info = AsyncMock()
+        mock_info = MagicMock()
         mock_info.sha = "1"  # Same revision — triggers "up_to_date"
         mock_model_info.return_value = mock_info
         response = await client.put(f"/api/models/{model_id}")

--- a/lib/tests/data_fixtures.py
+++ b/lib/tests/data_fixtures.py
@@ -166,4 +166,20 @@ def models_fixture() -> list[Model | dict[str, Any]]:
             "image": "image-text-to-text",
             "model_dir": "/home/test/.blackfish/models/models--llava-hf/llava-1.5-7b-hf",
         },
+        {
+            "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+            "repo": "openai/whisper-large-v3",
+            "profile": "hpc",
+            "revision": "1",
+            "image": "speech_recognition",
+            "model_dir": "/home/test/.blackfish/models/models--openai/whisper-large-v3",
+        },
+        {
+            "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+            "repo": "openai/whisper-large-v3",
+            "profile": "ondemand",
+            "revision": "1",
+            "image": "speech_recognition",
+            "model_dir": "/home/test/.blackfish/models/models--openai/whisper-large-v3",
+        },
     ]

--- a/lib/tests/profiles.cfg
+++ b/lib/tests/profiles.cfg
@@ -9,3 +9,10 @@ user = test
 host = hpc.example.com
 home_dir = /home/test/.blackfish
 cache_dir = /home/test/.blackfish/cache
+
+[ondemand]
+schema = slurm
+user = test
+host = localhost
+home_dir = /home/test/.blackfish
+cache_dir = /home/test/.blackfish/cache


### PR DESCRIPTION
## Summary

- Replace `isinstance(profile, LocalProfile)` with `profile.is_local()` at three sites in `asgi.py` (download endpoint, update endpoint, download-resume on startup) so Slurm profiles with `host=localhost` can download and update models. The delete endpoint already used `is_local()` correctly.
- Add an `ondemand` Slurm-localhost profile to the test fixtures (`profiles.cfg` + `data_fixtures.py`) and four tests verifying download/update acceptance for Slurm-localhost and rejection for remote Slurm.
- Fix the pre-existing broken `test_update_model_slurm_profile` which was hitting a 404 (non-existent profile) instead of testing the actual rejection logic.

Closes #268.

## Test plan

- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] `uv run pytest` — 754 passed, 8 skipped (3 net new)
- [ ] Manual: on OnDemand with a Slurm-localhost profile, download a model via the UI
