### PR TITLE
fix(lib): bypass apptainer runscript arg re-evaluation

### DIFF
--- a/lib/src/blackfish/server/templates/text_generation_local.sh
+++ b/lib/src/blackfish/server/templates/text_generation_local.sh
@@ -11,6 +11,7 @@ docker run -d {{ '--runtime nvidia --gpus all' if job_config.gres else '' }} \
   --revision {{ container_config.revision }} \
   --trust-remote-code \
 {%- elif provider == 'apptainer' %}
+export SINGULARITY_NO_EVAL=1
 apptainer instance run {{ ' --nv' if job_config.gres > 0 else '' }} \
   --bind {{ container_config.model_dir }}:/data \
   {{ profile.cache_dir }}/images/{{ image.sif }} \

--- a/lib/src/blackfish/server/templates/text_generation_slurm.sh
+++ b/lib/src/blackfish/server/templates/text_generation_slurm.sh
@@ -1,5 +1,6 @@
 {% extends "base_slurm.sh" %}
 {% block command %}
+export SINGULARITY_NO_EVAL=1
 apptainer run {{ '--nv' if job_config.gres else '' }} \
   --bind {{ container_config.model_dir }}:/data \
   {{ profile.cache_dir }}/images/{{ image.sif }} \


### PR DESCRIPTION
## Summary

- vLLM's apptainer-generated runscript wraps each arg in escaped double quotes and re-evaluates the result via `eval` before exec'ing the entrypoint, which strips inner double quotes from JSON values like `--default-chat-template-kwargs '{"enable_thinking": false}'` and corrupts them. Setting `SINGULARITY_NO_EVAL=1` selects the OCI-compatible code path that exec's args directly without re-evaluation.
- Applied to both apptainer-using launch templates: `text_generation_slurm.sh` and the apptainer branch of `text_generation_local.sh`.
- Unblocks passing JSON kwargs (and any other arg containing shell metacharacters) without manual `\"` escaping. Prerequisite for #332's "Disable thinking" toggle to ship as-is.

## Test plan

- [x] `uv run just lint`
- [x] `uv run just test` (802 passed)
- [x] Manual: confirmed Qwen3 launches successfully on the cluster with `--default-chat-template-kwargs '{"enable_thinking": false, "thinking": false}'` (no escaped inner quotes).