### PR TITLE
feat(lib): warn on `start` when no profiles are configured

### DIFF
--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -35,6 +35,24 @@ from blackfish.cli.classes import ServiceOptions
 DISPLAY_ID_LENGTH = 13
 
 
+def _warn_if_no_profiles(home_dir: str) -> None:
+    """Log a warning if `home_dir/profiles.cfg` has no profile sections.
+
+    A server with no profiles boots cleanly but cannot deploy any service —
+    surface the misconfig at startup rather than at first failed API call.
+    """
+    import configparser
+
+    profiles = configparser.ConfigParser()
+    profiles.read(os.path.join(home_dir, "profiles.cfg"))
+    if not profiles.sections():
+        logger.warning(
+            "No profiles configured. Run `blackfish init` or "
+            "`blackfish profile add` to register one. "
+            "Service deployment will fail until then."
+        )
+
+
 # blackfish
 @click.group()
 def main() -> None:  # pragma: no cover
@@ -218,6 +236,8 @@ def start(reload: bool) -> None:  # pragma: no cover
     from blackfish.server.bootstrap import bootstrap
 
     bootstrap(config.HOME_DIR)
+
+    _warn_if_no_profiles(config.HOME_DIR)
 
     # Check TigerFlow versions on Slurm profiles
     import asyncio

--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import rich_click as click
 from rich_click import Context
+import configparser
 import requests
 import os
 from yaspin import yaspin
@@ -41,8 +42,6 @@ def _warn_if_no_profiles(home_dir: str) -> None:
     A server with no profiles boots cleanly but cannot deploy any service —
     surface the misconfig at startup rather than at first failed API call.
     """
-    import configparser
-
     profiles = configparser.ConfigParser()
     profiles.read(os.path.join(home_dir, "profiles.cfg"))
     if not profiles.sections():
@@ -154,7 +153,6 @@ def init(
 
     from blackfish.server.bootstrap import bootstrap
     from blackfish.cli.profile import _auto_profile_, _create_profile_
-    import configparser
 
     bootstrap(app_dir)
 
@@ -241,7 +239,6 @@ def start(reload: bool) -> None:  # pragma: no cover
 
     # Check TigerFlow versions on Slurm profiles
     import asyncio
-    import configparser
     from blackfish.server.jobs.client import (
         TigerFlowClient,
         TigerFlowError,

--- a/lib/tests/cli/test_cli_start.py
+++ b/lib/tests/cli/test_cli_start.py
@@ -1,0 +1,30 @@
+import logging
+
+from blackfish.cli.__main__ import _warn_if_no_profiles
+
+
+def test_warn_if_no_profiles_emits_when_cfg_missing(tmp_path, caplog):
+    with caplog.at_level(logging.WARNING, logger="blackfish"):
+        _warn_if_no_profiles(str(tmp_path))
+
+    assert any("No profiles configured" in r.message for r in caplog.records)
+
+
+def test_warn_if_no_profiles_emits_when_cfg_empty(tmp_path, caplog):
+    (tmp_path / "profiles.cfg").write_text("")
+
+    with caplog.at_level(logging.WARNING, logger="blackfish"):
+        _warn_if_no_profiles(str(tmp_path))
+
+    assert any("No profiles configured" in r.message for r in caplog.records)
+
+
+def test_warn_if_no_profiles_silent_when_profile_exists(tmp_path, caplog):
+    (tmp_path / "profiles.cfg").write_text(
+        "[default]\nschema = local\nhome_dir = /tmp\ncache_dir = /tmp\n"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="blackfish"):
+        _warn_if_no_profiles(str(tmp_path))
+
+    assert not any("No profiles configured" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- Adds `_warn_if_no_profiles(home_dir)` in `cli/__main__.py`, called from `start` immediately after `bootstrap`. Logs a `WARNING` if `profiles.cfg` has no sections (or is missing entirely), pointing the user at `blackfish init` or `blackfish profile add`.
- Server still boots — this is a warn-and-proceed, matching the existing TigerFlow check pattern. A user starting the server before configuring a profile (e.g., to register one through a future UI/API) is still supported.
- Three tests in `tests/cli/test_cli_start.py` covering missing `profiles.cfg`, empty `profiles.cfg`, and a populated one.

Closes #303

## Test plan

- [x] `uv run pytest tests/cli/test_cli_start.py` — 3 passed
- [x] Manual: `rm -rf /tmp/bf && BLACKFISH_HOME_DIR=/tmp/bf uv run blackfish start` — warning fires, server starts.
- [x] Manual: same after `blackfish init --auto …` — no warning, server starts cleanly.