### PR TITLE
fix(web): abort in-flight stream when clearing conversation

### DIFF
--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
@@ -658,6 +658,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
   const [imageError, setImageError] = useState(null);
   const [apiError, setApiError] = useState(null);
   const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
+  const abortRef = useRef(null);
 
   // File attachment state and handlers
   const {
@@ -777,6 +778,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
     setIsWaitingForResponse(true);
 
     try {
+      abortRef.current = new AbortController();
       const stream = streamChatCompletionInference(
         selectedService,
         [systemMessage, ...messages, newUserMessage],
@@ -784,7 +786,8 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
           ...parameters,
           stream: true,
         },
-        true
+        true,
+        abortRef.current.signal
       );
 
       const data = await stream.next();
@@ -816,6 +819,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
         ]);
       }
     } catch (error) {
+      if (error.name === "AbortError") return;
       console.error("Chat submission error:", error);
       setIsWaitingForResponse(false);
       // Roll back the optimistically-added user message if no assistant response was started
@@ -849,6 +853,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
     setIsWaitingForResponse(true);
 
     try {
+      abortRef.current = new AbortController();
       const stream = streamChatCompletionInference(
         selectedService,
         [systemMessage, ...conversationUpToIndex],
@@ -856,7 +861,8 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
           ...parameters,
           stream: true,
         },
-        true
+        true,
+        abortRef.current.signal
       );
 
       const data = await stream.next();
@@ -888,6 +894,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
         ]);
       }
     } catch (error) {
+      if (error.name === "AbortError") return;
       console.error("Chat resubmit error:", error);
       setIsWaitingForResponse(false);
       setMessages(savedMessages.slice(0, index + 1));
@@ -909,6 +916,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
 
   function handleClearConversation() {
     if (messages.length === 0) return;
+    abortRef.current?.abort();
     setMessages([]);
     setUserMessage({ role: Role.USER, content: "" });
     setAttachedImages([]);

--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
@@ -819,6 +819,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
         ]);
       }
     } catch (error) {
+      // handleClearConversation already reset state; skip rollback
       if (error.name === "AbortError") return;
       console.error("Chat submission error:", error);
       setIsWaitingForResponse(false);
@@ -894,6 +895,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
         ]);
       }
     } catch (error) {
+      // handleClearConversation already reset state; skip rollback
       if (error.name === "AbortError") return;
       console.error("Chat resubmit error:", error);
       setIsWaitingForResponse(false);

--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.test.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.test.jsx
@@ -445,6 +445,37 @@ describe("TextGenerationChatContainer", () => {
         expect(getByText("Original response")).toBeInTheDocument();
       });
     });
+
+    it("does not append ghost message when conversation is cleared mid-stream", async () => {
+      const user = userEvent.setup();
+      const abortError = new DOMException("The operation was aborted.", "AbortError");
+      const mockStream = {
+        next: vi.fn().mockResolvedValue({
+          value: [{ choices: [{ delta: { content: "Partial response" } }] }]
+        }),
+        [Symbol.asyncIterator]: vi.fn().mockReturnValue({
+          next: vi.fn().mockRejectedValue(abortError)
+        })
+      };
+      streamChatCompletionInference.mockReturnValue(mockStream);
+      const { getByPlaceholderText, getByRole, queryByText } = render(
+        <MockProviders>
+          <TextGenerationChatContainer parameters={{}} systemMessage={{ role: "system", content: "" }} />
+        </MockProviders>
+      );
+      const textarea = getByPlaceholderText("Why are orcas so awesome?");
+      await user.type(textarea, "Test message");
+      await user.click(getByRole("button", { name: "Submit" }));
+      await waitFor(() => {
+        expect(queryByText("Partial response")).toBeInTheDocument();
+      });
+      const clearButton = getByRole("button", { name: "Clear conversation" });
+      await user.click(clearButton);
+      await waitFor(() => {
+        expect(queryByText("Partial response")).not.toBeInTheDocument();
+        expect(queryByText("Test message")).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe("Resubmit functionality", () => {

--- a/web/src/routes/text-generation/lib/requests.js
+++ b/web/src/routes/text-generation/lib/requests.js
@@ -165,7 +165,7 @@ export async function* streamTextGenerationInference(service, inputs, params, us
  * @param {boolean} [use_proxy=false]
  * @return {object}
  */
-export async function* streamChatCompletionInference(service, messages, params, use_proxy=false) {
+export async function* streamChatCompletionInference(service, messages, params, use_proxy=false, signal=undefined) {
 
   const body = JSON.stringify({
     messages: messages,
@@ -184,6 +184,7 @@ export async function* streamChatCompletionInference(service, messages, params, 
       "Content-Type": "application/json",
     },
     body: body,
+    signal,
   });
 
   if (!res.ok) {


### PR DESCRIPTION
## Summary

When a user clears the conversation while a response is actively streaming, the `for await` loop continues running and can append a ghost assistant message to the cleared conversation.

- Add `signal` parameter to `streamChatCompletionInference` in `requests.js`, passed through to `fetch()`
- Add `abortRef` in `TextGenerationChatContainer` — new `AbortController` created before each streaming call
- Call `abortRef.current?.abort()` in `handleClearConversation`
- Guard both catch blocks with `if (error.name === "AbortError") return` to avoid error toasts on intentional cancellation

Closes #227.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 283/283 passing
- [ ] Manual: start a streaming response, clear the conversation mid-stream, verify no ghost message appears
- [ ] Manual: start a streaming response, let it complete normally, verify behavior is unchanged
