### PR TITLE
refactor(web): show skeleton in service launch modal while models load

### DIFF
--- a/web/src/components/RevisionSelect.jsx
+++ b/web/src/components/RevisionSelect.jsx
@@ -30,11 +30,11 @@ function RevisionSelect({ models, repoId, setModel, disabled, isLoading = false 
   const isDisabled = disabled || isLoading;
 
   // filter repo_id revisions
-  const revisions = models.filter(model => model.repo_id === repoId);
+  const revisions = (models ?? []).filter(model => model.repo_id === repoId);
 
   // update selection on revisions refresh
   useEffect(() => {
-    const revisions = models.filter(model => model.repo_id === repoId);
+    const revisions = (models ?? []).filter(model => model.repo_id === repoId);
     if (revisions && revisions.length > 0) {
       setSelected(revisions[0])
     } else {

--- a/web/src/components/ServiceLauncher.jsx
+++ b/web/src/components/ServiceLauncher.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { RocketLaunchIcon } from "@heroicons/react/24/outline";
 import ServiceModal from "@/components/ServiceModal";
-import { useModels } from "@/lib/loaders";
 import PropTypes from "prop-types";
 
 /**
@@ -21,7 +20,6 @@ function ServiceLauncher({
   open: controlledOpen,
   setOpen: controlledSetOpen,
 }) {
-  const { models, isLoading } = useModels(profile, task)
   const [internalOpen, setInternalOpen] = React.useState(false);
   const open = controlledOpen ?? internalOpen;
   const setOpen = controlledSetOpen ?? setInternalOpen;
@@ -41,7 +39,7 @@ function ServiceLauncher({
         onClick={() => {
           setOpen(true);
         }}
-        disabled={!profile || (!models && isLoading)}
+        disabled={!profile}
         aria-label="Launch service"
       >
         <RocketLaunchIcon className="h-5 w-5" />

--- a/web/src/components/ServiceLauncher.test.jsx
+++ b/web/src/components/ServiceLauncher.test.jsx
@@ -5,14 +5,10 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import ServiceLauncher from "@/components/ServiceLauncher";
 import { ServiceContext } from "@/providers/ServiceProvider";
-import { useModels, useServices } from "@/lib/loaders";
+import { useServices } from "@/lib/loaders";
 
 // Mock the hooks
 vi.mock("@/lib/loaders", () => ({
-  useModels: vi.fn(() => ({
-    models: [{ id: "test-model", name: "Test Model" }],
-    isLoading: false
-  })),
   useServices: vi.fn(() => ({
     services: [],
     mutate: vi.fn()
@@ -46,11 +42,6 @@ function testComponent() {
 describe("ServiceLauncher", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset useModels to default
-    vi.mocked(useModels).mockReturnValue({
-      models: [{ id: "test-model", name: "Test Model" }],
-      isLoading: false
-    });
     vi.mocked(useServices).mockReturnValue({
       services: [],
       mutate: vi.fn()
@@ -87,12 +78,8 @@ describe("ServiceLauncher", () => {
     expect(baseElement).toMatchSnapshot();
   });
 
-  it("renders in enabled state when missing models and not loading", () => {
-    vi.mocked(useModels).mockReturnValueOnce({
-      models: undefined,
-      isLoading: false
-    });
-    const {baseElement} = render(
+  it("stays enabled while models are loading", () => {
+    const {getByLabelText} = render(
       <ServiceContext.Provider value={mockServiceContext}>
         <ServiceLauncher
           profile={{
@@ -105,28 +92,7 @@ describe("ServiceLauncher", () => {
         />
       </ServiceContext.Provider>
     );
-    expect(baseElement).toMatchSnapshot();
-  });
-
-  it("renders in disabled state when missing models and loading", () => {
-    vi.mocked(useModels).mockReturnValueOnce({
-      models: undefined,
-      isLoading: true
-    });
-    const {baseElement} = render(
-      <ServiceContext.Provider value={mockServiceContext}>
-        <ServiceLauncher
-          profile={{
-            host: "localhost",
-            type: "local"
-          }}
-          task="speech-recognition"
-          defaultContainerOptions={{testProp: "yes"}}
-          ContainerOptionsFormComponent={testComponent}
-        />
-      </ServiceContext.Provider>
-    );
-    expect(baseElement).toMatchSnapshot();
+    expect(getByLabelText("Launch service")).not.toBeDisabled();
   });
 
   it("renders container component", () => {

--- a/web/src/components/ServiceModal.jsx
+++ b/web/src/components/ServiceModal.jsx
@@ -104,7 +104,10 @@ function ServiceModal({
   } = useServices(profile, task);
   const {
     models,
+    isLoading: modelsLoading,
+    isRefreshing: modelsRefreshing,
   } = useModels(profile, task);
+  const modelsFetching = modelsLoading || modelsRefreshing;
   const {
     status: clusterStatus,
   } = useClusterStatus(profile);
@@ -274,6 +277,7 @@ function ServiceModal({
                   <form className="mt-2">
                       <ServiceModalForm
                         models={models}
+                        modelsFetching={modelsFetching}
                         services={services}
                         setModel={setModel}
                         jobOptions={jobOptions}
@@ -305,7 +309,7 @@ function ServiceModal({
                       type="button"
                       className="w-28 inline-flex justify-center items-center gap-2 rounded-md bg-blue-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:bg-gray-300 dark:disabled:bg-gray-600"
                       onClick={handleFormSubmit}
-                      disabled={!isDeepEmpty(validationErrors) || isLaunching}
+                      disabled={!isDeepEmpty(validationErrors) || isLaunching || modelsFetching || !model}
                     >
                       {isLaunching ? (
                         <>

--- a/web/src/components/ServiceModal.jsx
+++ b/web/src/components/ServiceModal.jsx
@@ -105,9 +105,7 @@ function ServiceModal({
   const {
     models,
     isLoading: modelsLoading,
-    isRefreshing: modelsRefreshing,
   } = useModels(profile, task);
-  const modelsFetching = modelsLoading || modelsRefreshing;
   const {
     status: clusterStatus,
   } = useClusterStatus(profile);
@@ -277,7 +275,7 @@ function ServiceModal({
                   <form className="mt-2">
                       <ServiceModalForm
                         models={models}
-                        modelsFetching={modelsFetching}
+                        modelsLoading={modelsLoading}
                         services={services}
                         setModel={setModel}
                         jobOptions={jobOptions}
@@ -309,7 +307,7 @@ function ServiceModal({
                       type="button"
                       className="w-28 inline-flex justify-center items-center gap-2 rounded-md bg-blue-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:bg-gray-300 dark:disabled:bg-gray-600"
                       onClick={handleFormSubmit}
-                      disabled={!isDeepEmpty(validationErrors) || isLaunching || modelsFetching || !model}
+                      disabled={!isDeepEmpty(validationErrors) || isLaunching || !model}
                     >
                       {isLaunching ? (
                         <>

--- a/web/src/components/ServiceModal.jsx
+++ b/web/src/components/ServiceModal.jsx
@@ -102,6 +102,7 @@ function ServiceModal({
     services,
     mutate: mutateServices
   } = useServices(profile, task);
+  // Using isLoading instead of isValidating to avoid loading state on revalidations
   const {
     models,
     isLoading: modelsLoading,
@@ -275,7 +276,7 @@ function ServiceModal({
                   <form className="mt-2">
                       <ServiceModalForm
                         models={models}
-                        modelsLoading={modelsLoading}
+                        isModelsLoading={modelsLoading}
                         services={services}
                         setModel={setModel}
                         jobOptions={jobOptions}

--- a/web/src/components/ServiceModal.test.jsx
+++ b/web/src/components/ServiceModal.test.jsx
@@ -212,6 +212,19 @@ describe("ServiceModal", () => {
       const {getByText} = renderServiceModal({ isLaunching: true });
       expect(getByText("Launching").closest("button")).toBeDisabled();
     });
+
+    it("disables Launch button while no model is selected", () => {
+      useModels.mockReturnValue({ models: [], isLoading: true });
+      const {getByText} = renderServiceModal();
+      expect(getByText("Launch")).toBeDisabled();
+    });
+
+    it("enables Launch button once a model is selected", async () => {
+      const user = userEvent.setup();
+      const {getByText, getByTestId} = renderServiceModal();
+      await user.click(getByTestId("set-model-button"));
+      expect(getByText("Launch")).not.toBeDisabled();
+    });
   });
 
   describe("Launch Error State", () => {

--- a/web/src/components/ServiceModalForm.jsx
+++ b/web/src/components/ServiceModalForm.jsx
@@ -24,7 +24,7 @@ const parseTime = (time) => {
 
 function ServiceModalForm({
   models,
-  modelsFetching = false,
+  modelsLoading = false,
   services,
   setModel,
   jobOptions,
@@ -316,7 +316,7 @@ function ServiceModalForm({
         />
       </fieldset>
 
-      {modelsFetching || (models && models.length) ? (
+      {modelsLoading || (models && models.length) ? (
         <div className="space-y-3">
           <fieldset>
             <ModelSelect
@@ -325,7 +325,7 @@ function ServiceModalForm({
               setRepoId={setRepoId}
               setModelId={setModelId}
               disabled={disabled}
-              isLoading={modelsFetching}
+              isLoading={modelsLoading}
             />
           </fieldset>
 
@@ -335,7 +335,7 @@ function ServiceModalForm({
               repoId={repoId}
               setModel={setModel}
               disabled={disabled}
-              isLoading={modelsFetching}
+              isLoading={modelsLoading}
             />
           </fieldset>
         </div>
@@ -541,7 +541,7 @@ function ServiceModalForm({
 
 ServiceModalForm.propTypes = {
   models: PropTypes.array,
-  modelsFetching: PropTypes.bool,
+  modelsLoading: PropTypes.bool,
   services: PropTypes.array,
   setModel: PropTypes.func,
   jobOptions: PropTypes.object,

--- a/web/src/components/ServiceModalForm.jsx
+++ b/web/src/components/ServiceModalForm.jsx
@@ -24,6 +24,7 @@ const parseTime = (time) => {
 
 function ServiceModalForm({
   models,
+  modelsFetching = false,
   services,
   setModel,
   jobOptions,
@@ -315,7 +316,7 @@ function ServiceModalForm({
         />
       </fieldset>
 
-      {models && models.length ? (
+      {modelsFetching || (models && models.length) ? (
         <div className="space-y-3">
           <fieldset>
             <ModelSelect
@@ -324,6 +325,7 @@ function ServiceModalForm({
               setRepoId={setRepoId}
               setModelId={setModelId}
               disabled={disabled}
+              isLoading={modelsFetching}
             />
           </fieldset>
 
@@ -333,6 +335,7 @@ function ServiceModalForm({
               repoId={repoId}
               setModel={setModel}
               disabled={disabled}
+              isLoading={modelsFetching}
             />
           </fieldset>
         </div>
@@ -538,6 +541,7 @@ function ServiceModalForm({
 
 ServiceModalForm.propTypes = {
   models: PropTypes.array,
+  modelsFetching: PropTypes.bool,
   services: PropTypes.array,
   setModel: PropTypes.func,
   jobOptions: PropTypes.object,

--- a/web/src/components/ServiceModalForm.jsx
+++ b/web/src/components/ServiceModalForm.jsx
@@ -24,7 +24,7 @@ const parseTime = (time) => {
 
 function ServiceModalForm({
   models,
-  modelsLoading = false,
+  isModelsLoading = false,
   services,
   setModel,
   jobOptions,
@@ -316,7 +316,7 @@ function ServiceModalForm({
         />
       </fieldset>
 
-      {modelsLoading || (models && models.length) ? (
+      {isModelsLoading || (models && models.length) ? (
         <div className="space-y-3">
           <fieldset>
             <ModelSelect
@@ -325,7 +325,7 @@ function ServiceModalForm({
               setRepoId={setRepoId}
               setModelId={setModelId}
               disabled={disabled}
-              isLoading={modelsLoading}
+              isLoading={isModelsLoading}
             />
           </fieldset>
 
@@ -335,7 +335,7 @@ function ServiceModalForm({
               repoId={repoId}
               setModel={setModel}
               disabled={disabled}
-              isLoading={modelsLoading}
+              isLoading={isModelsLoading}
             />
           </fieldset>
         </div>
@@ -541,7 +541,7 @@ function ServiceModalForm({
 
 ServiceModalForm.propTypes = {
   models: PropTypes.array,
-  modelsLoading: PropTypes.bool,
+  isModelsLoading: PropTypes.bool,
   services: PropTypes.array,
   setModel: PropTypes.func,
   jobOptions: PropTypes.object,

--- a/web/src/components/__snapshots__/ServiceLauncher.test.jsx.snap
+++ b/web/src/components/__snapshots__/ServiceLauncher.test.jsx.snap
@@ -44,51 +44,6 @@ exports[`ServiceLauncher > opens the modal 1`] = `
 </body>
 `;
 
-exports[`ServiceLauncher > renders in disabled state when missing models and loading 1`] = `
-<body>
-  <div>
-    <button
-      aria-label="Launch service"
-      class="p-1.5 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-700 disabled:text-gray-300 dark:disabled:text-gray-600 disabled:hover:bg-transparent focus:outline-none"
-      disabled=""
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        class="h-5 w-5"
-        data-slot="icon"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="1.5"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        />
-      </svg>
-    </button>
-    <div
-      data-testid="service-modal"
-    >
-      <fieldset>
-        <legend>
-          Legend
-        </legend>
-        <p>
-          Service deployment.
-        </p>
-        <input
-          type="text"
-        />
-      </fieldset>
-    </div>
-  </div>
-</body>
-`;
-
 exports[`ServiceLauncher > renders in disabled state when missing profile 1`] = `
 <body>
   <div>
@@ -96,50 +51,6 @@ exports[`ServiceLauncher > renders in disabled state when missing profile 1`] = 
       aria-label="Launch service"
       class="p-1.5 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-700 disabled:text-gray-300 dark:disabled:text-gray-600 disabled:hover:bg-transparent focus:outline-none"
       disabled=""
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        class="h-5 w-5"
-        data-slot="icon"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="1.5"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        />
-      </svg>
-    </button>
-    <div
-      data-testid="service-modal"
-    >
-      <fieldset>
-        <legend>
-          Legend
-        </legend>
-        <p>
-          Service deployment.
-        </p>
-        <input
-          type="text"
-        />
-      </fieldset>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`ServiceLauncher > renders in enabled state when missing models and not loading 1`] = `
-<body>
-  <div>
-    <button
-      aria-label="Launch service"
-      class="p-1.5 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-700 disabled:text-gray-300 dark:disabled:text-gray-600 disabled:hover:bg-transparent focus:outline-none"
       type="button"
     >
       <svg

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -451,13 +451,12 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
   const [jobName, setJobName] = useState("");
 
   // Model selection - fetch models for the task's service type(s)
+  // Using isLoading instead of isValidating to avoid loading state on revalidations
   const {
     models,
     isLoading: modelsLoading,
-    isRefreshing: modelsRefreshing,
     error: modelsError,
   } = useModels(profile, task?.service);
-  const modelsFetching = modelsLoading || modelsRefreshing;
   const [repoId, setRepoId] = useState(null);
   const [model, setModel] = useState(null);
 
@@ -811,7 +810,7 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
   const isStepValid = (stepId) => {
     switch (stepId) {
       case "model":
-        return repoId && !modelsFetching;
+        return repoId && !modelsLoading;
       case "options":
         // Check required params (including dynamically required ones based on model type)
         if (!task) return false;
@@ -883,7 +882,7 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
               <Alert variant="error" title="Failed to load models">
                 {modelsError.message || "Could not fetch models from the server."}
               </Alert>
-            ) : !modelsFetching && (!models || models.length === 0) ? (
+            ) : !modelsLoading && (!models || models.length === 0) ? (
               <Alert variant="warning" title="No models available">
                 Switch profiles or download a model from{" "}
                 <a className="underline" href="https://huggingface.co/models?pipeline_tag=text-generation&sort=trending">
@@ -897,8 +896,8 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
                     models={models || []}
                     repoId={repoId}
                     setRepoId={setRepoId}
-                    disabled={isSubmitting || modelsFetching}
-                    isLoading={modelsFetching}
+                    disabled={isSubmitting || modelsLoading}
+                    isLoading={modelsLoading}
                   />
                 </fieldset>
                 <fieldset>
@@ -906,8 +905,8 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
                     models={models || []}
                     repoId={repoId}
                     setModel={setModel}
-                    disabled={isSubmitting || modelsFetching}
-                    isLoading={modelsFetching}
+                    disabled={isSubmitting || modelsLoading}
+                    isLoading={modelsLoading}
                   />
                 </fieldset>
               </>


### PR DESCRIPTION
## Summary

- Match the batch-jobs UX in the service launch modal: launch button stays enabled regardless of model fetch state, and `ModelSelect`/`RevisionSelect` render the skeleton while the initial fetch is in flight.
- Submit stays disabled until a model is selected (so the user can't launch before the list arrives).
- Only the *initial* `useModels` load triggers the skeleton — SWR background revalidations (window focus, reconnect) are silent so alt-tabbing doesn't flicker the dropdowns.
- Guard `RevisionSelect` against `undefined` models so it can render before the fetch settles.

## Test plan

- [x] `npm run lint` (no new warnings)
- [x] `npm test` (290 passing)
- [x] Manually launch a service with a slow profile: confirm the launch button is immediately clickable, the modal opens with pulsing skeletons, and the dropdowns settle into populated selects without flicker.
- [x] Alt-tab away from the browser and back while the modal is open: confirm no skeleton flash on revalidation.
- [x] Open the modal against a profile with zero models: confirm the "no models available" warning still shows once the fetch settles.