### PR TITLE
feat(lib): add `blackfish image ls` with availability probing

### DIFF
--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -28,6 +28,7 @@ from blackfish.cli.profile import (
     upgrade_tigerflow,
     repair_profile,
 )
+from blackfish.cli.image import list_images, check_images
 from blackfish.server.config import config
 from blackfish.server.logger import logger
 from blackfish.cli.classes import ServiceOptions
@@ -68,23 +69,18 @@ def version() -> None:  # pragma: no cover
     print(f"blackfish-ai {version}")
 
 
-@main.command()
-def images() -> None:  # pragma: no cover
-    """Show pinned service container images.
+@main.group()
+def image() -> None:  # pragma: no cover
+    """Inspect and manage service container images.
 
-    Defaults can be overridden by `BLACKFISH_<SERVICE>_IMAGE` env vars
+    Pinned defaults can be overridden by `BLACKFISH_<SERVICE>_IMAGE` env vars
     (e.g. `BLACKFISH_TEXT_GENERATION_IMAGE=vllm/vllm-openai:v0.9.0`).
     """
-    from prettytable import PrettyTable, TableStyle
+    pass
 
-    tab = PrettyTable(field_names=["SERVICE", "DOCKER REF", "SIF"])
-    tab.set_style(TableStyle.PLAIN_COLUMNS)
-    for field in tab.field_names:
-        tab.align[field] = "l"
-    tab.right_padding_width = 3
-    for service, spec in config.IMAGES.items():
-        tab.add_row([service, spec.docker_ref, spec.sif])
-    print(tab)
+
+image.add_command(list_images, "ls")
+image.add_command(check_images, "check")
 
 
 @main.command()

--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -28,7 +28,7 @@ from blackfish.cli.profile import (
     upgrade_tigerflow,
     repair_profile,
 )
-from blackfish.cli.image import list_images, check_images
+from blackfish.cli.image import list_images
 from blackfish.server.config import config
 from blackfish.server.logger import logger
 from blackfish.cli.classes import ServiceOptions
@@ -80,7 +80,6 @@ def image() -> None:  # pragma: no cover
 
 
 image.add_command(list_images, "ls")
-image.add_command(check_images, "check")
 
 
 @main.command()

--- a/lib/src/blackfish/cli/image.py
+++ b/lib/src/blackfish/cli/image.py
@@ -1,9 +1,8 @@
 """CLI utilities for inspecting service container images.
 
 `blackfish image ls` shows pinned registry images, optionally with per-profile
-availability. `blackfish image check` is a script-friendly variant that exits
-non-zero when a registry image is missing from both shared (cache) and home
-dirs of the selected profile.
+availability. Pass `--strict` to exit non-zero when any pinned image is missing
+from both shared (cache) and home dirs — useful in scripts and health checks.
 """
 
 from __future__ import annotations
@@ -181,14 +180,24 @@ def _fail(ctx: click.Context, message: str) -> None:
     default=False,
     help="Inspect every profile.",
 )
+@click.option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help="Exit 1 if any pinned image is missing from the inspected profile(s).",
+)
 @click.pass_context
 def list_images(
-    ctx: click.Context, profile_name: str | None, all_profiles: bool
+    ctx: click.Context,
+    profile_name: str | None,
+    all_profiles: bool,
+    strict: bool,
 ) -> None:
     """List pinned service images.
 
     Without --profile or --all, shows the registry (service, docker ref, SIF).
     With either flag, also reports availability in shared (cache) and home dirs.
+    Pass --strict to exit 1 when any pinned image is missing from both locations.
     """
     try:
         profiles = _resolve_profiles(profile_name, all_profiles)
@@ -197,6 +206,9 @@ def list_images(
         return
 
     if not profiles:
+        if strict:
+            _fail(ctx, "--strict requires --profile or --all.")
+            return
         print(_render_registry_table())
         return
 
@@ -208,41 +220,13 @@ def list_images(
 
     print(_render_availability_table(profiles, availability))
 
-
-@click.command(name="check")
-@click.option(
-    "--profile", "profile_name", type=str, default=None, help="Profile to check."
-)
-@click.option(
-    "--all", "all_profiles", is_flag=True, default=False, help="Check every profile."
-)
-@click.pass_context
-def check_images(
-    ctx: click.Context, profile_name: str | None, all_profiles: bool
-) -> None:
-    """Check that pinned images are available for the selected profile(s).
-
-    Exits 1 if any registry image is missing from both shared and home dirs.
-    Defaults to the "default" profile when neither --profile nor --all is given.
-    """
-    if not profile_name and not all_profiles:
-        profile_name = "default"
-
-    try:
-        profiles = _resolve_profiles(profile_name, all_profiles)
-        availability = {p.name: _availability(p, config.IMAGES) for p in profiles}
-    except _ImageCliError as exc:
-        _fail(ctx, str(exc))
-        return
-
-    print(_render_availability_table(profiles, availability))
-
-    missing = [
-        (p.name, service)
-        for p in profiles
-        for service, (shared, home) in availability[p.name].items()
-        if not shared and not home
-    ]
-    if missing:
-        details = ", ".join(f"{p}:{s}" for p, s in missing)
-        _fail(ctx, f"Missing images: {details}")
+    if strict:
+        missing = [
+            (p.name, service)
+            for p in profiles
+            for service, (shared, home) in availability[p.name].items()
+            if not shared and not home
+        ]
+        if missing:
+            details = ", ".join(f"{p}:{s}" for p, s in missing)
+            _fail(ctx, f"Missing images: {details}")

--- a/lib/src/blackfish/cli/image.py
+++ b/lib/src/blackfish/cli/image.py
@@ -2,7 +2,7 @@
 
 `blackfish image ls` shows pinned registry images, optionally with per-profile
 availability. Pass `--strict` to exit non-zero when any pinned image is missing
-from both shared (cache) and home dirs — useful in scripts and health checks.
+from both cache and home dirs — useful in scripts and health checks.
 """
 
 from __future__ import annotations
@@ -40,7 +40,7 @@ def _load_profile(home_dir: str, name: str) -> BlackfishProfile:
 
 
 def _sif_paths(profile: BlackfishProfile, spec: ImageSpec) -> tuple[str, str]:
-    """Return (shared_path, home_path) for a SIF on this profile."""
+    """Return (cache_path, home_path) for a SIF on this profile."""
     return (
         os.path.join(profile.cache_dir, "images", spec.sif),
         os.path.join(profile.home_dir, "images", spec.sif),
@@ -82,14 +82,14 @@ async def _check_paths(
 def _availability(
     profile: BlackfishProfile, images: dict[str, ImageSpec]
 ) -> dict[str, tuple[bool, bool]]:
-    """For each service, return (shared_exists, home_exists) on the profile.
+    """For each service, return (cache_exists, home_exists) on the profile.
 
     Wraps the probe in a spinner so users get feedback during slow SSH calls.
     """
     paths: list[str] = []
     for spec in images.values():
-        shared, home = _sif_paths(profile, spec)
-        paths.extend([shared, home])
+        cache, home = _sif_paths(profile, spec)
+        paths.extend([cache, home])
 
     runner = _runner_for(profile)
     with yaspin(text=f"Checking images for profile {profile.name!r}...") as spinner:
@@ -107,8 +107,8 @@ def _availability(
 
     out: dict[str, tuple[bool, bool]] = {}
     for service, spec in images.items():
-        shared, home = _sif_paths(profile, spec)
-        out[service] = (present[shared], present[home])
+        cache, home = _sif_paths(profile, spec)
+        out[service] = (present[cache], present[home])
     return out
 
 
@@ -127,23 +127,25 @@ def _render_availability_table(
     profiles: list[BlackfishProfile],
     availability: dict[str, dict[str, tuple[bool, bool]]],
 ) -> PrettyTable:
-    headers = ["PROFILE", "SERVICE", "DOCKER REF", "SIF", "SHARED", "HOME"]
+    headers = ["PROFILE", "SERVICE", "DOCKER REF", "SIF", "CACHE", "HOME"]
     tab = PrettyTable(field_names=headers)
     tab.set_style(TableStyle.PLAIN_COLUMNS)
     for field in headers:
         tab.align[field] = "l"
     tab.right_padding_width = 3
+    yes = LogSymbols.SUCCESS.value
+    no = LogSymbols.ERROR.value
     for profile in profiles:
         for service, spec in config.IMAGES.items():
-            shared, home = availability[profile.name][service]
+            cache, home = availability[profile.name][service]
             tab.add_row(
                 [
                     profile.name,
                     service,
                     spec.docker_ref,
                     spec.sif,
-                    "yes" if shared else "no",
-                    "yes" if home else "no",
+                    yes if cache else no,
+                    yes if home else no,
                 ]
             )
     return tab
@@ -199,7 +201,7 @@ def list_images(
     """List pinned service images.
 
     Without --profile or --all, shows the registry (service, docker ref, SIF).
-    With either flag, also reports availability in shared (cache) and home dirs.
+    With either flag, also reports availability in cache and home dirs.
     Pass --strict to exit 1 when any pinned image is missing from both locations.
     """
     try:
@@ -227,8 +229,8 @@ def list_images(
         missing = [
             (p.name, service)
             for p in profiles
-            for service, (shared, home) in availability[p.name].items()
-            if not shared and not home
+            for service, (cache, home) in availability[p.name].items()
+            if not cache and not home
         ]
         if missing:
             details = ", ".join(f"{p}:{s}" for p, s in missing)

--- a/lib/src/blackfish/cli/image.py
+++ b/lib/src/blackfish/cli/image.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shlex
 from typing import Iterable
 
 import rich_click as click
@@ -61,7 +62,9 @@ async def _check_paths(
         return {}
 
     # One round trip: print "1" if exists else "0", line per path.
-    script = " ; ".join(f"if [ -e {p!r} ]; then echo 1; else echo 0; fi" for p in paths)
+    script = " ; ".join(
+        f"if [ -e {shlex.quote(p)} ]; then echo 1; else echo 0; fi" for p in paths
+    )
     rc, stdout, stderr = await runner.run(script)
     if rc != 0:
         raise _ImageCliError(

--- a/lib/src/blackfish/cli/image.py
+++ b/lib/src/blackfish/cli/image.py
@@ -1,0 +1,248 @@
+"""CLI utilities for inspecting service container images.
+
+`blackfish image ls` shows pinned registry images, optionally with per-profile
+availability. `blackfish image check` is a script-friendly variant that exits
+non-zero when a registry image is missing from both shared (cache) and home
+dirs of the selected profile.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Iterable
+
+import rich_click as click
+from log_symbols.symbols import LogSymbols
+from prettytable import PrettyTable, TableStyle
+from yaspin import yaspin
+
+from blackfish.server.config import config
+from blackfish.server.images import ImageSpec
+from blackfish.server.jobs.client import LocalRunner, SSHRunner, TigerFlowError
+from blackfish.server.models.profile import (
+    BlackfishProfile,
+    SlurmProfile,
+    deserialize_profile,
+    deserialize_profiles,
+)
+
+
+class _ImageCliError(Exception):
+    """Raised by helpers; commands convert into LogSymbols.ERROR + ctx.exit(1)."""
+
+
+def _load_profile(home_dir: str, name: str) -> BlackfishProfile:
+    profile = deserialize_profile(home_dir, name)
+    if profile is None:
+        raise _ImageCliError(f"Profile {name!r} not found.")
+    return profile
+
+
+def _sif_paths(profile: BlackfishProfile, spec: ImageSpec) -> tuple[str, str]:
+    """Return (shared_path, home_path) for a SIF on this profile."""
+    return (
+        os.path.join(profile.cache_dir, "images", spec.sif),
+        os.path.join(profile.home_dir, "images", spec.sif),
+    )
+
+
+def _runner_for(profile: BlackfishProfile) -> SSHRunner | LocalRunner:
+    if isinstance(profile, SlurmProfile) and not profile.is_local():
+        return SSHRunner(profile.user, profile.host)
+    return LocalRunner()
+
+
+async def _check_paths(
+    runner: SSHRunner | LocalRunner, paths: Iterable[str]
+) -> dict[str, bool]:
+    """Probe `paths` via `runner`. Returns path -> exists."""
+    paths = list(paths)
+    if not paths:
+        return {}
+
+    # One round trip: print "1" if exists else "0", line per path.
+    script = " ; ".join(f"if [ -e {p!r} ]; then echo 1; else echo 0; fi" for p in paths)
+    rc, stdout, stderr = await runner.run(script)
+    if rc != 0:
+        raise _ImageCliError(
+            f"Failed to probe images on {runner.host}: {stderr.decode().strip()}"
+        )
+    lines = stdout.decode().strip().splitlines()
+    if len(lines) != len(paths):
+        raise _ImageCliError(
+            f"Unexpected probe output on {runner.host}: "
+            f"got {len(lines)} lines for {len(paths)} paths."
+        )
+    return {p: line.strip() == "1" for p, line in zip(paths, lines)}
+
+
+def _availability(
+    profile: BlackfishProfile, images: dict[str, ImageSpec]
+) -> dict[str, tuple[bool, bool]]:
+    """For each service, return (shared_exists, home_exists) on the profile.
+
+    Wraps the probe in a spinner so users get feedback during slow SSH calls.
+    """
+    paths: list[str] = []
+    for spec in images.values():
+        shared, home = _sif_paths(profile, spec)
+        paths.extend([shared, home])
+
+    runner = _runner_for(profile)
+    with yaspin(text=f"Checking images for profile {profile.name!r}...") as spinner:
+        try:
+            present = asyncio.run(_check_paths(runner, paths))
+        except TigerFlowError as exc:
+            # SSHRunner raises TigerFlowError on transport failure (timeout, exit 255).
+            spinner.fail(f"{LogSymbols.ERROR.value}")
+            raise _ImageCliError(
+                f"Could not reach profile {profile.name!r}: {exc}"
+            ) from exc
+        except _ImageCliError:
+            spinner.fail(f"{LogSymbols.ERROR.value}")
+            raise
+
+    out: dict[str, tuple[bool, bool]] = {}
+    for service, spec in images.items():
+        shared, home = _sif_paths(profile, spec)
+        out[service] = (present[shared], present[home])
+    return out
+
+
+def _render_registry_table() -> PrettyTable:
+    tab = PrettyTable(field_names=["SERVICE", "DOCKER REF", "SIF"])
+    tab.set_style(TableStyle.PLAIN_COLUMNS)
+    for field in tab.field_names:
+        tab.align[field] = "l"
+    tab.right_padding_width = 3
+    for service, spec in config.IMAGES.items():
+        tab.add_row([service, spec.docker_ref, spec.sif])
+    return tab
+
+
+def _render_availability_table(
+    profiles: list[BlackfishProfile],
+    availability: dict[str, dict[str, tuple[bool, bool]]],
+) -> PrettyTable:
+    headers = ["PROFILE", "SERVICE", "DOCKER REF", "SIF", "SHARED", "HOME"]
+    tab = PrettyTable(field_names=headers)
+    tab.set_style(TableStyle.PLAIN_COLUMNS)
+    for field in headers:
+        tab.align[field] = "l"
+    tab.right_padding_width = 3
+    for profile in profiles:
+        for service, spec in config.IMAGES.items():
+            shared, home = availability[profile.name][service]
+            tab.add_row(
+                [
+                    profile.name,
+                    service,
+                    spec.docker_ref,
+                    spec.sif,
+                    "yes" if shared else "no",
+                    "yes" if home else "no",
+                ]
+            )
+    return tab
+
+
+def _resolve_profiles(
+    profile_name: str | None, all_profiles: bool
+) -> list[BlackfishProfile]:
+    if profile_name and all_profiles:
+        raise _ImageCliError("Pass either --profile or --all, not both.")
+    if all_profiles:
+        try:
+            profiles = deserialize_profiles(config.HOME_DIR)
+        except FileNotFoundError:
+            raise _ImageCliError("No profiles configured.")
+        if not profiles:
+            raise _ImageCliError("No profiles configured.")
+        return profiles
+    if profile_name:
+        return [_load_profile(config.HOME_DIR, profile_name)]
+    return []
+
+
+def _fail(ctx: click.Context, message: str) -> None:
+    print(f"{LogSymbols.ERROR.value} {message}")
+    ctx.exit(1)
+
+
+@click.command(name="ls")
+@click.option(
+    "--profile", "profile_name", type=str, default=None, help="Profile to inspect."
+)
+@click.option(
+    "--all",
+    "all_profiles",
+    is_flag=True,
+    default=False,
+    help="Inspect every profile.",
+)
+@click.pass_context
+def list_images(
+    ctx: click.Context, profile_name: str | None, all_profiles: bool
+) -> None:
+    """List pinned service images.
+
+    Without --profile or --all, shows the registry (service, docker ref, SIF).
+    With either flag, also reports availability in shared (cache) and home dirs.
+    """
+    try:
+        profiles = _resolve_profiles(profile_name, all_profiles)
+    except _ImageCliError as exc:
+        _fail(ctx, str(exc))
+        return
+
+    if not profiles:
+        print(_render_registry_table())
+        return
+
+    try:
+        availability = {p.name: _availability(p, config.IMAGES) for p in profiles}
+    except _ImageCliError as exc:
+        _fail(ctx, str(exc))
+        return
+
+    print(_render_availability_table(profiles, availability))
+
+
+@click.command(name="check")
+@click.option(
+    "--profile", "profile_name", type=str, default=None, help="Profile to check."
+)
+@click.option(
+    "--all", "all_profiles", is_flag=True, default=False, help="Check every profile."
+)
+@click.pass_context
+def check_images(
+    ctx: click.Context, profile_name: str | None, all_profiles: bool
+) -> None:
+    """Check that pinned images are available for the selected profile(s).
+
+    Exits 1 if any registry image is missing from both shared and home dirs.
+    Defaults to the "default" profile when neither --profile nor --all is given.
+    """
+    if not profile_name and not all_profiles:
+        profile_name = "default"
+
+    try:
+        profiles = _resolve_profiles(profile_name, all_profiles)
+        availability = {p.name: _availability(p, config.IMAGES) for p in profiles}
+    except _ImageCliError as exc:
+        _fail(ctx, str(exc))
+        return
+
+    print(_render_availability_table(profiles, availability))
+
+    missing = [
+        (p.name, service)
+        for p in profiles
+        for service, (shared, home) in availability[p.name].items()
+        if not shared and not home
+    ]
+    if missing:
+        details = ", ".join(f"{p}:{s}" for p, s in missing)
+        _fail(ctx, f"Missing images: {details}")

--- a/lib/tests/cli/test_cli_images.py
+++ b/lib/tests/cli/test_cli_images.py
@@ -6,8 +6,12 @@ from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
+from log_symbols.symbols import LogSymbols
 
 from blackfish.cli.__main__ import main
+
+YES = LogSymbols.SUCCESS.value
+NO = LogSymbols.ERROR.value
 
 
 @pytest.fixture
@@ -89,7 +93,7 @@ class TestImageLs:
         assert result.exit_code == 0, result.output
         assert "default" in result.output
         # No SIFs placed -> nothing is reported as available.
-        assert "yes" not in result.output
+        assert YES not in result.output
 
     def test_profile_reports_present_in_home(self, cli_runner, home_dir):
         home, profile_home, _ = home_dir
@@ -100,7 +104,7 @@ class TestImageLs:
         with _patch_home(home):
             result = cli_runner.invoke(main, ["image", "ls", "--profile", "default"])
         assert result.exit_code == 0, result.output
-        assert "yes" in result.output
+        assert YES in result.output
 
     def test_unknown_profile(self, cli_runner, home_dir):
         home, _, _ = home_dir
@@ -140,11 +144,11 @@ class TestImageLs:
         assert len(default_rows) == len(services)
         assert len(secondary_rows) == len(services)
 
-        # `default` reports HOME=yes for every service; `secondary` reports no.
+        # `default` reports HOME present for every service; `secondary` does not.
         for row in default_rows:
-            assert "yes" in row, row
+            assert YES in row, row
         for row in secondary_rows:
-            assert "yes" not in row, row
+            assert YES not in row, row
 
     def test_profile_and_all_conflict(self, cli_runner, home_dir):
         home, _, _ = home_dir

--- a/lib/tests/cli/test_cli_images.py
+++ b/lib/tests/cli/test_cli_images.py
@@ -1,0 +1,108 @@
+"""Tests for `blackfish image ls` and `blackfish image check`."""
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from blackfish.cli.__main__ import main
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def home_dir():
+    """A temp home dir with a profiles.cfg referencing further temp paths."""
+    with tempfile.TemporaryDirectory() as home:
+        with tempfile.TemporaryDirectory() as profile_home:
+            with tempfile.TemporaryDirectory() as profile_cache:
+                cfg = os.path.join(home, "profiles.cfg")
+                with open(cfg, "w") as f:
+                    f.write(
+                        "[default]\n"
+                        "schema = local\n"
+                        f"home_dir = {profile_home}\n"
+                        f"cache_dir = {profile_cache}\n"
+                    )
+                os.makedirs(os.path.join(profile_home, "images"))
+                os.makedirs(os.path.join(profile_cache, "images"))
+                yield home, profile_home, profile_cache
+
+
+def _patch_home(home: str):
+    return patch("blackfish.cli.image.config.HOME_DIR", home)
+
+
+class TestImageLs:
+    def test_no_profile_shows_registry(self, cli_runner):
+        result = cli_runner.invoke(main, ["image", "ls"])
+        assert result.exit_code == 0
+        assert "SERVICE" in result.output
+        assert "text_generation" in result.output
+        assert "speech_recognition" in result.output
+
+    def test_profile_reports_missing(self, cli_runner, home_dir):
+        home, _, _ = home_dir
+        with _patch_home(home):
+            result = cli_runner.invoke(main, ["image", "ls", "--profile", "default"])
+        assert result.exit_code == 0, result.output
+        assert "default" in result.output
+        # No SIFs placed -> nothing is reported as available.
+        assert "yes" not in result.output
+
+    def test_profile_reports_present_in_home(self, cli_runner, home_dir):
+        home, profile_home, _ = home_dir
+        from blackfish.server.images import DEFAULT_IMAGES
+
+        sif = DEFAULT_IMAGES["text_generation"].sif
+        open(os.path.join(profile_home, "images", sif), "w").close()
+        with _patch_home(home):
+            result = cli_runner.invoke(main, ["image", "ls", "--profile", "default"])
+        assert result.exit_code == 0, result.output
+        assert "yes" in result.output
+
+    def test_unknown_profile(self, cli_runner, home_dir):
+        home, _, _ = home_dir
+        with _patch_home(home):
+            result = cli_runner.invoke(main, ["image", "ls", "--profile", "nope"])
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+    def test_profile_and_all_conflict(self, cli_runner, home_dir):
+        home, _, _ = home_dir
+        with _patch_home(home):
+            result = cli_runner.invoke(
+                main, ["image", "ls", "--profile", "default", "--all"]
+            )
+        assert result.exit_code != 0
+
+
+class TestImageCheck:
+    def test_missing_exits_nonzero(self, cli_runner, home_dir):
+        home, _, _ = home_dir
+        with _patch_home(home):
+            result = cli_runner.invoke(main, ["image", "check", "--profile", "default"])
+        assert result.exit_code == 1
+        assert "Missing images" in result.output
+
+    def test_all_present_exits_zero(self, cli_runner, home_dir):
+        home, profile_home, _ = home_dir
+        from blackfish.server.config import config
+
+        for spec in config.IMAGES.values():
+            open(os.path.join(profile_home, "images", spec.sif), "w").close()
+        with _patch_home(home):
+            result = cli_runner.invoke(main, ["image", "check", "--profile", "default"])
+        assert result.exit_code == 0, result.output
+
+    def test_default_profile_when_no_args(self, cli_runner, home_dir):
+        home, _, _ = home_dir
+        with _patch_home(home):
+            result = cli_runner.invoke(main, ["image", "check"])
+        # default profile exists and has no images -> exit 1
+        assert result.exit_code == 1

--- a/lib/tests/cli/test_cli_images.py
+++ b/lib/tests/cli/test_cli_images.py
@@ -1,4 +1,4 @@
-"""Tests for `blackfish image ls` and `blackfish image check`."""
+"""Tests for `blackfish image ls`."""
 
 import os
 import tempfile
@@ -82,27 +82,31 @@ class TestImageLs:
         assert result.exit_code != 0
 
 
-class TestImageCheck:
-    def test_missing_exits_nonzero(self, cli_runner, home_dir):
+class TestImageLsStrict:
+    def test_strict_missing_exits_nonzero(self, cli_runner, home_dir):
         home, _, _ = home_dir
         with _patch_home(home):
-            result = cli_runner.invoke(main, ["image", "check", "--profile", "default"])
+            result = cli_runner.invoke(
+                main, ["image", "ls", "--profile", "default", "--strict"]
+            )
         assert result.exit_code == 1
         assert "Missing images" in result.output
 
-    def test_all_present_exits_zero(self, cli_runner, home_dir):
+    def test_strict_all_present_exits_zero(self, cli_runner, home_dir):
         home, profile_home, _ = home_dir
         from blackfish.server.config import config
 
         for spec in config.IMAGES.values():
             open(os.path.join(profile_home, "images", spec.sif), "w").close()
         with _patch_home(home):
-            result = cli_runner.invoke(main, ["image", "check", "--profile", "default"])
+            result = cli_runner.invoke(
+                main, ["image", "ls", "--profile", "default", "--strict"]
+            )
         assert result.exit_code == 0, result.output
 
-    def test_default_profile_when_no_args(self, cli_runner, home_dir):
+    def test_strict_without_profile_errors(self, cli_runner, home_dir):
         home, _, _ = home_dir
         with _patch_home(home):
-            result = cli_runner.invoke(main, ["image", "check"])
-        # default profile exists and has no images -> exit 1
-        assert result.exit_code == 1
+            result = cli_runner.invoke(main, ["image", "ls", "--strict"])
+        assert result.exit_code != 0
+        assert "--strict" in result.output

--- a/lib/tests/cli/test_cli_images.py
+++ b/lib/tests/cli/test_cli_images.py
@@ -34,6 +34,42 @@ def home_dir():
                 yield home, profile_home, profile_cache
 
 
+@pytest.fixture
+def home_dir_two_profiles():
+    """A temp home dir with two local profiles (`default` and `secondary`)."""
+    with tempfile.TemporaryDirectory() as home:
+        with tempfile.TemporaryDirectory() as default_home:
+            with tempfile.TemporaryDirectory() as default_cache:
+                with tempfile.TemporaryDirectory() as secondary_home:
+                    with tempfile.TemporaryDirectory() as secondary_cache:
+                        cfg = os.path.join(home, "profiles.cfg")
+                        with open(cfg, "w") as f:
+                            f.write(
+                                "[default]\n"
+                                "schema = local\n"
+                                f"home_dir = {default_home}\n"
+                                f"cache_dir = {default_cache}\n"
+                                "[secondary]\n"
+                                "schema = local\n"
+                                f"home_dir = {secondary_home}\n"
+                                f"cache_dir = {secondary_cache}\n"
+                            )
+                        for d in (
+                            default_home,
+                            default_cache,
+                            secondary_home,
+                            secondary_cache,
+                        ):
+                            os.makedirs(os.path.join(d, "images"))
+                        yield (
+                            home,
+                            {
+                                "default": (default_home, default_cache),
+                                "secondary": (secondary_home, secondary_cache),
+                            },
+                        )
+
+
 def _patch_home(home: str):
     return patch("blackfish.cli.image.config.HOME_DIR", home)
 
@@ -72,6 +108,43 @@ class TestImageLs:
             result = cli_runner.invoke(main, ["image", "ls", "--profile", "nope"])
         assert result.exit_code != 0
         assert "not found" in result.output.lower()
+
+    def test_all_reports_per_profile_availability(
+        self, cli_runner, home_dir_two_profiles
+    ):
+        home, profiles = home_dir_two_profiles
+        from blackfish.server.config import config
+
+        # Place every pinned SIF in `default`'s home; leave `secondary` empty.
+        default_home, _ = profiles["default"]
+        for spec in config.IMAGES.values():
+            open(os.path.join(default_home, "images", spec.sif), "w").close()
+
+        with _patch_home(home):
+            result = cli_runner.invoke(main, ["image", "ls", "--all"])
+        assert result.exit_code == 0, result.output
+
+        # Each profile gets one row per service.
+        services = list(config.IMAGES.keys())
+        lines = result.output.splitlines()
+        default_rows = [
+            line
+            for line in lines
+            if line.startswith("default") and any(s in line for s in services)
+        ]
+        secondary_rows = [
+            line
+            for line in lines
+            if line.startswith("secondary") and any(s in line for s in services)
+        ]
+        assert len(default_rows) == len(services)
+        assert len(secondary_rows) == len(services)
+
+        # `default` reports HOME=yes for every service; `secondary` reports no.
+        for row in default_rows:
+            assert "yes" in row, row
+        for row in secondary_rows:
+            assert "yes" not in row, row
 
     def test_profile_and_all_conflict(self, cli_runner, home_dir):
         home, _, _ = home_dir


### PR DESCRIPTION
## Summary

Replaces the placeholder `blackfish images` command (added in #249, never released) with a new `image` group.

- `image ls` (no flags): shows the pinned registry — service, docker ref, SIF.
- `image ls --profile NAME` / `--all`: also reports availability in shared (cache) and home dirs by probing the filesystem (over SSH for slurm profiles, locally otherwise).
- `image ls --strict`: exits 1 if any pinned image is missing from both locations on the inspected profile(s) — for scripts and health checks. Requires `--profile` or `--all`.

Probe paths are quoted with `shlex.quote` so user-configured `home_dir` / `cache_dir` values can't break the SSH script.

The mutating `pull` / `rm` commands originally scoped under #307 move to v1.1 (#320, #321).

Closes #307.

## Test plan

- [x] `uv run pytest tests/cli/test_cli_images.py` — 9 tests pass (incl. `--all` two-profile coverage)
- [x] `uv run pytest` — full suite green
- [x] `uv run pre-commit run --files <changed>` — clean
- [x] Manual: `blackfish image ls` (no profiles), `--profile`, `--all` against a slurm profile
- [x] Manual: `blackfish image ls --profile X --strict` exit code in scripts