### PR TITLE
Show pulsing skeleton fields while job model and revision options are loading or refreshing

### DIFF
--- a/web/src/components/ModelSelect.jsx
+++ b/web/src/components/ModelSelect.jsx
@@ -12,15 +12,46 @@ import PropTypes from "prop-types";
 import { classNames, getUniqueRepoIds } from "@/lib/util";
 
 /**
- * Model Select component.
+ * Loading skeleton for select controls.
  * @param {object} options
- * @param {Function} options.setRepoId
- * @param {boolean} options.disabled
+ * @param {string} options.label
  * @return {JSX.Element}
  */
-function ModelSelect({ models, setRepoId, setModelId, disabled }) {
+function SelectSkeleton({ label }) {
+  return (
+    <Field disabled>
+      <Label className="block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">
+        {label}
+      </Label>
+      <div className="relative mt-2">
+        <div
+          aria-label={`${label} loading`}
+          aria-busy="true"
+          className="h-9 w-full animate-pulse rounded-md bg-gray-200 dark:bg-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600"
+        />
+      </div>
+    </Field>
+  );
+}
+
+SelectSkeleton.propTypes = {
+  label: PropTypes.string.isRequired,
+};
+
+/**
+ * Model Select component.
+ * @param {object} options
+ * @param {Array<object>} options.models
+ * @param {Function} options.setRepoId
+ * @param {Function} options.setModelId
+ * @param {boolean} options.disabled
+ * @param {boolean} options.isLoading
+ * @return {JSX.Element}
+ */
+function ModelSelect({ models, setRepoId, setModelId, disabled, isLoading = false }) {
 
   const [selected, setSelected] = useState(null);
+  const isDisabled = disabled || isLoading;
 
   // filter unique repo_ids
   const repos = getUniqueRepoIds(models);
@@ -50,20 +81,24 @@ function ModelSelect({ models, setRepoId, setModelId, disabled }) {
   }
 
   // handle errors and missingness
+  if (isLoading) {
+    return <SelectSkeleton label="Model" />;
+  }
+
   if (selected === null) {
     return <></>;
   }
 
   return (
-    <Field disabled={disabled}>
-      <Listbox value={selected} onChange={handleRepoChange}>
+    <Field disabled={isDisabled}>
+      <Listbox value={selected} onChange={handleRepoChange} disabled={isDisabled}>
         <Label className="block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">
           Model
         </Label>
             <div className="relative mt-2">
               <ListboxButton
                 className={classNames(
-                  disabled ? "bg-gray-100 dark:bg-gray-800 ring-gray-300 dark:ring-gray-600 ring-1" : "bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500",
+                  isDisabled ? "bg-gray-100 dark:bg-gray-800 ring-gray-300 dark:ring-gray-600 ring-1" : "bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500",
                   "relative w-full cursor-default rounded-md py-1.5 pl-1 pr-10 text-left text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 sm:text-sm sm:leading-6"
                 )}
               >
@@ -135,6 +170,7 @@ ModelSelect.propTypes = {
   setRepoId: PropTypes.func,
   setModelId: PropTypes.func,
   disabled: PropTypes.bool,
+  isLoading: PropTypes.bool,
 };
 
 export default ModelSelect;

--- a/web/src/components/ModelSelect.jsx
+++ b/web/src/components/ModelSelect.jsx
@@ -10,33 +10,7 @@ import {
 import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/20/solid";
 import PropTypes from "prop-types";
 import { classNames, getUniqueRepoIds } from "@/lib/util";
-
-/**
- * Loading skeleton for select controls.
- * @param {object} options
- * @param {string} options.label
- * @return {JSX.Element}
- */
-function SelectSkeleton({ label }) {
-  return (
-    <Field disabled>
-      <Label className="block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">
-        {label}
-      </Label>
-      <div className="relative mt-2">
-        <div
-          aria-label={`${label} loading`}
-          aria-busy="true"
-          className="h-9 w-full animate-pulse rounded-md bg-gray-200 dark:bg-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600"
-        />
-      </div>
-    </Field>
-  );
-}
-
-SelectSkeleton.propTypes = {
-  label: PropTypes.string.isRequired,
-};
+import SelectSkeleton from "@/components/SelectSkeleton";
 
 /**
  * Model Select component.
@@ -107,7 +81,7 @@ function ModelSelect({ models, setRepoId, setModelId, disabled, isLoading = fals
                     {selected.repo_id}
                   </span>
                 </span>
-                {!disabled &&
+                {!isDisabled &&
                   <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
                     <ChevronUpDownIcon
                       className="h-5 w-5 text-gray-400"

--- a/web/src/components/ModelSelect.test.jsx
+++ b/web/src/components/ModelSelect.test.jsx
@@ -190,4 +190,34 @@ describe("ModelSelect", () => {
       expect(mockSetRepoId).toHaveBeenCalledWith("model-3");
     });
   });
+
+  it("renders a loading skeleton when models are being fetched", () => {
+    const {container, getByText, queryByText} = render(
+      <ModelSelect
+        models={[]}
+        setRepoId={mockSetRepoId}
+        disabled={true}
+        isLoading={true}
+      />
+    );
+    expect(getByText("Model")).toBeInTheDocument();
+    expect(queryByText("Loading models...")).not.toBeInTheDocument();
+    expect(container.querySelector('[aria-busy="true"].animate-pulse')).toBeInTheDocument();
+  });
+
+  it("shows a loading skeleton over stale model options while refreshing", async () => {
+    const {container, queryByText} = render(
+      <ModelSelect
+        models={mockModels}
+        setRepoId={mockSetRepoId}
+        disabled={true}
+        isLoading={true}
+      />
+    );
+    await waitFor(() => {
+      expect(container.querySelector('[aria-busy="true"].animate-pulse')).toBeInTheDocument();
+      expect(queryByText("Loading models...")).not.toBeInTheDocument();
+      expect(queryByText("model-1")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/web/src/components/ModelSelect.test.jsx
+++ b/web/src/components/ModelSelect.test.jsx
@@ -205,7 +205,7 @@ describe("ModelSelect", () => {
     expect(container.querySelector('[aria-busy="true"].animate-pulse')).toBeInTheDocument();
   });
 
-  it("shows a loading skeleton over stale model options while refreshing", async () => {
+  it("shows a loading skeleton over stale model options while refreshing", () => {
     const {container, queryByText} = render(
       <ModelSelect
         models={mockModels}
@@ -214,10 +214,8 @@ describe("ModelSelect", () => {
         isLoading={true}
       />
     );
-    await waitFor(() => {
-      expect(container.querySelector('[aria-busy="true"].animate-pulse')).toBeInTheDocument();
-      expect(queryByText("Loading models...")).not.toBeInTheDocument();
-      expect(queryByText("model-1")).not.toBeInTheDocument();
-    });
+    expect(container.querySelector('[aria-busy="true"].animate-pulse')).toBeInTheDocument();
+    expect(queryByText("Loading models...")).not.toBeInTheDocument();
+    expect(queryByText("model-1")).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/RevisionSelect.jsx
+++ b/web/src/components/RevisionSelect.jsx
@@ -12,6 +12,33 @@ import PropTypes from "prop-types";
 import { classNames } from "@/lib/util";
 
 /**
+ * Loading skeleton for select controls.
+ * @param {object} options
+ * @param {string} options.label
+ * @return {JSX.Element}
+ */
+function SelectSkeleton({ label }) {
+  return (
+    <Field disabled>
+      <Label className="block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">
+        {label}
+      </Label>
+      <div className="relative mt-2">
+        <div
+          aria-label={`${label} loading`}
+          aria-busy="true"
+          className="h-9 w-full animate-pulse rounded-md bg-gray-200 dark:bg-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600"
+        />
+      </div>
+    </Field>
+  );
+}
+
+SelectSkeleton.propTypes = {
+  label: PropTypes.string.isRequired,
+};
+
+/**
  * Revision Select component.
  * @param {object} options
  * @param {Array<object>} options.models
@@ -20,11 +47,13 @@ import { classNames } from "@/lib/util";
  * @param {string} options.repoId
  * @param {Function} options.setModel
  * @param {boolean} options.disabled
+ * @param {boolean} options.isLoading
  * @return {JSX.Element}
  */
-function RevisionSelect({ models, repoId, setModel, disabled }) {
+function RevisionSelect({ models, repoId, setModel, disabled, isLoading = false }) {
 
   const [selected, setSelected] = useState(null);
+  const isDisabled = disabled || isLoading;
 
   // filter repo_id revisions
   const revisions = models.filter(model => model.repo_id === repoId);
@@ -52,20 +81,24 @@ function RevisionSelect({ models, repoId, setModel, disabled }) {
   }
 
   // handle errors and missingness
+  if (isLoading) {
+    return <SelectSkeleton label="Revision" />;
+  }
+
   if (selected === null) {
     return <></>;
   }
 
   return (
-    <Field disabled={disabled}>
-      <Listbox value={selected} onChange={handleRevisionChange}>
+    <Field disabled={isDisabled}>
+      <Listbox value={selected} onChange={handleRevisionChange} disabled={isDisabled}>
         <Label className="block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">
           Revision
         </Label>
             <div className="relative mt-2">
               <ListboxButton
                 className={classNames(
-                  disabled ? "bg-gray-100 dark:bg-gray-800 ring-gray-300 dark:ring-gray-600 ring-1" : "bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500",
+                  isDisabled ? "bg-gray-100 dark:bg-gray-800 ring-gray-300 dark:ring-gray-600 ring-1" : "bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500",
                   "relative w-full cursor-default rounded-md py-1.5 pl-1 pr-10 text-left text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 sm:text-sm sm:leading-6"
                 )}
               >
@@ -74,8 +107,7 @@ function RevisionSelect({ models, repoId, setModel, disabled }) {
                     {selected.revision}
                   </span>
                 </span>
-                {
-                  !disabled &&
+                {!disabled &&
                   <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
                     <ChevronUpDownIcon
                       className="h-5 w-5 text-gray-400"
@@ -139,6 +171,7 @@ RevisionSelect.propTypes = {
   repoId: PropTypes.string,
   setModel: PropTypes.func,
   disabled: PropTypes.bool,
+  isLoading: PropTypes.bool,
 };
 
 export default RevisionSelect;

--- a/web/src/components/RevisionSelect.jsx
+++ b/web/src/components/RevisionSelect.jsx
@@ -10,33 +10,7 @@ import {
 import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/20/solid";
 import PropTypes from "prop-types";
 import { classNames } from "@/lib/util";
-
-/**
- * Loading skeleton for select controls.
- * @param {object} options
- * @param {string} options.label
- * @return {JSX.Element}
- */
-function SelectSkeleton({ label }) {
-  return (
-    <Field disabled>
-      <Label className="block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">
-        {label}
-      </Label>
-      <div className="relative mt-2">
-        <div
-          aria-label={`${label} loading`}
-          aria-busy="true"
-          className="h-9 w-full animate-pulse rounded-md bg-gray-200 dark:bg-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600"
-        />
-      </div>
-    </Field>
-  );
-}
-
-SelectSkeleton.propTypes = {
-  label: PropTypes.string.isRequired,
-};
+import SelectSkeleton from "@/components/SelectSkeleton";
 
 /**
  * Revision Select component.
@@ -107,7 +81,7 @@ function RevisionSelect({ models, repoId, setModel, disabled, isLoading = false 
                     {selected.revision}
                   </span>
                 </span>
-                {!disabled &&
+                {!isDisabled &&
                   <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
                     <ChevronUpDownIcon
                       className="h-5 w-5 text-gray-400"

--- a/web/src/components/RevisionSelect.test.jsx
+++ b/web/src/components/RevisionSelect.test.jsx
@@ -44,4 +44,39 @@ describe("RevisionSelect", () => {
     );
     expect(baseElement).toMatchSnapshot();
   });
+
+  test("Loading", () => {
+    const {container, getByText, queryByText} = render(
+      <RevisionSelect
+        models={[]}
+        repoId="model-1"
+        setModel={(e) => e}
+        disabled={true}
+        isLoading={true}
+      />
+    );
+    expect(getByText("Revision")).toBeInTheDocument();
+    expect(queryByText("Loading revisions...")).not.toBeInTheDocument();
+    expect(container.querySelector('[aria-busy="true"].animate-pulse')).toBeInTheDocument();
+  });
+
+  test("Refreshing", () => {
+    const {container, queryByText} = render(
+      <RevisionSelect
+        models={[
+          {
+            repo_id: "model-1",
+            revision: "rev-1"
+          },
+        ]}
+        repoId="model-1"
+        setModel={(e) => e}
+        disabled={true}
+        isLoading={true}
+      />
+    );
+    expect(container.querySelector('[aria-busy="true"].animate-pulse')).toBeInTheDocument();
+    expect(queryByText("Loading revisions...")).not.toBeInTheDocument();
+    expect(queryByText("rev-1")).not.toBeInTheDocument();
+  });
 });

--- a/web/src/components/RevisionSelect.test.jsx
+++ b/web/src/components/RevisionSelect.test.jsx
@@ -1,9 +1,9 @@
 import { render } from "@testing-library/react";
-import { describe, test, expect } from "vitest";
+import { describe, it, expect } from "vitest";
 import RevisionSelect from "@/components/RevisionSelect";
 
 describe("RevisionSelect", () => {
-  test("Standard", () => {
+  it("Standard", () => {
     const {baseElement} = render(
       <RevisionSelect
         models={[
@@ -24,7 +24,7 @@ describe("RevisionSelect", () => {
     expect(baseElement).toMatchSnapshot();
   });
 
-  test("Disabled", () => {
+  it("Disabled", () => {
     const {baseElement} = render(
       <RevisionSelect
         models={[
@@ -45,7 +45,7 @@ describe("RevisionSelect", () => {
     expect(baseElement).toMatchSnapshot();
   });
 
-  test("Loading", () => {
+  it("Loading", () => {
     const {container, getByText, queryByText} = render(
       <RevisionSelect
         models={[]}
@@ -60,7 +60,7 @@ describe("RevisionSelect", () => {
     expect(container.querySelector('[aria-busy="true"].animate-pulse')).toBeInTheDocument();
   });
 
-  test("Refreshing", () => {
+  it("Refreshing", () => {
     const {container, queryByText} = render(
       <RevisionSelect
         models={[

--- a/web/src/components/SelectSkeleton.jsx
+++ b/web/src/components/SelectSkeleton.jsx
@@ -1,0 +1,31 @@
+import { Field, Label } from "@headlessui/react";
+import PropTypes from "prop-types";
+
+/**
+ * Loading skeleton for select controls.
+ * @param {object} options
+ * @param {string} options.label
+ * @return {JSX.Element}
+ */
+function SelectSkeleton({ label }) {
+  return (
+    <Field disabled>
+      <Label className="block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">
+        {label}
+      </Label>
+      <div className="relative mt-2">
+        <div
+          aria-label={`${label} loading`}
+          aria-busy="true"
+          className="h-9 w-full animate-pulse rounded-md bg-gray-200 dark:bg-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600"
+        />
+      </div>
+    </Field>
+  );
+}
+
+SelectSkeleton.propTypes = {
+  label: PropTypes.string.isRequired,
+};
+
+export default SelectSkeleton;

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -451,7 +451,13 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
   const [jobName, setJobName] = useState("");
 
   // Model selection - fetch models for the task's service type(s)
-  const { models, isLoading: modelsLoading, error: modelsError } = useModels(profile, task?.service);
+  const {
+    models,
+    isLoading: modelsLoading,
+    isRefreshing: modelsRefreshing,
+    error: modelsError,
+  } = useModels(profile, task?.service);
+  const modelsFetching = modelsLoading || modelsRefreshing;
   const [repoId, setRepoId] = useState(null);
   const [model, setModel] = useState(null);
 
@@ -805,7 +811,7 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
   const isStepValid = (stepId) => {
     switch (stepId) {
       case "model":
-        return repoId && !modelsLoading;
+        return repoId && !modelsFetching;
       case "options":
         // Check required params (including dynamically required ones based on model type)
         if (!task) return false;
@@ -877,7 +883,7 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
               <Alert variant="error" title="Failed to load models">
                 {modelsError.message || "Could not fetch models from the server."}
               </Alert>
-            ) : !modelsLoading && (!models || models.length === 0) ? (
+            ) : !modelsFetching && (!models || models.length === 0) ? (
               <Alert variant="warning" title="No models available">
                 Switch profiles or download a model from{" "}
                 <a className="underline" href="https://huggingface.co/models?pipeline_tag=text-generation&sort=trending">
@@ -891,7 +897,8 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
                     models={models || []}
                     repoId={repoId}
                     setRepoId={setRepoId}
-                    disabled={isSubmitting || modelsLoading}
+                    disabled={isSubmitting || modelsFetching}
+                    isLoading={modelsFetching}
                   />
                 </fieldset>
                 <fieldset>
@@ -899,12 +906,10 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
                     models={models || []}
                     repoId={repoId}
                     setModel={setModel}
-                    disabled={isSubmitting || modelsLoading}
+                    disabled={isSubmitting || modelsFetching}
+                    isLoading={modelsFetching}
                   />
                 </fieldset>
-                {modelsLoading && (
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Loading models...</p>
-                )}
               </>
             )}
           </div>


### PR DESCRIPTION
Instead of only showing "Loading models..." while job model and revision options are loading inside the "Jobs" panel, show a pulsing skeletion when loading OR refreshing. 