### PR TITLE
chore(lib): bump vLLM image to v0.20.0 for Qwen3 family

### DIFF
--- a/lib/docs/contrib/developer_guide.md
+++ b/lib/docs/contrib/developer_guide.md
@@ -47,10 +47,10 @@ These commands create a secure public-private key pair and send the public key t
 Services deployed on HPC systems need to be run by Apptainer instead of Docker. Apptainer will not run Docker images directly. Instead, you need to convert Docker images to SIF files. For images hosted on Docker Hub, running `apptainer pull` will do this automatically. For example,
 
 ```shell
-apptainer pull docker://vllm/vllm-openai:v0.10.2
+apptainer pull docker://vllm/vllm-openai:<version>
 ```
 
-This command generates a file `vllm-openai_v0.10.2.sif`. In order for users to access the image, it should be moved to a shared cache directory, e.g., `/shared/.blackfish/images`.
+(Run `blackfish image ls` to see the version Blackfish currently pins.) This command generates a file `vllm-openai_<version>.sif`. In order for users to access the image, it should be moved to a shared cache directory, e.g., `/shared/.blackfish/images`.
 
 ## API Development
 

--- a/lib/docs/setup/management.md
+++ b/lib/docs/setup/management.md
@@ -31,12 +31,13 @@ Let's consider what happens when a user launches a service from their laptop tar
 
 ## Images
 
-Blackfish does **not** ship with the container images required to run services. These images should be downloaded before running services[^1]. The current required images are:
+Blackfish does **not** ship with the container images required to run services. These images should be downloaded before running services[^1]. To see the images required by your installed version of Blackfish, run:
 
-- Text generation: `vllm/vllm-openai:v0.10.2`
-- Speech recognition: `princeton-ddss/speech-recognition-inference:0.1.2`
+```shell
+blackfish image ls
+```
 
-These images are expected to change over time, so be sure to check release notes for updates.
+This lists each service's pinned image and whether it is available in the configured cache. Pinned versions change over time as Blackfish releases bump the underlying runtimes.
 
 ### Obtaining Images
 

--- a/lib/src/blackfish/server/images.py
+++ b/lib/src/blackfish/server/images.py
@@ -44,7 +44,7 @@ class ImageSpec:
 
 
 DEFAULT_IMAGES: dict[str, ImageSpec] = {
-    "text_generation": ImageSpec(repo="vllm/vllm-openai", tag="v0.10.2"),
+    "text_generation": ImageSpec(repo="vllm/vllm-openai", tag="v0.20.0"),
     "speech_recognition": ImageSpec(
         repo="ghcr.io/princeton-ddss/speech-recognition-inference",
         tag="0.1.2",


### PR DESCRIPTION
Closes #322

## Summary

- Bump the pinned `vllm/vllm-openai` image from v0.10.2 to v0.20.0, which adds support for the Qwen3 model family.
- Replace hardcoded version references in user-facing docs with pointers to `blackfish image ls` (introduced in #308) so the docs no longer go stale on every bump. `DEFAULT_IMAGES` in [lib/src/blackfish/server/images.py](lib/src/blackfish/server/images.py) is now the single source of truth for the pinned version.

## Test plan

- [x] `uv run just lint`
- [x] `uv run just test` (802 passed)
- [x] Verified Qwen3 (`Qwen/Qwen3.5-27B`) launches successfully on the new image with thinking disabled via `--default-chat-template-kwargs`. Quoting note: nested double quotes inside the JSON value need to be backslash-escaped (e.g. `'{\"enable_thinking\": false}'`) because the apptainer runscript double-evaluates its args. Tracked separately for later cleanup.