### PR TITLE
fix: wire up client timeout field in batch job modal

### DIFF
--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -101,6 +101,7 @@ from blackfish.server.models.profile import (
     BlackfishProfile as Profile,
 )
 from blackfish.server.jobs.client import (
+    DEFAULT_IDLE_TIMEOUT,
     TigerFlowClient,
     TigerFlowError,
     SSHRunner,
@@ -1323,6 +1324,7 @@ class BatchJobRequest(BaseModel):
     params: Optional[dict[str, Any]] = None  # Task-specific parameters
     resources: Optional[dict[str, Any]] = None  # Resource requirements
     max_workers: int = 1  # Max concurrent Slurm workers
+    idle_timeout: int = DEFAULT_IDLE_TIMEOUT  # Minutes before auto-stop
 
 
 def build_batch_job(data: BatchJobRequest) -> BatchJob:
@@ -1343,6 +1345,7 @@ def build_batch_job(data: BatchJobRequest) -> BatchJob:
         "params": data.params,
         "resources": data.resources,
         "max_workers": data.max_workers,
+        "idle_timeout": data.idle_timeout,
     }
 
     if isinstance(data.profile, LocalProfile):

--- a/lib/src/blackfish/server/db/migrations/versions/2026-04-16_add_idle_timeout_to_jobs_1cca2a04c7bb.py
+++ b/lib/src/blackfish/server/db/migrations/versions/2026-04-16_add_idle_timeout_to_jobs_1cca2a04c7bb.py
@@ -42,7 +42,7 @@ sa.EncryptedString = EncryptedString
 sa.EncryptedText = EncryptedText
 
 # revision identifiers, used by Alembic.
-revision = "c4d5e6f7a8b9"
+revision = "1cca2a04c7bb"
 down_revision = "e5df678f18d4"
 branch_labels = None
 depends_on = None

--- a/lib/src/blackfish/server/db/migrations/versions/2026-04-16_add_idle_timeout_to_jobs_c4d5e6f7a8b9.py
+++ b/lib/src/blackfish/server/db/migrations/versions/2026-04-16_add_idle_timeout_to_jobs_c4d5e6f7a8b9.py
@@ -1,0 +1,86 @@
+# type: ignore
+"""Add idle_timeout column to batch jobs
+
+Stores the TigerFlow idle timeout (minutes) used when the job was started.
+NULL for jobs created before this migration.
+
+Revision ID: c4d5e6f7a8b9
+Revises: e5df678f18d4
+Create Date: 2026-04-16
+
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import sqlalchemy as sa
+from alembic import op
+from advanced_alchemy.types import (
+    EncryptedString,
+    EncryptedText,
+    GUID,
+    ORA_JSONB,
+    DateTimeUTC,
+)
+from sqlalchemy import Text  # noqa: F401
+
+
+__all__ = [
+    "downgrade",
+    "upgrade",
+    "schema_upgrades",
+    "schema_downgrades",
+    "data_upgrades",
+    "data_downgrades",
+]
+
+sa.GUID = GUID
+sa.DateTimeUTC = DateTimeUTC
+sa.ORA_JSONB = ORA_JSONB
+sa.EncryptedString = EncryptedString
+sa.EncryptedText = EncryptedText
+
+# revision identifiers, used by Alembic.
+revision = "c4d5e6f7a8b9"
+down_revision = "e5df678f18d4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        with op.get_context().autocommit_block():
+            schema_upgrades()
+            data_upgrades()
+
+
+def downgrade() -> None:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        with op.get_context().autocommit_block():
+            data_downgrades()
+            schema_downgrades()
+
+
+def schema_upgrades() -> None:
+    """schema upgrade migrations go here."""
+
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("idle_timeout", sa.Integer(), nullable=True))
+
+
+def schema_downgrades() -> None:
+    """schema downgrade migrations go here."""
+
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.drop_column("idle_timeout")
+
+
+def data_upgrades() -> None:
+    """Add any optional data upgrade migrations here!"""
+
+
+def data_downgrades() -> None:
+    """Add any optional data downgrade migrations here!"""

--- a/lib/src/blackfish/server/jobs/base.py
+++ b/lib/src/blackfish/server/jobs/base.py
@@ -15,6 +15,7 @@ from blackfish.server.jobs.tasks import (
 from blackfish.server.logger import logger
 from blackfish.server.models.profile import SlurmProfile, deserialize_profile
 from blackfish.server.jobs.client import (
+    DEFAULT_IDLE_TIMEOUT,
     LocalRunner,
     SSHRunner,
     TigerFlowClient,
@@ -147,6 +148,7 @@ class BatchJob(UUIDAuditBase):
         JSON, nullable=True, default=None
     )
     max_workers: Mapped[int] = mapped_column(default=1)
+    idle_timeout: Mapped[Optional[int]] = mapped_column(default=None)  # minutes
 
     # Profile info (denormalized for convenience)
     profile: Mapped[str]
@@ -222,6 +224,7 @@ class BatchJob(UUIDAuditBase):
             config=config,
             input_dir=self.input_dir,
             output_dir=self.output_dir,
+            idle_timeout=self.idle_timeout or DEFAULT_IDLE_TIMEOUT,
             config_name=f"pipeline-{self.id}.yaml",
         )
 

--- a/lib/src/blackfish/server/jobs/base.py
+++ b/lib/src/blackfish/server/jobs/base.py
@@ -148,7 +148,9 @@ class BatchJob(UUIDAuditBase):
         JSON, nullable=True, default=None
     )
     max_workers: Mapped[int] = mapped_column(default=1)
-    idle_timeout: Mapped[Optional[int]] = mapped_column(default=None)  # minutes
+    idle_timeout: Mapped[Optional[int]] = mapped_column(
+        default=None
+    )  # minutes; nullable for pre-migration rows only
 
     # Profile info (denormalized for convenience)
     profile: Mapped[str]
@@ -224,7 +226,9 @@ class BatchJob(UUIDAuditBase):
             config=config,
             input_dir=self.input_dir,
             output_dir=self.output_dir,
-            idle_timeout=self.idle_timeout or DEFAULT_IDLE_TIMEOUT,
+            idle_timeout=self.idle_timeout
+            if self.idle_timeout is not None
+            else DEFAULT_IDLE_TIMEOUT,
             config_name=f"pipeline-{self.id}.yaml",
         )
 

--- a/lib/src/blackfish/server/jobs/client.py
+++ b/lib/src/blackfish/server/jobs/client.py
@@ -22,6 +22,9 @@ MIN_TIGERFLOW_ML_VERSION = "0.1.0a1"
 # Venv location on remote cluster (relative to home_dir)
 VENV_PATH = ".venv"
 
+# Default idle timeout for TigerFlow jobs (minutes)
+DEFAULT_IDLE_TIMEOUT = 10
+
 
 class TigerFlowReportStatus(BaseModel):
     """Status section from tigerflow report."""
@@ -603,7 +606,7 @@ class TigerFlowClient:
         config: dict[str, Any],
         input_dir: str,
         output_dir: str,
-        idle_timeout: int = 10,
+        idle_timeout: int = DEFAULT_IDLE_TIMEOUT,
         config_name: str = "pipeline.yaml",
     ) -> None:
         """Start tigerflow job in background.

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -150,32 +150,6 @@ class TestBatchJobStart:
         with pytest.raises(TigerFlowError):
             await job.start(client)
 
-
-def make_mock_report(
-    running: bool = True,
-    pid: int | None = 12345,
-    finished: int = 5,
-    in_progress: int = 3,
-    staged: int | None = 2,
-    errored: int = 0,
-) -> TigerFlowReport:
-    """Create a TigerFlowReport for testing."""
-    return TigerFlowReport(
-        status=TigerFlowReportStatus(running=running, pid=pid),
-        progress=TigerFlowProgress(
-            pipeline=TigerFlowPipelineProgress(
-                finished=finished,
-                in_progress=in_progress,
-                staged=staged,
-                errored=errored,
-            ),
-            tasks=[],
-        ),
-        metrics={},
-        errors={},
-    )
-
-
     async def test_start_passes_explicit_idle_timeout(self) -> None:
         """start should pass idle_timeout to client.run when set."""
         job = create_test_batch_job(idle_timeout=30)
@@ -201,6 +175,31 @@ def make_mock_report(
 
         call_args = client.run.call_args
         assert call_args.kwargs["idle_timeout"] == DEFAULT_IDLE_TIMEOUT
+
+
+def make_mock_report(
+    running: bool = True,
+    pid: int | None = 12345,
+    finished: int = 5,
+    in_progress: int = 3,
+    staged: int | None = 2,
+    errored: int = 0,
+) -> TigerFlowReport:
+    """Create a TigerFlowReport for testing."""
+    return TigerFlowReport(
+        status=TigerFlowReportStatus(running=running, pid=pid),
+        progress=TigerFlowProgress(
+            pipeline=TigerFlowPipelineProgress(
+                finished=finished,
+                in_progress=in_progress,
+                staged=staged,
+                errored=errored,
+            ),
+            tasks=[],
+        ),
+        metrics={},
+        errors={},
+    )
 
 
 class TestBatchJobUpdate:

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -11,6 +11,7 @@ from blackfish.server.jobs.base import (
     create_tigerflow_client_for_profile,
 )
 from blackfish.server.jobs.client import (
+    DEFAULT_IDLE_TIMEOUT,
     TigerFlowClient,
     TigerFlowReport,
     TigerFlowReportStatus,
@@ -173,6 +174,33 @@ def make_mock_report(
         metrics={},
         errors={},
     )
+
+
+    async def test_start_passes_explicit_idle_timeout(self) -> None:
+        """start should pass idle_timeout to client.run when set."""
+        job = create_test_batch_job(idle_timeout=30)
+        client = create_mock_client()
+        client.check_health.return_value = TigerFlowVersions(
+            tigerflow="0.1.0", tigerflow_ml="0.1.0"
+        )
+
+        await job.start(client)
+
+        call_args = client.run.call_args
+        assert call_args.kwargs["idle_timeout"] == 30
+
+    async def test_start_uses_default_idle_timeout_when_none(self) -> None:
+        """start should fall back to DEFAULT_IDLE_TIMEOUT when idle_timeout is None."""
+        job = create_test_batch_job(idle_timeout=None)
+        client = create_mock_client()
+        client.check_health.return_value = TigerFlowVersions(
+            tigerflow="0.1.0", tigerflow_ml="0.1.0"
+        )
+
+        await job.start(client)
+
+        call_args = client.run.call_args
+        assert call_args.kwargs["idle_timeout"] == DEFAULT_IDLE_TIMEOUT
 
 
 class TestBatchJobUpdate:

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -675,6 +675,7 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
         params: Object.keys(taskParams).length > 0 ? taskParams : null,
         resources: Object.keys(jobResources).length > 0 ? jobResources : null,
         max_workers: maxWorkers,
+        idle_timeout: clientTimeout ? parseInt(clientTimeout, 10) : undefined,
       };
 
       console.debug("Submitting job request:", jobRequest);


### PR DESCRIPTION
## Summary

The "Client Timeout" field in the batch job modal was collected in state but never included in the job request payload. TigerFlow always used its default of 10 minutes.

- Extract `DEFAULT_IDLE_TIMEOUT` constant in `client.py`
- Add `idle_timeout` to `BatchJobRequest` (defaults to 10, so omitting it from the frontend preserves current behavior)
- Add nullable `idle_timeout` column to `BatchJob` model + Alembic migration
- Thread through `BatchJob.start()` → `client.run(idle_timeout=...)`
- Frontend sends `idle_timeout` from the modal's `clientTimeout` state

Closes #235.

## Test plan

- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] `uv run pytest` — 754 passed, 8 skipped
- [ ] Manual: create a batch job with a custom client timeout, verify `--idle-timeout` flag in the TigerFlow command

🤖 Generated with [Claude Code](https://claude.com/claude-code)