### PR TITLE
fix: widen text file support and increase default grace period

### DIFF
--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -522,7 +522,6 @@ async def get_files(
 
 
 IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp"]
-TEXT_EXTENSIONS = [".txt", ".md", ".json", ".csv", ".xml", ".yaml", ".yml", ".log"]
 AUDIO_EXTENSIONS = [".wav", ".mp3"]
 
 # Mapping of task/image types to compatible pipeline tags
@@ -545,11 +544,6 @@ COMPATIBLE_PIPELINES: dict[str, list[str]] = {
 
 def has_image_extension(path: str) -> str:
     validate_file_extension(Path(path), IMAGE_EXTENSIONS)
-    return path
-
-
-def has_text_extension(path: str) -> str:
-    validate_file_extension(Path(path), TEXT_EXTENSIONS)
     return path
 
 
@@ -721,7 +715,7 @@ async def delete_image(path: str, profile: Optional[str] = None) -> Path | str:
 class TextUploadRequest(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    path: Annotated[str, AfterValidator(has_text_extension)]
+    path: str
     file: UploadFile
 
 
@@ -767,7 +761,6 @@ async def get_text(path: str, profile: Optional[str] = None) -> File | Response[
     """Retrieve a text file from the specified path."""
 
     if profile is not None:
-        validate_file_extension(Path(path), TEXT_EXTENSIONS)
         remote_profile = _get_validated_slurm_profile(profile)
         logger.debug(f"Downloading text file from remote profile {profile}: {path}")
         content = sftp.read_file(remote_profile, path)
@@ -803,7 +796,6 @@ async def get_text(path: str, profile: Optional[str] = None) -> File | Response[
     logger.debug(f"Attempting to retrieve text file from {file_path}")
 
     validate_file_exists(file_path)
-    validate_file_extension(file_path, TEXT_EXTENSIONS)
 
     try:
         with open(file_path, "r", encoding="utf-8") as f:
@@ -824,7 +816,6 @@ async def update_text(
 
     content = await data.file.read()
 
-    validate_file_extension(Path(data.path), TEXT_EXTENSIONS)
     validate_file_size(content, state.MAX_FILE_SIZE)
 
     try:
@@ -855,7 +846,6 @@ async def delete_text(path: str, profile: Optional[str] = None) -> Path | str:
     """Delete a text file at the specified path."""
 
     if profile is not None:
-        validate_file_extension(Path(path), TEXT_EXTENSIONS)
         remote_profile = _get_validated_slurm_profile(profile)
         logger.debug(f"Deleting text file on remote profile {profile}: {path}")
         return sftp.delete_file(remote_profile, path)
@@ -865,7 +855,6 @@ async def delete_text(path: str, profile: Optional[str] = None) -> Path | str:
     logger.debug(f"Attempting to delete text file at {file_path}")
 
     validate_file_exists(file_path)
-    validate_file_extension(file_path, TEXT_EXTENSIONS)
 
     return try_delete_file(file_path)
 

--- a/lib/tests/api/test_texts.py
+++ b/lib/tests/api/test_texts.py
@@ -72,26 +72,8 @@ class TestUploadTextAPI:
             # Should create new directories
             assert os.path.exists(os.path.join(temp_dir, "nested", "dirs"))
 
-    async def test_upload_text_invalid_extension(self, client: AsyncTestClient):
-        """Test that invalid file extensions are rejected."""
-        text_bytes = self._create_test_text()
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            file_path = os.path.join(temp_dir, "test.exe")
-
-            response = await client.post(
-                "/api/text",
-                files={"file": text_bytes},
-                data={"path": file_path},
-            )
-
-            # Should return validation error
-            assert response.status_code == 400
-            result = response.json()
-            assert "Validation failed for POST /api/text" in result["detail"]
-
     async def test_upload_text_valid_extensions(self, client: AsyncTestClient):
-        """Test that all valid text extensions are accepted."""
+        """Test that text and code file extensions are accepted."""
 
         valid_extensions = [
             ".txt",
@@ -102,6 +84,10 @@ class TestUploadTextAPI:
             ".yaml",
             ".yml",
             ".log",
+            ".py",
+            ".js",
+            ".sh",
+            ".toml",
         ]
         text_bytes = self._create_test_text()
 
@@ -260,24 +246,6 @@ class TestGetTextAPI:
             assert response.status_code == 400
             result = response.json()
             assert "not a file" in result["detail"]
-
-    async def test_get_text_invalid_extension(self, client: AsyncTestClient):
-        """Test that files with invalid extensions are rejected."""
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            file_path = os.path.join(temp_dir, "test.exe")
-            with open(file_path, "w") as f:
-                f.write("Not a valid extension")
-
-            response = await client.get(
-                "/api/text",
-                params={"path": file_path},
-            )
-
-            # Should return validation error
-            assert response.status_code == 400
-            result = response.json()
-            assert "Invalid file extension" in result["detail"]
 
     async def test_get_text_corrupted_file(self, client: AsyncTestClient):
         """Test that corrupted text files (invalid UTF-8) are rejected."""
@@ -521,24 +489,6 @@ class TestDeleteTextAPI:
             assert response.status_code == 400
             result = response.json()
             assert "not a file" in result["detail"]
-
-    async def test_delete_text_invalid_extension(self, client: AsyncTestClient):
-        """Test that files with invalid extensions cannot be deleted."""
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            file_path = os.path.join(temp_dir, "test.exe")
-            with open(file_path, "w") as f:
-                f.write("Not a text file")
-
-            response = await client.delete(
-                "/api/text",
-                params={"path": file_path},
-            )
-
-            # Should return validation error
-            assert response.status_code == 400
-            result = response.json()
-            assert "Invalid file extension" in result["detail"]
 
     async def test_delete_text_permission_denied(self, client: AsyncTestClient):
         """Test handling of permission denied errors."""

--- a/web/src/lib/requests.js
+++ b/web/src/lib/requests.js
@@ -143,7 +143,7 @@ export async function runService(pipeline, model, jobConfig, containerConfig, pr
       },
       job_config: jobConfig,
       mount: containerConfig.input_dir,
-      grace_period: 180,
+      grace_period: 600,
     }
   } else if (profile.schema === "local") {
     const res = await fetch(`${blackfishApiURL}/api/ports`)
@@ -170,7 +170,7 @@ export async function runService(pipeline, model, jobConfig, containerConfig, pr
         gres: jobConfig.gres,
       },
       mount: containerConfig.input_dir,
-      grace_period: 180,
+      grace_period: 600,
     }
   } else {
     throw new Error(`Unsupported job profile type: ${profile.schema}`)

--- a/web/src/routes/text-generation/lib/fileUtils.js
+++ b/web/src/routes/text-generation/lib/fileUtils.js
@@ -7,26 +7,27 @@ import { isRemoteProfile } from "@/lib/util";
 
 /**
  * Supported text file extensions for attachments.
+ * The backend accepts any UTF-8 file, so this list is a UX filter only.
  */
 export const TEXT_FILE_EXTENSIONS = [
-  ".txt",
-  ".md",
-  ".json",
-  ".py",
-  ".js",
-  ".jsx",
-  ".ts",
-  ".tsx",
-  ".html",
-  ".css",
-  ".sh",
-  ".sql",
-  ".toml",
-  ".yaml",
-  ".yml",
-  ".log",
-  ".csv",
-  ".xml",
+  // Prose / data
+  ".txt", ".md", ".csv", ".xml", ".json",
+  ".yaml", ".yml", ".toml", ".log", ".env",
+  // Web
+  ".html", ".css", ".js", ".jsx", ".ts", ".tsx", ".vue", ".svelte",
+  // Systems / scripting
+  ".py", ".sh", ".bash", ".zsh", ".rb", ".pl", ".lua",
+  ".r", ".R", ".jl",
+  // Compiled languages
+  ".c", ".h", ".cpp", ".hpp", ".cc", ".cxx",
+  ".java", ".kt", ".kts", ".scala",
+  ".go", ".rs", ".swift", ".m",
+  // Config / infra
+  ".sql", ".graphql", ".proto",
+  ".dockerfile", ".tf", ".hcl",
+  ".ini", ".cfg", ".conf",
+  // Other
+  ".tex", ".bib", ".rst",
 ];
 
 /**

--- a/web/src/routes/text-generation/lib/fileUtils.js
+++ b/web/src/routes/text-generation/lib/fileUtils.js
@@ -12,7 +12,7 @@ import { isRemoteProfile } from "@/lib/util";
 export const TEXT_FILE_EXTENSIONS = [
   // Prose / data
   ".txt", ".md", ".csv", ".xml", ".json",
-  ".yaml", ".yml", ".toml", ".log", ".env",
+  ".yaml", ".yml", ".toml", ".log",
   // Web
   ".html", ".css", ".js", ".jsx", ".ts", ".tsx", ".vue", ".svelte",
   // Systems / scripting


### PR DESCRIPTION
## Summary

- **#239** — Remove the backend `TEXT_EXTENSIONS` allowlist that blocked code files (`.py`, `.sh`, `.js`, etc.) from being attached in text generation. The UTF-8 decode check already prevents binary files, making the extension gate redundant. Expand the frontend extension list to cover common code and config file types.
- **#251** — Increase the default grace period for UI-launched services from 3 minutes to 10 minutes. Large models (70B+) can take 5-10 minutes to load weights, causing premature UNHEALTHY status with the old default.

Note: #235 (client timeout wiring) was originally planned for this PR but deferred — it requires a database migration and its own PR.

Closes #239, closes #251.

## Test plan

- [x] `uv run pytest` — 748 passed, 8 skipped (3 extension-validation tests removed)
- [x] `npm run lint` — clean
- [x] `npm test` — 281/281 passing
- [ ] Manual: attach a `.py` or `.sh` file in text generation chat — should succeed
- [ ] Manual: launch a large model service, confirm it doesn't go UNHEALTHY during load
