### PR TITLE
feat(web): add Disable Thinking toggle for text-generation launches

### DIFF
--- a/web/src/lib/requests.js
+++ b/web/src/lib/requests.js
@@ -124,6 +124,23 @@ export async function deleteProfile(name) {
   return res.json();
 }
 
+/**
+ * Translate UI-only container option flags into backend fields. Currently:
+ * `disable_thinking` becomes `--default-chat-template-kwargs '{...}'` appended
+ * to `launch_kwargs`. The UI flag itself is stripped from the returned object.
+ */
+function buildContainerConfig(containerConfig) {
+  const { disable_thinking, launch_kwargs, ...rest } = containerConfig;
+  if (!disable_thinking) {
+    return launch_kwargs !== undefined ? { ...rest, launch_kwargs } : rest;
+  }
+  const flag = `--default-chat-template-kwargs '{"enable_thinking": false, "thinking": false}'`;
+  return {
+    ...rest,
+    launch_kwargs: launch_kwargs ? `${launch_kwargs} ${flag}` : flag,
+  };
+}
+
 /** Start an service to perform the specified ML/AI pipeline. */
 export async function runService(pipeline, model, jobConfig, containerConfig, profile) {
   let body;
@@ -134,7 +151,7 @@ export async function runService(pipeline, model, jobConfig, containerConfig, pr
       repo_id: model.repo_id,
       profile: profile,
       container_config: {
-        ...containerConfig,
+        ...buildContainerConfig(containerConfig),
         revision: model.revision,
         model_dir: pipeline === "speech-recognition"
           ? dirname(model.model_dir)
@@ -159,7 +176,7 @@ export async function runService(pipeline, model, jobConfig, containerConfig, pr
       repo_id: model.repo_id,
       profile: profile,
       container_config: {
-        ...containerConfig,
+        ...buildContainerConfig(containerConfig),
         revision: model.revision,
         model_dir: pipeline === "speech-recognition"
           ? dirname(model.model_dir)

--- a/web/src/lib/requests.js
+++ b/web/src/lib/requests.js
@@ -126,18 +126,15 @@ export async function deleteProfile(name) {
 
 /**
  * Translate UI-only container option flags into backend fields. Currently:
- * `disable_thinking` becomes `--default-chat-template-kwargs '{...}'` appended
- * to `launch_kwargs`. The UI flag itself is stripped from the returned object.
+ * `disable_thinking` becomes `launch_kwargs: --default-chat-template-kwargs '{...}'`.
+ * The UI flag itself is stripped from the returned object.
  */
-function buildContainerConfig(containerConfig) {
-  const { disable_thinking, launch_kwargs, ...rest } = containerConfig;
-  if (!disable_thinking) {
-    return launch_kwargs !== undefined ? { ...rest, launch_kwargs } : rest;
-  }
-  const flag = `--default-chat-template-kwargs '{"enable_thinking": false, "thinking": false}'`;
+export function buildContainerConfig(containerConfig) {
+  const { disable_thinking, ...rest } = containerConfig;
+  if (!disable_thinking) return rest;
   return {
     ...rest,
-    launch_kwargs: launch_kwargs ? `${launch_kwargs} ${flag}` : flag,
+    launch_kwargs: `--default-chat-template-kwargs '{"enable_thinking": false, "thinking": false}'`,
   };
 }
 

--- a/web/src/lib/requests.test.js
+++ b/web/src/lib/requests.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { buildContainerConfig } from "@/lib/requests";
+
+describe("buildContainerConfig", () => {
+  it("strips disable_thinking when false and adds no launch_kwargs", () => {
+    const out = buildContainerConfig({
+      disable_thinking: false,
+      disable_custom_kernels: false,
+      input_dir: "/data",
+    });
+    expect(out).toEqual({
+      disable_custom_kernels: false,
+      input_dir: "/data",
+    });
+    expect(out).not.toHaveProperty("disable_thinking");
+    expect(out).not.toHaveProperty("launch_kwargs");
+  });
+
+  it("translates disable_thinking=true into launch_kwargs and strips the flag", () => {
+    const out = buildContainerConfig({
+      disable_thinking: true,
+      disable_custom_kernels: false,
+    });
+    expect(out).not.toHaveProperty("disable_thinking");
+    expect(out.launch_kwargs).toBe(
+      `--default-chat-template-kwargs '{"enable_thinking": false, "thinking": false}'`
+    );
+    expect(out.disable_custom_kernels).toBe(false);
+  });
+});

--- a/web/src/routes/text-generation/components/TextGenerationContainerOptionsForm.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationContainerOptionsForm.jsx
@@ -28,7 +28,7 @@ function TextGenerationContainerOptionsForm({
           )}
         </button>
         {expanded && (
-          <div className="mt-3">
+          <div className="mt-3 space-y-3">
             <ServiceModalCheckbox
               checked={containerOptions.disable_custom_kernels}
               onChange={() => setContainerOptions(prevContainerOptions => {
@@ -39,6 +39,18 @@ function TextGenerationContainerOptionsForm({
               })}
               label="Disable Custom Kernels"
               help="Disables custom CUDA kernels that may not work on all devices."
+              disabled={disabled}
+            />
+            <ServiceModalCheckbox
+              checked={containerOptions.disable_thinking}
+              onChange={() => setContainerOptions(prevContainerOptions => {
+                return {
+                  ...prevContainerOptions,
+                  disable_thinking: !prevContainerOptions.disable_thinking,
+                };
+              })}
+              label="Disable Thinking"
+              help="Disables thinking/reasoning output for models that support it."
               disabled={disabled}
             />
           </div>

--- a/web/src/routes/text-generation/components/TextGenerationContainerOptionsForm.test.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationContainerOptionsForm.test.jsx
@@ -1,0 +1,63 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import TextGenerationContainerOptionsForm from "./TextGenerationContainerOptionsForm";
+
+const defaultOptions = {
+  disable_custom_kernels: false,
+  disable_thinking: true,
+};
+
+function renderForm({ containerOptions = defaultOptions, setContainerOptions = vi.fn(), disabled = false } = {}) {
+  return {
+    setContainerOptions,
+    ...render(
+      <TextGenerationContainerOptionsForm
+        containerOptions={containerOptions}
+        setContainerOptions={setContainerOptions}
+        disabled={disabled}
+      />
+    ),
+  };
+}
+
+// Find the checkbox <input> nearest to a label's text. ServiceModalCheckbox
+// doesn't wire htmlFor/id, so getByLabelText doesn't work.
+function checkboxFor(container, labelText) {
+  const label = Array.from(container.querySelectorAll("label")).find(
+    (el) => el.textContent === labelText
+  );
+  return label.closest("div.relative").querySelector("input[type='checkbox']");
+}
+
+describe("TextGenerationContainerOptionsForm", () => {
+  it("hides the toggles until Deployment Options is expanded", async () => {
+    const user = userEvent.setup();
+    const { getByText, container, queryByText } = renderForm();
+    expect(queryByText("Disable Thinking")).not.toBeInTheDocument();
+    await user.click(getByText("Deployment Options"));
+    expect(checkboxFor(container, "Disable Thinking")).toBeInTheDocument();
+    expect(checkboxFor(container, "Disable Custom Kernels")).toBeInTheDocument();
+  });
+
+  it("renders Disable Thinking checked when disable_thinking is true", async () => {
+    const user = userEvent.setup();
+    const { getByText, container } = renderForm();
+    await user.click(getByText("Deployment Options"));
+    expect(checkboxFor(container, "Disable Thinking")).toBeChecked();
+  });
+
+  it("flips disable_thinking when the checkbox is clicked", async () => {
+    const user = userEvent.setup();
+    const setContainerOptions = vi.fn();
+    const { getByText, container } = renderForm({ setContainerOptions });
+    await user.click(getByText("Deployment Options"));
+    await user.click(checkboxFor(container, "Disable Thinking"));
+    expect(setContainerOptions).toHaveBeenCalledTimes(1);
+    const updater = setContainerOptions.mock.calls[0][0];
+    expect(updater(defaultOptions)).toEqual({
+      ...defaultOptions,
+      disable_thinking: false,
+    });
+  });
+});

--- a/web/src/routes/text-generation/text-generation.jsx
+++ b/web/src/routes/text-generation/text-generation.jsx
@@ -200,6 +200,7 @@ export default function TextGenerationPage() {
   const defaultContainerOptions = useMemo(() => {
     return {
       disable_custom_kernels: false,
+      disable_thinking: true,
     };
   }, []);
 


### PR DESCRIPTION
Refs #326

## Summary

- Adds a "Disable thinking" checkbox under Deployment Options in the text-generation launch modal. When checked (default), the launch injects `--default-chat-template-kwargs '{"enable_thinking": false, "thinking": false}'` into `launch_kwargs` so reasoning models like Qwen3 emit final content directly without `<think>` blocks. Both keys are sent intentionally to cover the per-family kwarg name differences (Qwen3 uses `enable_thinking`, Granite/DeepSeek-V3.1 use `thinking`); keys not referenced by a model's chat template are silently ignored.
- Defaulting to off-thinking matches the immediate user need — this PR is a minimal step toward broader reasoning-model support tracked in #326. A future curated table will replace the manual override with model-aware defaults.
- Cleans up `buildContainerConfig` (drops a dead `launch_kwargs` merge branch that the UI never set) and exports it for unit testing. New tests cover the toggle's default-on state, click behavior, and the kwarg translation.

## Test plan

- [x] `npm run lint` (1 pre-existing warning in `ImageAttachment.jsx`, unrelated)
- [x] `npm test` (297 passed)
- [x] Manual: launch a Qwen3 service from the UI with the toggle on; confirm the rendered job script includes the kwargs flag and the model returns content without `<think>` blocks.