### PR TITLE
feat(lib): versioned bootstrap for app dir on init/start

### DIFF
--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -115,11 +115,11 @@ def init(
     Creates all files and directories to run Blackfish.
     """
 
-    from blackfish.server.setup import create_local_home_dir
+    from blackfish.server.migrations import bootstrap
     from blackfish.cli.profile import _auto_profile_, _create_profile_
     import configparser
 
-    create_local_home_dir(app_dir)
+    bootstrap(app_dir)
 
     profiles = configparser.ConfigParser()
     profiles.read(f"{app_dir}/profiles.cfg")
@@ -194,36 +194,11 @@ def start(reload: bool) -> None:  # pragma: no cover
     """
 
     import uvicorn
-    from advanced_alchemy.extensions.litestar import (
-        AlembicCommands as _AlembicCommands,
-        SQLAlchemyInitPlugin,
-    )
-    from sqlalchemy.exc import OperationalError
-    from litestar import Litestar
 
     import blackfish.server as server
-    from blackfish.server.asgi import app
+    from blackfish.server.migrations import bootstrap
 
-    if not os.path.isdir(config.HOME_DIR):
-        click.echo("Home directory not found. Have you run `blackfish init`?")
-        return
-
-    class AlembicCommands(_AlembicCommands):
-        def __init__(self, app: Litestar) -> None:
-            self._app = app
-            self.sqlalchemy_config = self._app.plugins.get(SQLAlchemyInitPlugin)._config  # type: ignore # noqa: SLF001
-            self.config = self._get_alembic_command_config()
-
-    alembic_commands = AlembicCommands(app=app)
-
-    try:
-        logger.info("Upgrading database...")
-        alembic_commands.upgrade()
-    except OperationalError as e:
-        if e.args == ("(sqlite3.OperationalError) table service already exists",):
-            logger.info("Database is already up-to-date. Skipping.")
-        else:
-            logger.error(f"Failed to upgrade database: {e}")
+    bootstrap(config.HOME_DIR)
 
     # Check TigerFlow versions on Slurm profiles
     import asyncio

--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -115,7 +115,7 @@ def init(
     Creates all files and directories to run Blackfish.
     """
 
-    from blackfish.server.migrations import bootstrap
+    from blackfish.server.bootstrap import bootstrap
     from blackfish.cli.profile import _auto_profile_, _create_profile_
     import configparser
 
@@ -196,7 +196,7 @@ def start(reload: bool) -> None:  # pragma: no cover
     import uvicorn
 
     import blackfish.server as server
-    from blackfish.server.migrations import bootstrap
+    from blackfish.server.bootstrap import bootstrap
 
     bootstrap(config.HOME_DIR)
 

--- a/lib/src/blackfish/server/bootstrap.py
+++ b/lib/src/blackfish/server/bootstrap.py
@@ -51,7 +51,7 @@ def ensure_app_dir(app_dir: str | os.PathLike[str]) -> None:
     if app_path.exists() and not app_path.is_dir():
         raise NotADirectoryError(str(app_path))
     if not app_path.exists():
-        os.mkdir(app_path)
+        app_path.mkdir()
     (app_path / "models").mkdir(exist_ok=True)
     (app_path / "images").mkdir(exist_ok=True)
 
@@ -67,17 +67,22 @@ def ensure_db(app_dir: str | os.PathLike[str]) -> None:
 
     import blackfish.server as server
 
-    server_dir = os.path.dirname(server.__file__)
-    migrations_dir = os.path.join(server_dir, "db", "migrations")
+    migrations_dir = Path(server.__file__).parent / "db" / "migrations"
+    db_path = Path(app_dir) / "app.sqlite"
 
+    # `metadata` is intentionally inert here: Alembic uses file-based migration
+    # scripts (not the live ORM metadata), and `create_all=False` means
+    # SQLAlchemyAsyncConfig won't materialize tables from it either. We pass
+    # UUIDAuditBase.metadata only because the field is required; the model
+    # modules aren't imported on this path, so the metadata is empty anyway.
     db_config = SQLAlchemyAsyncConfig(
-        connection_string=f"sqlite+aiosqlite:///{app_dir}/app.sqlite",
+        connection_string=f"sqlite+aiosqlite:///{db_path}",
         metadata=UUIDAuditBase.metadata,
         create_all=False,
         alembic_config=AlembicAsyncConfig(
             version_table_name="ddl_version",
-            script_config=os.path.join(migrations_dir, "alembic.ini"),
-            script_location=migrations_dir,
+            script_config=str(migrations_dir / "alembic.ini"),
+            script_location=str(migrations_dir),
         ),
     )
 
@@ -105,7 +110,7 @@ def normalize_profiles_cfg(app_dir: str | os.PathLike[str]) -> None:
             changed = True
 
     if changed:
-        with open(cfg_path, "w") as f:
+        with cfg_path.open("w") as f:
             parser.write(f)
 
 

--- a/lib/src/blackfish/server/migrations.py
+++ b/lib/src/blackfish/server/migrations.py
@@ -1,0 +1,120 @@
+"""Bootstrap the Blackfish application directory.
+
+`bootstrap` brings `app_dir` to a runnable state — creating directories,
+applying DB migrations, normalizing config — and is invoked from both
+`blackfish init` and `blackfish start` so upgrade-time work runs wherever
+the user enters the system.
+
+Note on terminology: `app_dir` here refers to the *application* directory
+(e.g. `~/.blackfish`), which is distinct from a profile's `home_dir` (a
+per-profile, often remote, location used to deploy services). This module
+only touches the application directory.
+"""
+
+from __future__ import annotations
+
+import configparser
+import importlib.metadata
+import os
+from pathlib import Path
+
+from blackfish.server.logger import logger
+
+
+CURRENT_VERSION = importlib.metadata.version("blackfish-ai")
+VERSION_FILE = ".blackfish_app_version"
+
+
+def read_app_version(app_dir: str | os.PathLike[str]) -> str | None:
+    """Return the Blackfish version recorded in `app_dir`, or None if unrecorded."""
+    path = Path(app_dir) / VERSION_FILE
+    if not path.is_file():
+        return None
+    contents = path.read_text().strip()
+    return contents or None
+
+
+def write_app_version(app_dir: str | os.PathLike[str], version: str) -> None:
+    """Stamp `app_dir` with the given Blackfish version."""
+    path = Path(app_dir) / VERSION_FILE
+    path.write_text(f"{version}\n")
+
+
+def ensure_app_dir(app_dir: str | os.PathLike[str]) -> None:
+    """Create the application directory and its `models/` and `images/`
+    subdirectories if missing.
+
+    Raises FileNotFoundError if the parent of `app_dir` does not exist —
+    matches the behavior of the previous `create_local_home_dir` and
+    surfaces typo'd `--app-dir` values loudly instead of silently
+    materializing a tree under a missing parent.
+    """
+    app_path = Path(app_dir)
+    if app_path.exists() and not app_path.is_dir():
+        raise NotADirectoryError(str(app_path))
+    if not app_path.exists():
+        os.mkdir(app_path)
+    (app_path / "models").mkdir(exist_ok=True)
+    (app_path / "images").mkdir(exist_ok=True)
+
+
+def ensure_db(app_dir: str | os.PathLike[str]) -> None:
+    """Apply Alembic migrations to `{app_dir}/app.sqlite`. Idempotent."""
+    from advanced_alchemy.alembic.commands import AlembicCommands
+    from advanced_alchemy.config import (
+        AlembicAsyncConfig,
+        SQLAlchemyAsyncConfig,
+    )
+    from advanced_alchemy.base import UUIDAuditBase
+
+    import blackfish.server as server
+
+    server_dir = os.path.dirname(server.__file__)
+    migrations_dir = os.path.join(server_dir, "db", "migrations")
+
+    db_config = SQLAlchemyAsyncConfig(
+        connection_string=f"sqlite+aiosqlite:///{app_dir}/app.sqlite",
+        metadata=UUIDAuditBase.metadata,
+        create_all=False,
+        alembic_config=AlembicAsyncConfig(
+            version_table_name="ddl_version",
+            script_config=os.path.join(migrations_dir, "alembic.ini"),
+            script_location=migrations_dir,
+        ),
+    )
+
+    logger.info("Upgrading database...")
+    AlembicCommands(sqlalchemy_config=db_config).upgrade()
+
+
+def normalize_profiles_cfg(app_dir: str | os.PathLike[str]) -> None:
+    """Rewrite legacy `type =` keys to `schema =` in `app_dir/profiles.cfg`.
+
+    Only writes when at least one section changes, so `mtime` is preserved
+    across no-op bootstraps.
+    """
+    cfg_path = Path(app_dir) / "profiles.cfg"
+    if not cfg_path.is_file():
+        return
+
+    parser = configparser.ConfigParser()
+    parser.read(cfg_path)
+
+    changed = False
+    for section in parser.sections():
+        if "type" in parser[section] and "schema" not in parser[section]:
+            parser[section]["schema"] = parser[section]["type"]
+            del parser[section]["type"]
+            changed = True
+
+    if changed:
+        with open(cfg_path, "w") as f:
+            parser.write(f)
+
+
+def bootstrap(app_dir: str | os.PathLike[str]) -> None:
+    """Apply all install/upgrade-time reconciliation steps to `app_dir`."""
+    ensure_app_dir(app_dir)
+    ensure_db(app_dir)
+    normalize_profiles_cfg(app_dir)
+    write_app_version(app_dir, CURRENT_VERSION)

--- a/lib/src/blackfish/server/migrations.py
+++ b/lib/src/blackfish/server/migrations.py
@@ -18,8 +18,6 @@ import importlib.metadata
 import os
 from pathlib import Path
 
-from blackfish.server.logger import logger
-
 
 CURRENT_VERSION = importlib.metadata.version("blackfish-ai")
 VERSION_FILE = ".blackfish_app_version"
@@ -83,7 +81,6 @@ def ensure_db(app_dir: str | os.PathLike[str]) -> None:
         ),
     )
 
-    logger.info("Upgrading database...")
     AlembicCommands(sqlalchemy_config=db_config).upgrade()
 
 

--- a/lib/src/blackfish/server/setup.py
+++ b/lib/src/blackfish/server/setup.py
@@ -244,30 +244,6 @@ async def repair_slurm_profile(
     return RepairResult(repaired=True, message=f"Profile repaired on {host}.")
 
 
-def create_local_home_dir(home_dir: str | os.PathLike[str]) -> None:
-    """Attempt to construct root directory to store core application data and raise an
-    exception if creation fails and the directory does not already exist.
-
-    This method should be called when the application is initialized or a local profile
-    is created.
-    """
-    with yaspin(text=f"Setting up home directory {home_dir}") as spinner:
-        if not os.path.isdir(home_dir):
-            try:
-                os.mkdir(home_dir)
-                os.mkdir(os.path.join(home_dir, "models"))
-                os.mkdir(os.path.join(home_dir, "images"))
-                spinner.text = f"Set up default Blackfish home directory {home_dir}"
-                spinner.ok(f"{LogSymbols.SUCCESS.value}")
-            except OSError as e:
-                spinner.text = f"Failed to set up Blackfish home directory: {e}"
-                spinner.fail(f"{LogSymbols.ERROR.value}")
-                raise Exception
-        else:
-            spinner.text = "Blackfish home directory already exists."
-            spinner.ok(f"{LogSymbols.SUCCESS.value}")
-
-
 def create_remote_home_dir(
     host: str, user: str, home_dir: str | os.PathLike[str]
 ) -> None:

--- a/lib/tests/unit/test_app_bootstrap.py
+++ b/lib/tests/unit/test_app_bootstrap.py
@@ -5,7 +5,7 @@ import sqlite3
 
 import pytest
 
-from blackfish.server.migrations import (
+from blackfish.server.bootstrap import (
     CURRENT_VERSION,
     VERSION_FILE,
     ensure_app_dir,
@@ -118,6 +118,24 @@ def test_ensure_db_idempotent(tmp_path):
     ensure_app_dir(p)
     ensure_db(p)
     ensure_db(p)
+
+
+def test_ensure_db_preserves_existing_data(tmp_path):
+    p = tmp_path / ".blackfish"
+    ensure_app_dir(p)
+    ensure_db(p)
+
+    db_path = p / "app.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE _smoke (id INTEGER PRIMARY KEY, payload TEXT)")
+        conn.execute("INSERT INTO _smoke (id, payload) VALUES (1, 'keep me')")
+        conn.commit()
+
+    ensure_db(p)
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute("SELECT payload FROM _smoke WHERE id = 1").fetchone()
+    assert row == ("keep me",)
 
 
 def test_bootstrap_empty_dir(tmp_path):

--- a/lib/tests/unit/test_app_bootstrap.py
+++ b/lib/tests/unit/test_app_bootstrap.py
@@ -1,0 +1,153 @@
+"""Tests for the application-directory bootstrap module."""
+
+import configparser
+import sqlite3
+
+import pytest
+
+from blackfish.server.migrations import (
+    CURRENT_VERSION,
+    VERSION_FILE,
+    ensure_app_dir,
+    ensure_db,
+    normalize_profiles_cfg,
+    read_app_version,
+    bootstrap,
+    write_app_version,
+)
+
+
+def test_ensure_app_dir_creates_subdirs(tmp_path):
+    p = tmp_path / ".blackfish"
+    ensure_app_dir(p)
+    assert (p / "models").is_dir()
+    assert (p / "images").is_dir()
+
+
+def test_ensure_app_dir_idempotent(tmp_path):
+    p = tmp_path / ".blackfish"
+    ensure_app_dir(p)
+    sentinel = p / "models" / "keep.txt"
+    sentinel.write_text("keep me")
+
+    ensure_app_dir(p)
+
+    assert sentinel.read_text() == "keep me"
+
+
+def test_ensure_app_dir_missing_parent(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        ensure_app_dir(tmp_path / "missing" / ".blackfish")
+
+
+def test_ensure_app_dir_path_is_file(tmp_path):
+    p = tmp_path / "not-a-dir"
+    p.write_text("oops")
+    with pytest.raises(NotADirectoryError):
+        ensure_app_dir(p)
+
+
+def test_write_and_read_app_version(tmp_path):
+    write_app_version(tmp_path, "9.9.9")
+    assert read_app_version(tmp_path) == "9.9.9"
+    assert (tmp_path / VERSION_FILE).read_text() == "9.9.9\n"
+
+
+def test_read_app_version_missing(tmp_path):
+    assert read_app_version(tmp_path) is None
+
+
+def test_normalize_profiles_cfg_rewrites_legacy_type(tmp_path):
+    cfg = tmp_path / "profiles.cfg"
+    cfg.write_text(
+        "[default]\ntype = slurm\nhost = della.princeton.edu\nuser = alice\n"
+    )
+
+    normalize_profiles_cfg(tmp_path)
+
+    parser = configparser.ConfigParser()
+    parser.read(cfg)
+    assert parser["default"]["schema"] == "slurm"
+    assert "type" not in parser["default"]
+
+
+def test_normalize_profiles_cfg_no_op_preserves_mtime(tmp_path):
+    cfg = tmp_path / "profiles.cfg"
+    cfg.write_text("[default]\nschema = local\nhome_dir = /tmp\n")
+    mtime_before = cfg.stat().st_mtime_ns
+
+    normalize_profiles_cfg(tmp_path)
+
+    assert cfg.stat().st_mtime_ns == mtime_before
+
+
+def test_normalize_profiles_cfg_missing_file(tmp_path):
+    normalize_profiles_cfg(tmp_path)
+
+
+def test_normalize_profiles_cfg_keeps_schema_when_both_present(tmp_path):
+    cfg = tmp_path / "profiles.cfg"
+    cfg.write_text("[default]\nschema = local\ntype = slurm\n")
+
+    normalize_profiles_cfg(tmp_path)
+
+    parser = configparser.ConfigParser()
+    parser.read(cfg)
+    assert parser["default"]["schema"] == "local"
+    assert parser["default"]["type"] == "slurm"
+
+
+def test_ensure_db_creates_sqlite(tmp_path):
+    p = tmp_path / ".blackfish"
+    ensure_app_dir(p)
+    ensure_db(p)
+
+    db_path = p / "app.sqlite"
+    assert db_path.is_file()
+
+    with sqlite3.connect(db_path) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+    assert "ddl_version" in tables
+
+
+def test_ensure_db_idempotent(tmp_path):
+    p = tmp_path / ".blackfish"
+    ensure_app_dir(p)
+    ensure_db(p)
+    ensure_db(p)
+
+
+def test_bootstrap_empty_dir(tmp_path):
+    p = tmp_path / ".blackfish"
+    bootstrap(p)
+
+    assert (p / "models").is_dir()
+    assert (p / "images").is_dir()
+    assert (p / "app.sqlite").is_file()
+    assert read_app_version(p) == CURRENT_VERSION
+
+
+def test_bootstrap_idempotent(tmp_path):
+    p = tmp_path / ".blackfish"
+    bootstrap(p)
+    bootstrap(p)
+    assert read_app_version(p) == CURRENT_VERSION
+    assert (p / "app.sqlite").is_file()
+
+
+def test_bootstrap_normalizes_legacy_profiles(tmp_path):
+    p = tmp_path / ".blackfish"
+    p.mkdir()
+    (p / "profiles.cfg").write_text(
+        "[default]\ntype = local\nhome_dir = /tmp\ncache_dir = /tmp\n"
+    )
+
+    bootstrap(p)
+
+    parser = configparser.ConfigParser()
+    parser.read(p / "profiles.cfg")
+    assert parser["default"]["schema"] == "local"
+    assert "type" not in parser["default"]

--- a/lib/tests/unit/test_setup.py
+++ b/lib/tests/unit/test_setup.py
@@ -2,7 +2,7 @@ import pytest
 
 
 from blackfish.server.setup import check_local_cache_exists
-from blackfish.server.migrations import ensure_app_dir
+from blackfish.server.bootstrap import ensure_app_dir
 from blackfish.cli.profile import _auto_profile_
 
 

--- a/lib/tests/unit/test_setup.py
+++ b/lib/tests/unit/test_setup.py
@@ -1,23 +1,9 @@
 import pytest
 
 
-from blackfish.server.setup import (
-    create_local_home_dir,
-    check_local_cache_exists,
-)
+from blackfish.server.setup import check_local_cache_exists
+from blackfish.server.migrations import ensure_app_dir
 from blackfish.cli.profile import _auto_profile_
-
-
-def test_create_local_home_dir_existing_root(tmp_path):
-    p = tmp_path / ".blackfish"
-    create_local_home_dir(p)
-    assert p.exists()
-
-
-def test_create_local_home_dir_missing_root(tmp_path):
-    p = tmp_path / "missing" / ".blackfish"
-    with pytest.raises(Exception):
-        create_local_home_dir(p)
 
 
 def test_check_local_cache_exists_existing_dir(tmp_path):
@@ -31,11 +17,11 @@ def test_check_local_cache_exists_missing_dir(tmp_path):
 
 def test_local_auto_setup(tmp_path):
     p = tmp_path / ".blackfish"
-    create_local_home_dir(p)
+    ensure_app_dir(p)
     _auto_profile_(p, "default", "local", None, None, home_dir=p, cache_dir=p)
 
 
 def test_slurm_auto_setup(tmp_path):
     p = tmp_path / ".blackfish"
-    create_local_home_dir(p)
+    ensure_app_dir(p)
     _auto_profile_(p, "default", "slurm", "localhost", "test", home_dir=p, cache_dir=p)


### PR DESCRIPTION
## Summary

- New `blackfish.server.migrations.bootstrap(app_dir)` module: creates the application directory, applies Alembic migrations, normalizes legacy `type =` keys to `schema =` in `profiles.cfg`, and stamps the directory with the current Blackfish version (`.blackfish_app_version`).
- `init` and `start` both call `bootstrap` so upgrade-time work runs wherever the user enters the system. Removes `init`'s early-exit when a `default` profile already exists, and replaces `start`'s brittle `("(sqlite3.OperationalError) table service already exists",)` exception-string match.
- `bootstrap` builds its own `SQLAlchemyAsyncConfig` (rather than going through the asgi app), so DB migrations are testable against a temp `app_dir` in isolation.
- `CURRENT_VERSION` is derived from `importlib.metadata.version("blackfish-ai")` — single source of truth in `pyproject.toml`, no hardcoded constant to drift.
- Deletes the old `setup.create_local_home_dir`; ports its tests onto `ensure_app_dir`.

Closes #287

## Test plan

- [x] `uv run pytest tests/unit` — 766 passed, 8 skipped
- [x] `uv run just lint` — pre-commit clean
- [ ] Manual: fresh install — `rm -rf $TMP && BLACKFISH_HOME_DIR=$TMP uv run blackfish init --auto --schema local …`; expect `app.sqlite`, `models/`, `images/`, `.blackfish_app_version` populated.
- [ ] Manual: re-run `init` after deleting only `.blackfish_app_version`; expect file recreated (regression for the old early-exit).
- [ ] Manual: seed `profiles.cfg` with a `type = local` section; run `init`; expect rewritten to `schema = local`.
- [ ] Manual: `rm -rf $TMP && BLACKFISH_HOME_DIR=$TMP uv run blackfish start`; expect bootstrap runs and server boots.