### PR TITLE
fix(web): persist only profile name, resolve full profile from API

### DIFF
--- a/web/src/components/ProfileSelect.jsx
+++ b/web/src/components/ProfileSelect.jsx
@@ -1,4 +1,4 @@
-import { createContext, useState, useEffect } from "react";
+import { createContext, useState, useEffect, useMemo } from "react";
 import {
   Menu,
   MenuButton,
@@ -19,18 +19,30 @@ const ProfileContext = createContext();
  * @return {JSX.Element}
  */
 const ProfileProvider = ({ children }) => {
-  const [profile, setProfileContext] = useState(null);
+  const { profiles } = useProfiles();
+  const [profileName, setProfileName] = useState(() =>
+    typeof window !== "undefined" ? localStorage.getItem("profileName") : null
+  );
 
+  // Discard the legacy full-object payload so stale shapes from older
+  // versions (or external writers like Open OnDemand) can't leak in.
   useEffect(() => {
-    const data = localStorage.getItem("profile");
-    const restoredProfile = data ? JSON.parse(data) : null;
-    console.debug("Restored profile", restoredProfile);
-    setProfileContext(restoredProfile);
+    localStorage.removeItem("profile");
   }, []);
 
-  const setProfile = (profile) => {
-    localStorage.setItem("profile", JSON.stringify(profile));
-    setProfileContext(profile);
+  const profile = useMemo(
+    () => profiles?.find((p) => p.name === profileName) ?? null,
+    [profiles, profileName]
+  );
+
+  const setProfile = (nextProfile) => {
+    const name = nextProfile?.name ?? null;
+    if (name) {
+      localStorage.setItem("profileName", name);
+    } else {
+      localStorage.removeItem("profileName");
+    }
+    setProfileName(name);
   };
 
   return (

--- a/web/src/components/ProfileSelect.jsx
+++ b/web/src/components/ProfileSelect.jsx
@@ -1,4 +1,4 @@
-import { createContext, useState, useEffect, useMemo } from "react";
+import { createContext, useState, useEffect, useMemo, useCallback } from "react";
 import {
   Menu,
   MenuButton,
@@ -35,7 +35,7 @@ const ProfileProvider = ({ children }) => {
     [profiles, profileName]
   );
 
-  const setProfile = (nextProfile) => {
+  const setProfile = useCallback((nextProfile) => {
     const name = nextProfile?.name ?? null;
     if (name) {
       localStorage.setItem("profileName", name);
@@ -43,10 +43,15 @@ const ProfileProvider = ({ children }) => {
       localStorage.removeItem("profileName");
     }
     setProfileName(name);
-  };
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({ profile, setProfile }),
+    [profile, setProfile]
+  );
 
   return (
-    <ProfileContext.Provider value={{ profile, setProfile }}>
+    <ProfileContext.Provider value={contextValue}>
       {children}
     </ProfileContext.Provider>
   );

--- a/web/src/components/ProfileSelect.test.jsx
+++ b/web/src/components/ProfileSelect.test.jsx
@@ -7,13 +7,16 @@ import ProfileSelect, {
 } from "@/components/ProfileSelect";
 import { useProfiles } from "@/lib/loaders";
 
+const defaultProfiles = [
+  {name: "test-profile", host: "example.com"},
+  {name: "local-test-profile", host: "localhost"},
+  {name: "new-profile", host: "newhost.com"}
+];
+
 // Mock the hooks
 vi.mock("@/lib/loaders", () => ({
   useProfiles: vi.fn(() => ({
-    profiles: [
-      {name: "test-profile", host: "example.com"},
-      {name: "local-test-profile", host: "localhost"}
-    ],
+    profiles: defaultProfiles,
     isLoading: false,
     error: false
   }))
@@ -31,6 +34,11 @@ describe("ProfileProvider", () => {
     vi.clearAllMocks();
     // Clear localStorage
     localStorage.clear();
+    vi.mocked(useProfiles).mockReturnValue({
+      profiles: defaultProfiles,
+      isLoading: false,
+      error: false
+    });
   });
 
   it("renders children", () => {
@@ -43,14 +51,8 @@ describe("ProfileProvider", () => {
     expect(baseElement).toMatchSnapshot();
   });
 
-  it("restores profile from storage", () => {
-    const mockProfile = {
-      name: "test-profile",
-      host: "example.com"
-    };
-
-    // Set the item in localStorage before rendering
-    localStorage.setItem("profile", JSON.stringify(mockProfile));
+  it("resolves profile from storage by name", () => {
+    localStorage.setItem("profileName", "test-profile");
 
     let contextValue = null;
     const TestComponent = () => {
@@ -70,15 +72,81 @@ describe("ProfileProvider", () => {
       </ProfileProvider>
     );
 
-    expect(contextValue.profile).toEqual(mockProfile);
+    expect(contextValue.profile).toEqual(
+      defaultProfiles.find((p) => p.name === "test-profile")
+    );
     expect(baseElement).toMatchSnapshot();
   });
 
-  it("setProfile updates context and localStorage", () => {
-    const mockProfile = {
-      name: "new-profile",
-      host: "newhost.com"
+  it("resolves to null when the stored name is not in /api/profiles", () => {
+    localStorage.setItem("profileName", "unknown-profile");
+
+    let contextValue = null;
+    const TestComponent = () => {
+      const context = useContext(ProfileContext);
+      contextValue = context;
+      return <h1>Hello, world!</h1>;
     };
+
+    render(
+      <ProfileProvider>
+        <ProfileContext.Consumer>
+          {(value) => {
+            contextValue = value;
+            return <TestComponent />;
+          }}
+        </ProfileContext.Consumer>
+      </ProfileProvider>
+    );
+
+    expect(contextValue.profile).toBeNull();
+  });
+
+  it("removes legacy 'profile' key on mount", () => {
+    localStorage.setItem("profile", JSON.stringify({name: "stale", type: "slurm"}));
+
+    render(
+      <ProfileProvider>
+        <h1>Hello, world!</h1>
+      </ProfileProvider>
+    );
+
+    expect(localStorage.getItem("profile")).toBeNull();
+  });
+
+  it("setProfile persists name and resolves fresh profile from the API list", () => {
+    let contextValue = null;
+    const TestComponent = () => {
+      const context = useContext(ProfileContext);
+      contextValue = context;
+      return <h1>Hello, world!</h1>;
+    };
+
+    render(
+      <ProfileProvider>
+        <ProfileContext.Consumer>
+          {(value) => {
+            contextValue = value;
+            return <TestComponent />;
+          }}
+        </ProfileContext.Consumer>
+      </ProfileProvider>
+    );
+
+    // Simulate an external writer passing a stale shape. Only the name
+    // should be persisted; the resolved profile should be the fresh API copy.
+    act(() => {
+      contextValue.setProfile({name: "new-profile", type: "slurm", host: "stale"});
+    });
+
+    expect(localStorage.getItem("profileName")).toEqual("new-profile");
+    expect(contextValue.profile).toEqual(
+      defaultProfiles.find((p) => p.name === "new-profile")
+    );
+  });
+
+  it("setProfile with null clears the stored name", () => {
+    localStorage.setItem("profileName", "test-profile");
 
     let contextValue = null;
     const TestComponent = () => {
@@ -99,11 +167,11 @@ describe("ProfileProvider", () => {
     );
 
     act(() => {
-      contextValue.setProfile(mockProfile);
+      contextValue.setProfile(null);
     });
 
-    expect(localStorage.getItem("profile")).toEqual(JSON.stringify(mockProfile));
-    expect(contextValue.profile).toEqual(mockProfile);
+    expect(localStorage.getItem("profileName")).toBeNull();
+    expect(contextValue.profile).toBeNull();
   });
 });
 
@@ -112,10 +180,7 @@ describe("ProfileSelect", () => {
     vi.clearAllMocks();
     // Reset mock to default
     vi.mocked(useProfiles).mockReturnValue({
-      profiles: [
-        {name: "test-profile", host: "example.com"},
-        {name: "local-test-profile", host: "localhost"}
-      ],
+      profiles: defaultProfiles,
       isLoading: false,
       error: false
     });

--- a/web/src/components/__snapshots__/ProfileSelect.test.jsx.snap
+++ b/web/src/components/__snapshots__/ProfileSelect.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`ProfileProvider > renders children 1`] = `
 </body>
 `;
 
-exports[`ProfileProvider > restores profile from storage 1`] = `
+exports[`ProfileProvider > resolves profile from storage by name 1`] = `
 <body>
   <div>
     <h1>


### PR DESCRIPTION
## Summary

- `ProfileProvider` now persists only the profile **name** in `localStorage["profileName"]` and resolves the full profile from the fresh `/api/profiles` response via `useMemo`, so stale object shapes from earlier versions or external writers (e.g. the Open OnDemand launcher script) can no longer leak through to downstream `profile.schema` checks.
- Removes the legacy `localStorage["profile"]` key on mount so existing users discard any cached payload on the next load.
- Context shape `{ profile, setProfile }` is unchanged; no consumer edits were required.

Closes #257

## Test plan

- [x] `npm run lint` — clean (one pre-existing unrelated warning in `ImageAttachment.jsx`)
- [x] `npx vitest run` — 287/287 tests pass
- [x] New tests cover: name-based resolution, unknown stored name → `null`, legacy `"profile"` key cleanup, external-writer stale shape (only name is persisted; resolved profile is the fresh API copy), and `setProfile(null)` clearing
- [ ] Manual: in Open OnDemand, prepopulate `localStorage["profileName"]` with a Slurm profile name and confirm the service launcher modal shows the Slurm view (Partition / Tier / Advanced)
- [ ] Manual: upgrade from a version that wrote `localStorage["profile"]` and confirm the legacy key is removed on first load