### PR TITLE
release: v1.0.0a3

### DIFF
--- a/lib/docs/assets/img/coverage.svg
+++ b/lib/docs/assets/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">66%</text>
-        <text x="80" y="14">66%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">67%</text>
+        <text x="80" y="14">67%</text>
     </g>
 </svg>

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "blackfish-ai"
-version = "1.0.0a2"
+version = "1.0.0a3"
 description = "An open-source AI-as-a-Service platform."
 readme = "README.md"
 license = "MIT"

--- a/lib/uv.lock
+++ b/lib/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blackfish-ai"
-version = "1.0.0a2"
+version = "1.0.0a3"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blackfish-ui",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blackfish-ui",
-      "version": "1.0.0-alpha.2",
+      "version": "1.0.0-alpha.3",
       "dependencies": {
         "@headlessui/react": "^2.1",
         "@heroicons/react": "^2.0.18",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blackfish-ui",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/web/src/components/SettingsSlideOver.jsx
+++ b/web/src/components/SettingsSlideOver.jsx
@@ -764,7 +764,7 @@ function AppConfigSection() {
         HOME_DIR: "/deep/blue/sea/.blackfish",
         DEBUG: true,
         CONTAINER_PROVIDER: "docker",
-        VERSION: "1.0.0a2-whale",
+        VERSION: "1.0.0a3-whale",
       });
       setLoading(false);
       return;


### PR DESCRIPTION
## Summary

Fourth alpha. Bundles five PRs since v1.0.0a2:

- **#269** — Model download/update now works for Slurm-localhost profiles (`isinstance` → `is_local()`)
- **#272** — Remove backend text extension allowlist (UTF-8 check is sufficient); expand frontend extension list; increase default service grace period from 3 to 10 minutes
- **#273** — Wire up idle timeout field in batch job modal (backend plumbing + migration)
- **#276** — Preserve typed input on chat submission failure; preserve assistant message on regeneration failure
- **#277** — Abort in-flight stream when clearing conversation (AbortController)

Also: coverage badge refreshed (66% → 67%).

## Test plan

- [x] `uv run pytest` — 753 passed, 8 skipped
- [x] `npm test` — 284 passed
- [x] Coverage badge regenerated