### PR TITLE
fix(web): remove unimplemented chat history and object detection placeholders

### DIFF
--- a/web/src/components/Sidebar.jsx
+++ b/web/src/components/Sidebar.jsx
@@ -7,7 +7,6 @@ import {
     FolderIcon,
     HomeIcon,
     CubeIcon,
-    ViewfinderCircleIcon,
     Square3Stack3DIcon,
 } from "@heroicons/react/24/outline";
 import { assetPath } from "@/config";
@@ -23,7 +22,6 @@ const navigation = [
 const secondaryNavigation = [
     { name: "Text Generation", href: "/text-generation", icon: ChatBubbleLeftRightIcon },
     { name: "Speech Recognition", href: "/speech-recognition", icon: MicrophoneIcon },
-    { name: "Object Detection", href: "/object-detection", icon: ViewfinderCircleIcon },
 ];
 
 function classNames(...classes) {

--- a/web/src/routes/dashboard/lib/tasks.js
+++ b/web/src/routes/dashboard/lib/tasks.js
@@ -1,7 +1,6 @@
 import {
   ChatBubbleBottomCenterTextIcon,
   SpeakerWaveIcon,
-  PhotoIcon,
 } from "@heroicons/react/24/outline";
 
 const tasks = [
@@ -18,13 +17,6 @@ const tasks = [
     description: "Convert spoken words to text.",
     icon: SpeakerWaveIcon,
     path: "speech-recognition",
-  },
-  {
-    id: "object-detection",
-    name: "Object Detection",
-    description: "Locate and classify objects in images.",
-    icon: PhotoIcon,
-    path: "object-detection",
   },
 ];
 

--- a/web/src/routes/text-generation/text-generation.jsx
+++ b/web/src/routes/text-generation/text-generation.jsx
@@ -11,7 +11,6 @@ import {
 } from "@heroicons/react/20/solid";
 import {
   CodeBracketIcon,
-  ClockIcon,
 } from "@heroicons/react/24/outline";
 
 import { Page } from "@/components/Page";
@@ -240,14 +239,6 @@ export default function TextGenerationPage() {
                   <CodeBracketIcon className="h-5 w-5" />
                   <span className="absolute top-full left-1/2 -translate-x-1/2 mt-0.5 text-xs whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none">Code</span>
                 </button>
-                <button
-                  type="button"
-                  className="group relative p-2 mr-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-700 rounded-md"
-                  aria-label="History"
-                >
-                  <ClockIcon className="h-5 w-5" />
-                  <span className="absolute top-full left-1/2 -translate-x-1/2 mt-0.5 text-xs whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none">History</span>
-                </button>
                 <ModeSelect selectedMode={mode} setSelectedMode={setMode} />
               </div>
             }
@@ -266,14 +257,6 @@ export default function TextGenerationPage() {
                 >
                   <CodeBracketIcon className="h-5 w-5" />
                   <span className="absolute top-full left-1/2 -translate-x-1/2 mt-0.5 text-xs whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none">Code</span>
-                </button>
-                <button
-                  type="button"
-                  className="group relative p-2 mr-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-700 rounded-md"
-                  aria-label="History"
-                >
-                  <ClockIcon className="h-5 w-5" />
-                  <span className="absolute top-full left-1/2 -translate-x-1/2 mt-0.5 text-xs whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none">History</span>
                 </button>
                 <ModeSelect selectedMode={mode} setSelectedMode={setMode} />
               </div>


### PR DESCRIPTION
## Summary

- **#262** — Remove the unimplemented chat history button from the text-generation toolbar (both completion and chat modes). Feature tracked in #200.
- **#263** — Remove the object detection placeholder from the sidebar and dashboard task cards. The nav links pointed to `/object-detection` which has no route or page component. The batch job "detect" task in `NewJobModal` is unaffected (it's a TigerFlow task, not a service). Feature tracked in #270.

Closes #262, closes #263.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 281/281 passing