### PR TITLE
fix(lib): preserve quoting of vLLM extra args

### DIFF
--- a/lib/src/blackfish/cli/services/text_generation.py
+++ b/lib/src/blackfish/cli/services/text_generation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 from typing import Optional, Tuple
 import rich_click as click
 from rich_click import Context
@@ -150,7 +151,7 @@ def run_text_generation(
         port=port,
         model_dir=model_dir,
         revision=revision,
-        launch_kwargs=" ".join(ctx.args),
+        launch_kwargs=shlex.join(ctx.args),
     )
 
     job_config: JobConfig

--- a/lib/tests/cli/test_cli_run.py
+++ b/lib/tests/cli/test_cli_run.py
@@ -5,6 +5,7 @@ This module tests the CLI commands for running inference services:
 - `blackfish run speech-recognition` - Start a speech recognition service
 """
 
+import shlex
 import pytest
 from unittest.mock import patch, Mock, MagicMock
 from blackfish.cli.__main__ import main
@@ -396,6 +397,61 @@ class TestRunTextGeneration:
         assert "secret" in launch_kwargs
         assert "--seed" in launch_kwargs
         assert "42" in launch_kwargs
+
+    def test_extra_args_with_spaces_are_quoted(
+        self, cli_runner, mock_config, local_profile
+    ):
+        """Extra args containing spaces/JSON must round-trip through the shell."""
+        json_value = '{"enable_thinking": false, "thinking": false}'
+        cmd = [
+            "run",
+            "-p",
+            "default",
+            "text-generation",
+            "openai/gpt-2",
+            "--",
+            "--default-chat-template-kwargs",
+            json_value,
+        ]
+
+        with (
+            patch(
+                "blackfish.server.models.profile.deserialize_profile"
+            ) as mock_deserialize,
+            patch(
+                "blackfish.cli.services.text_generation.get_models"
+            ) as mock_get_models,
+            patch(
+                "blackfish.cli.services.text_generation.get_revisions"
+            ) as mock_get_revisions,
+            patch(
+                "blackfish.cli.services.text_generation.get_latest_commit"
+            ) as mock_get_latest,
+            patch(
+                "blackfish.cli.services.text_generation.get_model_dir"
+            ) as mock_get_model_dir,
+            patch("blackfish.cli.services.text_generation.requests.post") as mock_post,
+        ):
+            mock_deserialize.return_value = local_profile
+            mock_get_models.return_value = ["openai/gpt-2"]
+            mock_get_revisions.return_value = ["abc123"]
+            mock_get_latest.return_value = "abc123"
+            mock_get_model_dir.return_value = "/path/to/model"
+
+            mock_response = Mock()
+            mock_response.ok = True
+            mock_response.json.return_value = {"id": "service-uuid-123"}
+            mock_post.return_value = mock_response
+
+            cli_runner.invoke(main, cmd)
+
+        launch_kwargs = mock_post.call_args[1]["json"]["container_config"][
+            "launch_kwargs"
+        ]
+        assert shlex.split(launch_kwargs) == [
+            "--default-chat-template-kwargs",
+            json_value,
+        ]
 
     def test_no_revision_uses_latest(self, cli_runner, mock_config, local_profile):
         """Test that when no revision is provided, the latest commit is used."""

--- a/lib/tests/cli/test_cli_run.py
+++ b/lib/tests/cli/test_cli_run.py
@@ -402,7 +402,7 @@ class TestRunTextGeneration:
         self, cli_runner, mock_config, local_profile
     ):
         """Extra args containing spaces/JSON must round-trip through the shell."""
-        json_value = '{"enable_thinking": false, "thinking": false}'
+        json_value = '{"enable_thinking": false}'
         cmd = [
             "run",
             "-p",
@@ -443,8 +443,9 @@ class TestRunTextGeneration:
             mock_response.json.return_value = {"id": "service-uuid-123"}
             mock_post.return_value = mock_response
 
-            cli_runner.invoke(main, cmd)
+            result = cli_runner.invoke(main, cmd)
 
+        assert result.exit_code == 0, result.output
         launch_kwargs = mock_post.call_args[1]["json"]["container_config"][
             "launch_kwargs"
         ]


### PR DESCRIPTION
## Summary

- `blackfish run text-generation` joined `ctx.args` with a plain space, so JSON values like `--default-chat-template-kwargs '{"enable_thinking": false}'` rendered as bare braces in the launch script and the shell mangled them.
- Switched to `shlex.join` so any extra arg containing spaces or shell metacharacters survives intact.
- Added a CLI test that round-trips a JSON arg through `shlex.split` to confirm the quoting holds.

This is a prerequisite for testing the upcoming vLLM bump on Qwen3 with thinking disabled.

## Test plan

- [x] `uv run just lint`
- [x] `uv run just test` (802 passed)
- [x] Manual: `blackfish run text-generation <model> --default-chat-template-kwargs '{"enable_thinking": false}' --dry-run` shows quoted JSON in the rendered script.