### PR TITLE
Release v1.0.0a4

### DIFF
--- a/lib/.pre-commit-config.yaml
+++ b/lib/.pre-commit-config.yaml
@@ -25,17 +25,17 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.21.1
+    rev: v2.21.2
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.10
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.1
+    rev: v1.20.2
     hooks:
       - id: mypy
         files: ^(lib/src/)

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "blackfish-ai"
-version = "1.0.0a3"
+version = "1.0.0a4"
 description = "An open-source AI-as-a-Service platform."
 readme = "README.md"
 license = "MIT"

--- a/lib/uv.lock
+++ b/lib/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blackfish-ai"
-version = "1.0.0a3"
+version = "1.0.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blackfish-ui",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blackfish-ui",
-      "version": "1.0.0-alpha.3",
+      "version": "1.0.0-alpha.4",
       "dependencies": {
         "@headlessui/react": "^2.1",
         "@heroicons/react": "^2.0.18",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blackfish-ui",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "private": true,
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Bumps Blackfish to **v1.0.0a4** (lib `1.0.0a4`, web `1.0.0-alpha.4`). Also rolls forward pre-commit hook pins (pyproject-fmt, ruff, mypy) that have drifted since the last release.

### Highlights since v1.0.0a3

- **Reasoning model groundwork:** Disable Thinking toggle in the UI (#332), apptainer arg-quoting fixes (#327, #333), vLLM bump to v0.20.0 unlocking the Qwen3 family (#330).
- **Image management:** `blackfish image ls` with availability probing (#308); `DEFAULT_IMAGES` is now the single source of truth for service image pinnings (#306).
- **Setup robustness:** Versioned bootstrap for the app dir on init/start (#304); warn on `start` when no profiles are configured (#305); TigerFlow setup fails fast on venv collisions (#281).
- **UI polish:** Skeleton loaders in launch modals (#325, #329); dark-mode color fixes (#324); batch job modal validation (#282); profile persistence (#283).

## Test plan

- [x] `cd lib && uv run just lint`
- [x] `cd lib && uv run just test` (802 passed)
- [x] `cd web && npm run lint` (1 pre-existing warning in `ImageAttachment.jsx`, unrelated)
- [x] `cd web && npm test` (297 passed)
- [x] Manual smoke test on the cluster: Qwen3 launch via Disable Thinking toggle, `blackfish image ls`, `blackfish start` with no profiles configured.