### PR TITLE
fix(web): preserve messages and input on chat errors

### DIFF
--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
@@ -839,6 +839,9 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
 
     setApiError(null);
 
+    // Save messages before truncating (restored on error)
+    const savedMessages = messages;
+
     // Get messages up to (but not including) the message being regenerated
     const conversationUpToIndex = messages.slice(0, index);
 
@@ -890,6 +893,8 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
     } catch (error) {
       console.error("Chat resubmit error:", error);
       setIsWaitingForResponse(false);
+      // Restore the original conversation including the assistant message
+      setMessages(savedMessages.slice(0, index + 1));
       setApiError(classifyApiError(error));
     }
   };

--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
@@ -765,6 +765,9 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
 
     setMessages((messages) => [...messages, newUserMessage]);
 
+    // Save input before clearing (restored on error)
+    const savedInput = userMessage.content;
+
     // Clear input and attached items after sending
     setUserMessage({ role: Role.USER, content: "" });
     sessionStorage.removeItem("tgcc-um");
@@ -823,6 +826,9 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
         }
         return prev;
       });
+      // Restore the typed input so the user doesn't have to retype
+      setUserMessage({ role: Role.USER, content: savedInput });
+      sessionStorage.setItem("tgcc-um", savedInput);
       setApiError(classifyApiError(error));
     }
   };

--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
@@ -765,7 +765,6 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
 
     setMessages((messages) => [...messages, newUserMessage]);
 
-    // Save input before clearing (restored on error)
     const savedInput = userMessage.content;
 
     // Clear input and attached items after sending
@@ -826,7 +825,6 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
         }
         return prev;
       });
-      // Restore the typed input so the user doesn't have to retype
       setUserMessage({ role: Role.USER, content: savedInput });
       sessionStorage.setItem("tgcc-um", savedInput);
       setApiError(classifyApiError(error));
@@ -839,7 +837,6 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
 
     setApiError(null);
 
-    // Save messages before truncating (restored on error)
     const savedMessages = messages;
 
     // Get messages up to (but not including) the message being regenerated
@@ -893,7 +890,6 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
     } catch (error) {
       console.error("Chat resubmit error:", error);
       setIsWaitingForResponse(false);
-      // Restore the original conversation including the assistant message
       setMessages(savedMessages.slice(0, index + 1));
       setApiError(classifyApiError(error));
     }

--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.test.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.test.jsx
@@ -383,6 +383,70 @@ describe("TextGenerationChatContainer", () => {
     });
   });
 
+  describe("Error recovery", () => {
+    it("restores typed input when submission fails", async () => {
+      const user = userEvent.setup();
+      const failingStream = {
+        next: vi.fn().mockRejectedValue(new Error("API error")),
+        [Symbol.asyncIterator]: vi.fn().mockReturnValue({
+          next: vi.fn().mockResolvedValue({ done: true })
+        })
+      };
+      streamChatCompletionInference.mockReturnValue(failingStream);
+      const { getByPlaceholderText, getByRole } = render(
+        <MockProviders>
+          <TextGenerationChatContainer parameters={{}} systemMessage={{ role: "system", content: "" }} />
+        </MockProviders>
+      );
+      const textarea = getByPlaceholderText("Why are orcas so awesome?");
+      await user.type(textarea, "My important message");
+      await user.click(getByRole("button", { name: "Submit" }));
+      await waitFor(() => {
+        expect(textarea.value).toBe("My important message");
+      });
+    });
+
+    it("preserves assistant message when regeneration fails", async () => {
+      const user = userEvent.setup();
+      // First call succeeds
+      const successStream = {
+        next: vi.fn().mockResolvedValue({
+          value: [{ choices: [{ delta: { content: "Original response" } }] }]
+        }),
+        [Symbol.asyncIterator]: vi.fn().mockReturnValue({
+          next: vi.fn().mockResolvedValue({ done: true })
+        })
+      };
+      streamChatCompletionInference.mockReturnValue(successStream);
+      const { getByPlaceholderText, getByRole, getByText } = render(
+        <MockProviders>
+          <TextGenerationChatContainer parameters={{}} systemMessage={{ role: "system", content: "" }} />
+        </MockProviders>
+      );
+      const textarea = getByPlaceholderText("Why are orcas so awesome?");
+      await user.type(textarea, "Test message");
+      await user.click(getByRole("button", { name: "Submit" }));
+      await waitFor(() => {
+        expect(getByText("Original response")).toBeInTheDocument();
+      });
+      // Second call (regeneration) fails
+      const failingStream = {
+        next: vi.fn().mockRejectedValue(new Error("API error")),
+        [Symbol.asyncIterator]: vi.fn().mockReturnValue({
+          next: vi.fn().mockResolvedValue({ done: true })
+        })
+      };
+      streamChatCompletionInference.mockReturnValue(failingStream);
+      const assistantMessage = getByText("Original response").closest(".mt-3");
+      await user.hover(assistantMessage);
+      const regenButton = getByRole("button", { name: "Regenerate" });
+      await user.click(regenButton);
+      await waitFor(() => {
+        expect(getByText("Original response")).toBeInTheDocument();
+      });
+    });
+  });
+
   describe("Resubmit functionality", () => {
     it("handles resubmit of assistant message", async () => {
       const user = userEvent.setup();


### PR DESCRIPTION
## Summary

- **#242** — Restore the typed input when chat submission fails. Previously the input was cleared before the API call; on error the user had to retype from scratch. Now the input text and session storage are restored in the catch block.
- **#243** — Preserve the assistant message when regeneration fails. Previously `handleResubmit` truncated the conversation before streaming; on error the original assistant response was lost. Now the full conversation is saved before truncating and restored on error.

Closes #242, closes #243.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 281/281 passing
- [ ] Manual: send a message to a stopped service, verify the input is restored after the error
- [ ] Manual: regenerate a response with a stopped service, verify the original assistant message is preserved after the error