### PR TITLE
Fix venv setup to use home_dir instead of nested .blackfish

### DIFF
--- a/lib/src/blackfish/server/jobs/client.py
+++ b/lib/src/blackfish/server/jobs/client.py
@@ -349,9 +349,22 @@ class TigerFlowClient:
         """
         self._on_progress(f"Setting up TigerFlow on {self.host}")
 
-        # Create parent directory if needed
+        # Fail fast if venv path is already occupied (non-empty dir or file).
+        # Otherwise `python -m venv` produces a confusing self-symlink error.
+        returncode, stdout, _ = await self.runner.run(
+            f"ls -A {self._venv_path} 2>/dev/null"
+        )
+        if returncode == 0 and stdout.strip():
+            raise TigerFlowError(
+                "setup",
+                self.host,
+                f"Venv path {self._venv_path} already exists and is not empty. "
+                "Remove it or choose a different home_dir.",
+            )
+
+        # Create home directory if needed
         try:
-            await self._run(f"mkdir -p {self.home_dir}/.blackfish")
+            await self._run(f"mkdir -p {self.home_dir}")
         except TigerFlowError:
             raise TigerFlowError("setup", self.host, "Failed to create directory")
 

--- a/lib/tests/unit/test_client.py
+++ b/lib/tests/unit/test_client.py
@@ -304,7 +304,6 @@ class TestTigerFlowClientSetup:
         await client.setup()
 
         assert runner.commands[1] == "mkdir -p /home/user/.blackfish"
-        assert "/home/user/.blackfish/.blackfish" not in runner.commands[1]
 
     async def test_setup_installs_tigerflow_packages(self) -> None:
         """Setup should install tigerflow and tigerflow-ml."""

--- a/lib/tests/unit/test_client.py
+++ b/lib/tests/unit/test_client.py
@@ -269,10 +269,11 @@ class TestTigerFlowClientSetup:
     """Tests for TigerFlowClient.setup()."""
 
     async def test_setup_creates_directory_and_venv(self) -> None:
-        """Setup should create .blackfish directory and venv."""
+        """Setup should create home directory and venv."""
         runner = MockRunner()
         runner.set_responses(
             [
+                (1, b"", b""),  # venv path check (empty)
                 (0, b"", b""),  # mkdir
                 (0, b"", b""),  # venv creation
                 (0, b"", b""),  # pip upgrade
@@ -283,14 +284,34 @@ class TestTigerFlowClientSetup:
 
         await client.setup()
 
-        assert "mkdir -p /home/user/.blackfish" in runner.commands[0]
-        assert "-m venv" in runner.commands[1]
+        assert runner.commands[1] == "mkdir -p /home/user"
+        assert "-m venv" in runner.commands[2]
+
+    async def test_setup_does_not_create_nested_blackfish_directory(self) -> None:
+        """Setup should not create a nested .blackfish subdirectory."""
+        runner = MockRunner()
+        runner.set_responses(
+            [
+                (1, b"", b""),  # venv path check (empty)
+                (0, b"", b""),  # mkdir
+                (0, b"", b""),  # venv creation
+                (0, b"", b""),  # pip upgrade
+                (0, b"", b""),  # pip install
+            ]
+        )
+        client = TigerFlowClient(runner, "/home/user/.blackfish")
+
+        await client.setup()
+
+        assert runner.commands[1] == "mkdir -p /home/user/.blackfish"
+        assert "/home/user/.blackfish/.blackfish" not in runner.commands[1]
 
     async def test_setup_installs_tigerflow_packages(self) -> None:
         """Setup should install tigerflow and tigerflow-ml."""
         runner = MockRunner()
         runner.set_responses(
             [
+                (1, b"", b""),  # venv path check (empty)
                 (0, b"", b""),  # mkdir
                 (0, b"", b""),  # venv creation
                 (0, b"", b""),  # pip upgrade
@@ -301,7 +322,7 @@ class TestTigerFlowClientSetup:
 
         await client.setup()
 
-        install_cmd = runner.commands[3]
+        install_cmd = runner.commands[4]
         assert "tigerflow" in install_cmd
         assert "tigerflow-ml" in install_cmd
 
@@ -310,6 +331,7 @@ class TestTigerFlowClientSetup:
         runner = MockRunner()
         runner.set_responses(
             [
+                (1, b"", b""),  # venv path check (empty)
                 (0, b"", b""),  # mkdir
                 (0, b"", b""),  # venv creation
                 (0, b"", b""),  # pip upgrade
@@ -322,7 +344,7 @@ class TestTigerFlowClientSetup:
 
         await client.setup()
 
-        venv_cmd = runner.commands[1]
+        venv_cmd = runner.commands[2]
         assert "/opt/python3.11/bin/python3 -m venv" in venv_cmd
 
     async def test_setup_uses_venv_pip_not_system_pip(self) -> None:
@@ -330,6 +352,7 @@ class TestTigerFlowClientSetup:
         runner = MockRunner()
         runner.set_responses(
             [
+                (1, b"", b""),  # venv path check (empty)
                 (0, b"", b""),  # mkdir
                 (0, b"", b""),  # venv creation
                 (0, b"", b""),  # pip upgrade
@@ -340,16 +363,55 @@ class TestTigerFlowClientSetup:
 
         await client.setup()
 
-        pip_upgrade_cmd = runner.commands[2]
-        pip_install_cmd = runner.commands[3]
+        pip_upgrade_cmd = runner.commands[3]
+        pip_install_cmd = runner.commands[4]
         expected_pip = f"/home/user/{VENV_PATH}/bin/pip"
         assert expected_pip in pip_upgrade_cmd
         assert expected_pip in pip_install_cmd
 
+    async def test_setup_raises_setup_error_when_venv_path_not_empty(self) -> None:
+        """Setup should fail fast with a clear message if venv path is occupied."""
+        runner = MockRunner()
+        runner.set_response(0, b"conda-meta\nbin\n", b"")  # venv path is non-empty
+        client = TigerFlowClient(runner, "/home/user")
+
+        with pytest.raises(TigerFlowError) as exc_info:
+            await client.setup()
+
+        assert exc_info.value.error_type == "setup"
+        details = str(exc_info.value.details)
+        assert client._venv_path in details
+        assert "already exists" in details
+        # Should bail before attempting mkdir or venv creation
+        assert len(runner.commands) == 1
+
+    async def test_setup_proceeds_when_venv_path_empty_directory(self) -> None:
+        """Setup should proceed if venv path exists but is an empty directory."""
+        runner = MockRunner()
+        runner.set_responses(
+            [
+                (0, b"", b""),  # ls returns 0 with empty stdout (empty dir)
+                (0, b"", b""),  # mkdir
+                (0, b"", b""),  # venv creation
+                (0, b"", b""),  # pip upgrade
+                (0, b"", b""),  # pip install
+            ]
+        )
+        client = TigerFlowClient(runner, "/home/user")
+
+        await client.setup()
+
+        assert "-m venv" in runner.commands[2]
+
     async def test_setup_raises_setup_error_when_mkdir_fails(self) -> None:
         """Setup should raise setup error if directory creation fails."""
         runner = MockRunner()
-        runner.set_response(1, b"", b"Permission denied")
+        runner.set_responses(
+            [
+                (1, b"", b""),  # venv path check (empty)
+                (1, b"", b"Permission denied"),  # mkdir fails
+            ]
+        )
         client = TigerFlowClient(runner, "/home/user")
 
         with pytest.raises(TigerFlowError) as exc_info:
@@ -362,6 +424,7 @@ class TestTigerFlowClientSetup:
         runner = MockRunner()
         runner.set_responses(
             [
+                (1, b"", b""),  # venv path check (empty)
                 (0, b"", b""),  # mkdir succeeds
                 (1, b"", b"venv module not found"),  # venv fails
             ]
@@ -379,6 +442,7 @@ class TestTigerFlowClientSetup:
         runner = MockRunner()
         runner.set_responses(
             [
+                (1, b"", b""),  # venv path check (empty)
                 (0, b"", b""),  # mkdir succeeds
                 (127, b"", b"/opt/python3.11/bin/python3: No such file or directory"),
             ]
@@ -398,6 +462,7 @@ class TestTigerFlowClientSetup:
         runner = MockRunner()
         runner.set_responses(
             [
+                (1, b"", b""),  # venv path check (empty)
                 (0, b"", b""),  # mkdir
                 (0, b"", b""),  # venv creation
                 (0, b"", b""),  # pip upgrade
@@ -597,6 +662,7 @@ class TestTigerFlowClientCleanup:
         runner.set_responses(
             [
                 (0, b"", b""),  # rm -rf
+                (1, b"", b""),  # venv path check (empty after rm)
                 (0, b"", b""),  # mkdir
                 (0, b"", b""),  # venv creation
                 (0, b"", b""),  # pip upgrade


### PR DESCRIPTION
## Summary
This PR fixes the TigerFlowClient setup process to create the venv in the configured home directory instead of creating a nested `.blackfish` subdirectory. It also adds validation to prevent setup from proceeding if the venv path is already occupied by non-empty content.

## Key Changes
- **Changed directory creation**: Modified setup to create `{home_dir}` instead of `{home_dir}/.blackfish`, eliminating unnecessary nesting
- **Added venv path validation**: Added an upfront check using `ls -A` to detect if the venv path already exists and contains files/directories. If occupied, setup fails fast with a clear error message instead of allowing `python -m venv` to produce confusing self-symlink errors
- **Updated test expectations**: Updated all setup-related tests to account for the new venv path check command being the first command executed, shifting subsequent command indices
- **Added new test cases**:
  - `test_setup_does_not_create_nested_blackfish_directory`: Verifies that nested `.blackfish` directories are not created
  - `test_setup_raises_setup_error_when_venv_path_not_empty`: Validates that setup fails with a clear error when venv path is occupied
  - `test_setup_proceeds_when_venv_path_empty_directory`: Confirms setup proceeds normally when venv path is an empty directory

## Implementation Details
- The venv path check uses `ls -A {venv_path} 2>/dev/null` which returns exit code 0 with empty stdout for empty directories and exit code 0 with content for non-empty directories
- Exit code 1 indicates the path doesn't exist, which is the expected case for a fresh setup
- The validation happens before any directory creation or venv setup, providing fail-fast behavior with a user-friendly error message

https://claude.ai/code/session_015WZysBrrFKy7sCZGovn6iz