### PR TITLE
feat: explicit default flag for profiles (#316)

### DIFF
--- a/lib/docs/assets/img/coverage.svg
+++ b/lib/docs/assets/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">67%</text>
-        <text x="80" y="14">67%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">61%</text>
+        <text x="80" y="14">61%</text>
     </g>
 </svg>

--- a/lib/docs/usage/cli.md
+++ b/lib/docs/usage/cli.md
@@ -34,10 +34,13 @@ Blackfish's primary function is to launch services that perform AI tasks. These 
 Every profile specifies a number of attributes that allow Blackfish to find resources (e.g., model
 files) and deploy services accordingly. The exact attributes depend on the profile *schema*. There are currently two profile schemas: Slurm and Local. All profiles require the following attributes:
 
-- `name`: a unique profile name. The profile named "default" is used by Blackfish when a profile isn't
-explicitly provided.
+- `name`: a unique profile name. Profiles can be named freely.
 - `schema`: one of "slurm" or "local". The profile schema determines how services associated with this
 profile are deployed by Blackfish. Use "slurm" if this profile will run jobs on an HPC cluster (via a Slurm job scheduler) and "local" to run services on your laptop.
+- `default`: an optional boolean. Exactly one profile is the *default*, used by Blackfish whenever a
+profile isn't explicitly provided. The default is the profile with `default = true`; for backward
+compatibility, a profile literally named "default" is treated as the default if no profile sets the
+flag. Use `blackfish profile default <name>` to change it.
 
 The additional attribute requirements for specific types are listed below.
 
@@ -79,7 +82,8 @@ blackfish profile add
 ```
 
 and following the prompts (see attribute descriptions above). Note that profile names
-are unique.
+are unique. The first profile you create becomes the default automatically;
+subsequent profiles do not change the default.
 
 #### show - View a profile
 
@@ -103,6 +107,18 @@ blackfish profile update --name <profile>
 
 This command updates the default profile if no `--name` is specified. Note that you cannot change
 the `name` or `schema` attributes of a profile.
+
+#### default - Set the default profile
+
+To change which profile is the default, use the `blackfish profile default` command, e.g.
+
+```shell
+blackfish profile default <profile>
+```
+
+This marks `<profile>` as the default and clears the flag from every other profile—exactly one
+profile is the default at a time. The default profile is shown with a `(default)` marker in
+`blackfish profile ls`.
 
 #### upgrade - Upgrade TigerFlow
 
@@ -134,16 +150,29 @@ This recreates the profile's directories and reinstalls TigerFlow.
 
 #### rm - Delete a profile
 
-To delete a profile, type `blackfish profile rm --name <profile>`. By default, the command
+To delete a profile, type `blackfish profile rm --name <profile>`. The command
 requires you to confirm before deleting.
 
 ```shell
 blackfish profile rm --name <profile>
 ```
 
+Blackfish refuses to delete the default profile. Set another profile as the default first
+(`blackfish profile default <other>`), or pass `--force` to delete it anyway:
+
+```shell
+blackfish profile rm --name <profile> --force
+```
+
 !!! note
 
     Deleting a profile does not remove its remote resources (e.g., models, images, or job files in `home_dir` or `cache_dir`). These may be shared with other profiles and should be cleaned up manually if no longer needed.
+
+!!! warning
+
+    Force-deleting the default profile leaves Blackfish without an explicitly flagged default. It
+    will fall back to a profile named "default" or, failing that, the first profile listed—set a new
+    default explicitly to avoid surprises.
 
 ## Services
 

--- a/lib/docs/usage/ui.md
+++ b/lib/docs/usage/ui.md
@@ -144,8 +144,9 @@ when a Slurm profile is selected.
     - Click **Create**.
 - **To edit a profile**: click :heroicons-pencil: on the row; the same
   form appears pre-filled with every field editable except Name.
-- **To delete a profile**: click :heroicons-trash:. The `default` profile
-  is protected and cannot be deleted.
+- **To delete a profile**: click :heroicons-trash:. The default profile
+  is protected and cannot be deleted from the UI — change the default
+  first (currently via the CLI: `blackfish profile default <name>`).
 
 #### Hugging Face
 

--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -27,7 +27,10 @@ from blackfish.cli.profile import (
     delete_profile,
     upgrade_tigerflow,
     repair_profile,
+    set_default_profile,
+    resolve_profile_or_exit,
 )
+from blackfish.server.models.profile import get_default_profile_name
 from blackfish.cli.image import list_images
 from blackfish.server.config import config
 from blackfish.server.logger import logger
@@ -151,9 +154,8 @@ def init(
 
     bootstrap(app_dir)
 
-    profiles = configparser.ConfigParser()
-    profiles.read(f"{app_dir}/profiles.cfg")
-    if "default" not in profiles:
+    existing_default = get_default_profile_name(app_dir)
+    if existing_default is None:
         success = False
         if auto and schema:
             success = _auto_profile_(
@@ -171,7 +173,10 @@ def init(
         if success:
             print("🎉 All done—let's fish!")
     else:
-        print(f"{LogSymbols.SUCCESS.value} Default profile already exists.")
+        print(
+            f"{LogSymbols.SUCCESS.value} Default profile '{existing_default}' already"
+            " exists."
+        )
         print("🎉 Looks good—let's fish!")
 
 
@@ -195,6 +200,7 @@ profile.add_command(delete_profile, "rm")
 profile.add_command(update_profile, "update")
 profile.add_command(upgrade_tigerflow, "upgrade")
 profile.add_command(repair_profile, "repair")
+profile.add_command(set_default_profile, "default")
 
 
 @main.command()
@@ -360,7 +366,11 @@ def start(reload: bool) -> None:  # pragma: no cover
     help="The Slurm account to charge resources to.",
 )
 @click.option(
-    "--profile", "-p", type=str, default="default", help="The Blackfish profile to use."
+    "--profile",
+    "-p",
+    type=str,
+    default=None,
+    help="The Blackfish profile to use (defaults to the default profile).",
 )
 @click.option(
     "--mount", "-m", type=str, default=None, help="An optional directory to mount."
@@ -382,7 +392,7 @@ def run(
     partition: Optional[str],
     constraint: Optional[str],
     account: Optional[str],
-    profile: str,
+    profile: Optional[str],
     mount: Optional[str],
     grace_period: int,
 ) -> None:  # pragma: no cover
@@ -392,6 +402,8 @@ def run(
     """
 
     from blackfish.server.models.profile import deserialize_profile
+
+    profile = resolve_profile_or_exit(config.HOME_DIR, profile)
 
     ctx.obj = {
         "config": config,
@@ -832,8 +844,8 @@ def models_ls(
     "--profile",
     type=str,
     required=False,
-    default="default",
-    help="Add model to the given profile (default: 'default').",
+    default=None,
+    help="Add model to the given profile (defaults to the default profile).",
 )
 @click.option(
     "-r",
@@ -857,7 +869,7 @@ def models_ls(
     ),
 )
 def models_add(
-    repo_id: str, profile: str, revision: Optional[str], use_cache: bool
+    repo_id: str, profile: Optional[str], revision: Optional[str], use_cache: bool
 ) -> None:
     """Download a model to make it available.
 
@@ -867,6 +879,7 @@ def models_add(
     from blackfish.server.models.model import add_model
     from blackfish.server.models.profile import deserialize_profile, SlurmProfile
 
+    profile = resolve_profile_or_exit(config.HOME_DIR, profile)
     matched = deserialize_profile(config.HOME_DIR, profile)
     if matched is None:
         click.echo(
@@ -926,8 +939,8 @@ def models_add(
     "--profile",
     type=str,
     required=False,
-    default="default",
-    help="Remove model from the given profile (default: 'default').",
+    default=None,
+    help="Remove model from the given profile (defaults to the default profile).",
 )
 @click.option(
     "-r",
@@ -951,13 +964,14 @@ def models_add(
     ),
 )
 def models_remove(
-    repo_id: str, profile: str, revision: Optional[str], use_cache: bool
+    repo_id: str, profile: Optional[str], revision: Optional[str], use_cache: bool
 ) -> None:
     """Remove model files."""
 
     from blackfish.server.models.model import remove_model
     from blackfish.server.models.profile import deserialize_profile, SlurmProfile
 
+    profile = resolve_profile_or_exit(config.HOME_DIR, profile)
     matched = deserialize_profile(config.HOME_DIR, profile)
     if matched is None:
         click.echo(

--- a/lib/src/blackfish/cli/batch.py
+++ b/lib/src/blackfish/cli/batch.py
@@ -26,6 +26,7 @@ from blackfish.server.jobs.tasks import (
     get_default_input_ext,
     is_supported_task,
 )
+from blackfish.cli.profile import resolve_profile_or_exit
 from blackfish.server.models.profile import deserialize_profile
 from blackfish.server.utils import (
     format_datetime,
@@ -407,8 +408,8 @@ def remove_batch_job(
     "--profile",
     "-p",
     type=str,
-    default="default",
-    help="Blackfish profile to use.",
+    default=None,
+    help="Blackfish profile to use (defaults to the default profile).",
 )
 @click.option(
     "--input-dir",
@@ -464,7 +465,7 @@ def run_batch_job(
     name: str,
     task: str,
     model: str,
-    profile: str,
+    profile: Optional[str],
     input_dir: str,
     output_dir: str,
     revision: Optional[str],
@@ -480,7 +481,8 @@ def run_batch_job(
     writing results to OUTPUT_DIR. Jobs are managed by TigerFlow on the cluster.
     """
 
-    # 1. Validate profile exists
+    # 1. Validate profile exists (falling back to the default)
+    profile = resolve_profile_or_exit(config.HOME_DIR, profile)
     matched_profile = deserialize_profile(config.HOME_DIR, profile)
     if matched_profile is None:
         click.echo(

--- a/lib/src/blackfish/cli/profile.py
+++ b/lib/src/blackfish/cli/profile.py
@@ -9,7 +9,14 @@ from log_symbols.symbols import LogSymbols
 from yaspin import yaspin
 
 from blackfish.server.setup import ProfileManager, ProfileSetupError
-from blackfish.server.models.profile import SlurmProfile, LocalProfile
+from blackfish.server.models.profile import (
+    SlurmProfile,
+    LocalProfile,
+    get_default_profile_name,
+    has_any_default,
+    section_is_default,
+    set_exclusive_default,
+)
 from blackfish.server.jobs.client import (
     TigerFlowClient,
     TigerFlowError,
@@ -193,6 +200,24 @@ class ProfileType(StrEnum):
     Local = "local"
 
 
+def resolve_profile_or_exit(home_dir: str, profile: Optional[str]) -> str:
+    """Return ``profile`` if provided, else the resolved default profile name.
+
+    Exits the process with code 1 if no profile is given and none is configured.
+    Intended for CLI commands whose ``--profile`` option falls back to the default.
+    """
+    if profile is not None:
+        return profile
+    resolved = get_default_profile_name(home_dir)
+    if resolved is None:
+        print(
+            f"{LogSymbols.ERROR.value} No profiles configured. Run"
+            " `blackfish profile add` to register one."
+        )
+        raise SystemExit(1)
+    return resolved
+
+
 def _create_profile_(app_dir: str, default_name: str = "default") -> bool:
     profiles = configparser.ConfigParser()
     profiles.read(f"{app_dir}/profiles.cfg")
@@ -288,6 +313,11 @@ def _create_profile_(app_dir: str, default_name: str = "default") -> bool:
             "home_dir": home_dir,
             "cache_dir": cache_dir,
         }
+
+    if not has_any_default(profiles):
+        profiles[name]["default"] = "true"
+    else:
+        profiles[name]["default"] = "false"
 
     with open(os.path.join(app_dir, "profiles.cfg"), "w") as f:
         profiles.write(f)
@@ -403,6 +433,11 @@ def _auto_profile_(
             "cache_dir": profile.cache_dir,
         }
 
+    if not has_any_default(profiles):
+        profiles[profile.name]["default"] = "true"
+    else:
+        profiles[profile.name]["default"] = "false"
+
     with open(os.path.join(app_dir, "profiles.cfg"), "w") as f:
         profiles.write(f)
         print(f"{LogSymbols.SUCCESS.value} Created profile '{profile.name}'.")
@@ -418,6 +453,8 @@ def _update_profile_(
     if name is None:
         name = input(f"> name [{default_name}]: ")
         name = default_name if name == "" else name
+
+    was_default = name in profiles and section_is_default(profiles, name)
 
     if name not in profiles:
         print(
@@ -502,6 +539,8 @@ def _update_profile_(
     else:
         raise NotImplementedError
 
+    profiles[name]["default"] = "true" if was_default else "false"
+
     with open(os.path.join(default_home, "profiles.cfg"), "w") as f:
         profiles.write(f)
         print(f"{LogSymbols.SUCCESS.value} Updated profile {name}.")
@@ -520,16 +559,26 @@ def create_profile(ctx: Context) -> None:  # pragma: no cover
 
 @click.command()
 @click.option(
-    "--name", type=str, default="default", help="The name of the profile to display."
+    "--name",
+    type=str,
+    default=None,
+    help="The name of the profile to display (defaults to the default profile).",
 )
 @click.pass_context
-def show_profile(ctx: Context, name: str) -> None:  # pragma: no cover
+def show_profile(ctx: Context, name: str | None) -> None:  # pragma: no cover
     """Display a profile."""
 
     default_home = ctx.obj.get("home_dir")
 
     profiles = configparser.ConfigParser()
     profiles.read(f"{default_home}/profiles.cfg")
+
+    if name is None:
+        name = get_default_profile_name(default_home)
+        if name is None:
+            print(f"{LogSymbols.ERROR.value} No profiles configured.")
+            ctx.exit(1)
+            return
 
     if name in profiles:
         profile = profiles[name]
@@ -565,13 +614,16 @@ def list_profiles(ctx: Context) -> None:  # pragma: no cover
     profiles = configparser.ConfigParser()
     profiles.read(f"{default_home}/profiles.cfg")
 
+    default_name = get_default_profile_name(default_home)
+
     for name in profiles:
         profile = profiles[name]
         if profile.name == "DEFAULT":
             continue
         schema = profile.get("schema") or profile.get("type")
+        marker = " (default)" if name == default_name else ""
         if schema == "slurm":
-            print(f"[{name}]")
+            print(f"[{name}]{marker}")
             print("schema: slurm")
             print(f"host: {profile['host']}")
             print(f"user: {profile['user']}")
@@ -580,7 +632,7 @@ def list_profiles(ctx: Context) -> None:  # pragma: no cover
             python_path = profile.get("python_path", "python3")
             print(f"python_path: {python_path}")
         elif schema == "local":
-            print(f"[{name}]")
+            print(f"[{name}]{marker}")
             print("schema: local")
             print(f"home: {profile['home_dir']}")
             print(f"cache: {profile['cache_dir']}")
@@ -607,10 +659,16 @@ def update_profile(ctx: Context, name: str) -> None:  # pragma: no cover
 
 @click.command()
 @click.option(
-    "--name", type=str, default="default", help="The name of the profile to delete."
+    "--name", type=str, required=True, help="The name of the profile to delete."
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Allow deleting the default profile; another must be set as default first.",
 )
 @click.pass_context
-def delete_profile(ctx: Context, name: str) -> None:  # pragma: no cover
+def delete_profile(ctx: Context, name: str, force: bool) -> None:  # pragma: no cover
     """Delete a profile.
 
     This command does not clean up the profile's remote or local resources because
@@ -621,17 +679,52 @@ def delete_profile(ctx: Context, name: str) -> None:  # pragma: no cover
     profiles = configparser.ConfigParser()
     profiles.read(f"{home_dir}/profiles.cfg")
 
-    if name in profiles:
-        confirm = input(f"  Delete profile {name}? (y/n) ")
-        if confirm.lower() == "y":
-            del profiles[name]
-            with open(os.path.join(home_dir, "profiles.cfg"), "w") as f:
-                profiles.write(f)
-            print(f"{LogSymbols.SUCCESS.value} Profile {name} deleted.")
-        # Note: User canceling deletion is not an error, so no exit(1)
-    else:
+    if name not in profiles:
         print(f"{LogSymbols.ERROR.value} Profile {name} not found.")
         ctx.exit(1)
+        return
+
+    if name == get_default_profile_name(home_dir) and not force:
+        print(
+            f"{LogSymbols.ERROR.value} '{name}' is the default profile. Set another"
+            " profile as default with `blackfish profile default <name>` first, or"
+            " pass --force."
+        )
+        ctx.exit(1)
+        return
+
+    confirm = input(f"  Delete profile {name}? (y/n) ")
+    if confirm.lower() == "y":
+        del profiles[name]
+        with open(os.path.join(home_dir, "profiles.cfg"), "w") as f:
+            profiles.write(f)
+        print(f"{LogSymbols.SUCCESS.value} Profile {name} deleted.")
+    # Note: User canceling deletion is not an error, so no exit(1)
+
+
+@click.command(name="default")
+@click.argument("name", type=str, required=True)
+@click.pass_context
+def set_default_profile(ctx: Context, name: str) -> None:  # pragma: no cover
+    """Set the default profile.
+
+    Exactly one profile is marked default at a time; this command sets the flag on
+    NAME and clears it from every other profile.
+    """
+
+    home_dir = ctx.obj.get("home_dir")
+    profiles = configparser.ConfigParser()
+    profiles.read(f"{home_dir}/profiles.cfg")
+
+    if name not in profiles:
+        print(f"{LogSymbols.ERROR.value} Profile {name} not found.")
+        ctx.exit(1)
+        return
+
+    set_exclusive_default(profiles, name)
+    with open(os.path.join(home_dir, "profiles.cfg"), "w") as f:
+        profiles.write(f)
+    print(f"{LogSymbols.SUCCESS.value} '{name}' is now the default profile.")
 
 
 @click.command()

--- a/lib/src/blackfish/cli/profile.py
+++ b/lib/src/blackfish/cli/profile.py
@@ -1,5 +1,6 @@
 from typing import Optional
 import asyncio
+import sys
 import rich_click as click
 from rich_click import Context
 import configparser
@@ -210,11 +211,11 @@ def resolve_profile_or_exit(home_dir: str, profile: Optional[str]) -> str:
         return profile
     resolved = get_default_profile_name(home_dir)
     if resolved is None:
-        print(
+        click.echo(
             f"{LogSymbols.ERROR.value} No profiles configured. Run"
             " `blackfish profile add` to register one."
         )
-        raise SystemExit(1)
+        sys.exit(1)
     return resolved
 
 
@@ -684,7 +685,8 @@ def delete_profile(ctx: Context, name: str, force: bool) -> None:  # pragma: no 
         ctx.exit(1)
         return
 
-    if name == get_default_profile_name(home_dir) and not force:
+    was_default = name == get_default_profile_name(home_dir)
+    if was_default and not force:
         print(
             f"{LogSymbols.ERROR.value} '{name}' is the default profile. Set another"
             " profile as default with `blackfish profile default <name>` first, or"
@@ -699,6 +701,11 @@ def delete_profile(ctx: Context, name: str, force: bool) -> None:  # pragma: no 
         with open(os.path.join(home_dir, "profiles.cfg"), "w") as f:
             profiles.write(f)
         print(f"{LogSymbols.SUCCESS.value} Profile {name} deleted.")
+        if was_default and not has_any_default(profiles):
+            print(
+                f"{LogSymbols.WARNING.value} No default profile is set. Run"
+                " `blackfish profile default <name>` to assign one."
+            )
     # Note: User canceling deletion is not an error, so no exit(1)
 
 

--- a/lib/src/blackfish/client.py
+++ b/lib/src/blackfish/client.py
@@ -26,6 +26,7 @@ from log_symbols.symbols import LogSymbols
 from blackfish.server.config import BlackfishConfig
 from blackfish.server.models.profile import (
     deserialize_profile,
+    get_default_profile_name,
     LocalProfile,
     SlurmProfile,
 )
@@ -264,7 +265,7 @@ class Blackfish:
         name: str,
         image: str,
         model: str,
-        profile_name: str = "default",
+        profile_name: Optional[str] = None,
         container_config: Optional[dict[str, Any]] = None,
         job_config: Optional[dict[str, Any]] = None,
         mount: Optional[str] = None,
@@ -278,7 +279,8 @@ class Blackfish:
             name: Service name
             image: Service image type (e.g., "text_generation", "speech_recognition")
             model: Model repository ID (e.g., "meta-llama/Llama-3.3-70B-Instruct")
-            profile_name: Name of the profile to use
+            profile_name: Name of the profile to use. If None, the configured
+                default profile is used.
             container_config: Container configuration options. If 'model_dir' and 'revision'
                 are not provided, they will be automatically determined by searching for
                 the model in the profile's cache directories and selecting the latest revision.
@@ -297,7 +299,12 @@ class Blackfish:
                 or model files cannot be located.
         """
 
-        # Load profile
+        # Load profile (falling back to the configured default)
+        if profile_name is None:
+            profile_name = get_default_profile_name(self.home_dir)
+            if profile_name is None:
+                raise ValueError("No profiles are configured.")
+
         profile = deserialize_profile(self.home_dir, profile_name)
         if profile is None:
             raise ValueError(f"Profile '{profile_name}' not found")
@@ -442,7 +449,7 @@ class Blackfish:
         name: str,
         image: str,
         model: str,
-        profile_name: str = "default",
+        profile_name: Optional[str] = None,
         container_config: Optional[dict[str, Any]] = None,
         job_config: Optional[dict[str, Any]] = None,
         mount: Optional[str] = None,

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -96,8 +96,8 @@ from blackfish.server.utils import find_port
 from blackfish.server.models.profile import (
     deserialize_profiles,
     deserialize_profile,
-    get_default_profile_name,
     has_any_default,
+    resolve_default_section,
     section_is_default,
     set_exclusive_default,
     SlurmProfile,
@@ -2867,7 +2867,8 @@ async def delete_profile(name: str, force: bool = False) -> dict[str, str]:
     if name not in config:
         raise NotFoundException(detail=f"Profile '{name}' not found.")
 
-    if name == get_default_profile_name(blackfish_config.HOME_DIR) and not force:
+    is_default = name == resolve_default_section(config)
+    if is_default and not force:
         raise ClientException(
             status_code=HTTP_409_CONFLICT,
             detail=(
@@ -2879,7 +2880,11 @@ async def delete_profile(name: str, force: bool = False) -> dict[str, str]:
     del config[name]
     _save_profiles_config(config)
 
-    return {"status": "ok", "message": f"Profile '{name}' deleted."}
+    message = f"Profile '{name}' deleted."
+    if is_default and not has_any_default(config):
+        message += " No default profile is set; assign one with PUT /api/profiles/{name}/default."
+
+    return {"status": "ok", "message": message}
 
 
 @put("/api/profiles/{name:str}/default", guards=ENDPOINT_GUARDS)

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -96,6 +96,10 @@ from blackfish.server.utils import find_port
 from blackfish.server.models.profile import (
     deserialize_profiles,
     deserialize_profile,
+    get_default_profile_name,
+    has_any_default,
+    section_is_default,
+    set_exclusive_default,
     SlurmProfile,
     LocalProfile,
     BlackfishProfile as Profile,
@@ -2679,12 +2683,15 @@ async def create_profile(data: ProfileRequest) -> Profile:
         except TigerFlowError as e:
             raise InternalServerException(detail=e.user_message())
 
+        is_default = not has_any_default(config)
+
         config[data.name] = {
             "schema": "slurm",
             "host": data.host,
             "user": data.user,
             "home_dir": data.home_dir,
             "cache_dir": data.cache_dir,
+            "default": "true" if is_default else "false",
         }
         if data.python_path:
             config[data.name]["python_path"] = data.python_path
@@ -2697,6 +2704,7 @@ async def create_profile(data: ProfileRequest) -> Profile:
             user=data.user,
             home_dir=data.home_dir,
             cache_dir=data.cache_dir,
+            default=is_default,
         )
 
     elif data.schema_type == "local":
@@ -2713,10 +2721,13 @@ async def create_profile(data: ProfileRequest) -> Profile:
         except ProfileSetupError as e:
             raise InternalServerException(detail=e.user_message())
 
+        is_default = not has_any_default(config)
+
         config[data.name] = {
             "schema": "local",
             "home_dir": data.home_dir,
             "cache_dir": data.cache_dir,
+            "default": "true" if is_default else "false",
         }
         _save_profiles_config(config)
 
@@ -2724,6 +2735,7 @@ async def create_profile(data: ProfileRequest) -> Profile:
             name=data.name,
             home_dir=data.home_dir,
             cache_dir=data.cache_dir,
+            default=is_default,
         )
 
     else:
@@ -2745,6 +2757,9 @@ async def update_profile(name: str, data: ProfileRequest) -> Profile:
         raise ValidationException(
             detail="Profile name cannot be changed. Delete and recreate the profile instead."
         )
+
+    # Preserve the existing default flag across the rewrite.
+    was_default = section_is_default(config, name)
 
     if data.schema_type == "slurm":
         if not data.host or not data.user:
@@ -2788,6 +2803,7 @@ async def update_profile(name: str, data: ProfileRequest) -> Profile:
             "user": data.user,
             "home_dir": data.home_dir,
             "cache_dir": data.cache_dir,
+            "default": "true" if was_default else "false",
         }
         if data.python_path:
             config[data.name]["python_path"] = data.python_path
@@ -2800,6 +2816,7 @@ async def update_profile(name: str, data: ProfileRequest) -> Profile:
             user=data.user,
             home_dir=data.home_dir,
             cache_dir=data.cache_dir,
+            default=was_default,
         )
 
     elif data.schema_type == "local":
@@ -2820,6 +2837,7 @@ async def update_profile(name: str, data: ProfileRequest) -> Profile:
             "schema": "local",
             "home_dir": data.home_dir,
             "cache_dir": data.cache_dir,
+            "default": "true" if was_default else "false",
         }
         _save_profiles_config(config)
 
@@ -2827,6 +2845,7 @@ async def update_profile(name: str, data: ProfileRequest) -> Profile:
             name=data.name,
             home_dir=data.home_dir,
             cache_dir=data.cache_dir,
+            default=was_default,
         )
 
     else:
@@ -2836,20 +2855,45 @@ async def update_profile(name: str, data: ProfileRequest) -> Profile:
 
 
 @delete("/api/profiles/{name:str}", guards=ENDPOINT_GUARDS, status_code=200)
-async def delete_profile(name: str) -> dict[str, str]:
+async def delete_profile(name: str, force: bool = False) -> dict[str, str]:
     """Delete a profile.
 
-    This does not clean up remote resources (venv, files) as they may be shared.
+    Refuses to delete the default profile unless ``force=true`` is passed; the
+    caller is expected to set another profile as default first. Does not clean
+    up remote resources (venv, files) as they may be shared.
     """
     config = _get_profiles_config()
 
     if name not in config:
         raise NotFoundException(detail=f"Profile '{name}' not found.")
 
+    if name == get_default_profile_name(blackfish_config.HOME_DIR) and not force:
+        raise ClientException(
+            status_code=HTTP_409_CONFLICT,
+            detail=(
+                f"'{name}' is the default profile. Set another profile as default"
+                " first, or retry with force=true."
+            ),
+        )
+
     del config[name]
     _save_profiles_config(config)
 
     return {"status": "ok", "message": f"Profile '{name}' deleted."}
+
+
+@put("/api/profiles/{name:str}/default", guards=ENDPOINT_GUARDS)
+async def set_profile_default(name: str) -> dict[str, str]:
+    """Mark ``name`` as the default profile (clearing the flag from all others)."""
+    config = _get_profiles_config()
+
+    if name not in config:
+        raise NotFoundException(detail=f"Profile '{name}' not found.")
+
+    set_exclusive_default(config, name)
+    _save_profiles_config(config)
+
+    return {"status": "ok", "message": f"'{name}' is now the default profile."}
 
 
 @put("/api/profiles/{name:str}/repair", guards=ENDPOINT_GUARDS)
@@ -3472,6 +3516,7 @@ app = Litestar(
         create_profile,
         update_profile,
         delete_profile,
+        set_profile_default,
         repair_profile,
         upgrade_profile,
         get_cluster_status,

--- a/lib/src/blackfish/server/models/profile.py
+++ b/lib/src/blackfish/server/models/profile.py
@@ -15,6 +15,7 @@ class SlurmProfile:
     cache_dir: str
     python_path: str = "python3"
     schema: str = "slurm"
+    default: bool = False
 
     def is_local(self) -> bool:
         return self.host == "localhost"
@@ -38,6 +39,7 @@ class LocalProfile:
     home_dir: str
     cache_dir: str
     schema: str = "local"
+    default: bool = False
 
     def is_local(self) -> bool:
         return True
@@ -59,6 +61,54 @@ class ProfileTypeException(Exception):
         super().__init__(f"Profile type {schema} is not supported.")
 
 
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _as_bool(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in _TRUTHY
+
+
+def section_is_default(parser: ConfigParser, name: str) -> bool:
+    """Return whether the named section is flagged as the default profile."""
+    return _as_bool(parser[name].get("default"))
+
+
+def has_any_default(parser: ConfigParser) -> bool:
+    """Return whether any section in the parser has ``default = true`` set."""
+    return any(section_is_default(parser, s) for s in parser.sections())
+
+
+def set_exclusive_default(parser: ConfigParser, name: str) -> None:
+    """Mark ``name`` as default and explicitly clear the flag on all other sections."""
+    for section in parser.sections():
+        parser[section]["default"] = "true" if section == name else "false"
+
+
+def _build_profile(name: str, raw: dict[str, str]) -> BlackfishProfile | None:
+    schema = raw.get("schema") or raw.get("type")
+    is_default = _as_bool(raw.get("default"))
+    if schema == "slurm":
+        return SlurmProfile(
+            name=name,
+            host=raw["host"],
+            user=raw["user"],
+            home_dir=raw["home_dir"],
+            cache_dir=raw["cache_dir"],
+            python_path=raw.get("python_path", "python3"),
+            default=is_default,
+        )
+    if schema == "local":
+        return LocalProfile(
+            name=name,
+            home_dir=raw["home_dir"],
+            cache_dir=raw["cache_dir"],
+            default=is_default,
+        )
+    return None
+
+
 def deserialize_profiles(home_dir: str) -> list[BlackfishProfile]:
     """Parse profiles from profile.cfg."""
 
@@ -71,29 +121,10 @@ def deserialize_profiles(home_dir: str) -> list[BlackfishProfile]:
 
     profiles: list[BlackfishProfile] = []
     for section in parser.sections():
-        profile = {k: v for k, v in parser[section].items()}
-        schema = profile.get("schema") or profile.get("type")
-        if schema == "slurm":
-            profiles.append(
-                SlurmProfile(
-                    name=section,
-                    host=profile["host"],
-                    user=profile["user"],
-                    home_dir=profile["home_dir"],
-                    cache_dir=profile["cache_dir"],
-                    python_path=profile.get("python_path", "python3"),
-                )
-            )
-        elif schema == "local":
-            profiles.append(
-                LocalProfile(
-                    name=section,
-                    home_dir=profile["home_dir"],
-                    cache_dir=profile["cache_dir"],
-                )
-            )
-        else:
-            pass
+        raw = {k: v for k, v in parser[section].items()}
+        profile = _build_profile(section, raw)
+        if profile is not None:
+            profiles.append(profile)
 
     return profiles
 
@@ -110,25 +141,39 @@ def deserialize_profile(home_dir: str, name: str) -> BlackfishProfile | None:
 
     for section in parser.sections():
         if section == name:
-            profile = {k: v for k, v in parser[section].items()}
-            schema = profile.get("schema") or profile.get("type")
-            if schema == "slurm":
-                return SlurmProfile(
-                    name=section,
-                    host=profile["host"],
-                    user=profile["user"],
-                    home_dir=profile["home_dir"],
-                    cache_dir=profile["cache_dir"],
-                    python_path=profile.get("python_path", "python3"),
-                )
-            elif schema == "local":
-                return LocalProfile(
-                    name=section,
-                    home_dir=profile["home_dir"],
-                    cache_dir=profile["cache_dir"],
-                )
-            else:
-                schema_value = profile.get("schema") or profile.get("type", "unknown")
+            raw = {k: v for k, v in parser[section].items()}
+            profile = _build_profile(section, raw)
+            if profile is None:
+                schema_value = raw.get("schema") or raw.get("type", "unknown")
                 raise ProfileTypeException(schema_value)
+            return profile
 
     return None
+
+
+def get_default_profile_name(home_dir: str) -> str | None:
+    """Resolve the name of the default profile.
+
+    Resolution order:
+      1. The (first) profile with ``default = true``.
+      2. A profile literally named ``default`` (legacy convention).
+      3. The first declared profile section.
+      4. ``None`` if no profiles exist.
+    """
+
+    profiles_path = os.path.join(home_dir, "profiles.cfg")
+    if not os.path.isfile(profiles_path):
+        return None
+
+    parser = ConfigParser()
+    parser.read(profiles_path)
+
+    sections: list[str] = parser.sections()
+    for section in sections:
+        if _as_bool(parser[section].get("default")):
+            return section
+
+    if "default" in sections:
+        return "default"
+
+    return sections[0] if sections else None

--- a/lib/src/blackfish/server/models/profile.py
+++ b/lib/src/blackfish/server/models/profile.py
@@ -151,14 +151,30 @@ def deserialize_profile(home_dir: str, name: str) -> BlackfishProfile | None:
     return None
 
 
-def get_default_profile_name(home_dir: str) -> str | None:
-    """Resolve the name of the default profile.
+def resolve_default_section(parser: ConfigParser) -> str | None:
+    """Resolve the default profile name from an already-loaded parser.
 
     Resolution order:
       1. The (first) profile with ``default = true``.
       2. A profile literally named ``default`` (legacy convention).
       3. The first declared profile section.
       4. ``None`` if no profiles exist.
+    """
+    sections: list[str] = parser.sections()
+    for section in sections:
+        if section_is_default(parser, section):
+            return section
+
+    if "default" in sections:
+        return "default"
+
+    return sections[0] if sections else None
+
+
+def get_default_profile_name(home_dir: str) -> str | None:
+    """Resolve the name of the default profile from ``home_dir/profiles.cfg``.
+
+    See :func:`resolve_default_section` for the resolution order.
     """
 
     profiles_path = os.path.join(home_dir, "profiles.cfg")
@@ -168,12 +184,4 @@ def get_default_profile_name(home_dir: str) -> str | None:
     parser = ConfigParser()
     parser.read(profiles_path)
 
-    sections: list[str] = parser.sections()
-    for section in sections:
-        if _as_bool(parser[section].get("default")):
-            return section
-
-    if "default" in sections:
-        return "default"
-
-    return sections[0] if sections else None
+    return resolve_default_section(parser)

--- a/lib/tests/api/test_profiles.py
+++ b/lib/tests/api/test_profiles.py
@@ -639,38 +639,38 @@ class TestDefaultFlagAPI:
 
     async def test_delete_refuses_default(self, client: AsyncTestClient):
         """DELETE refuses to remove the default profile without force=true."""
-        with patch(
-            "blackfish.server.asgi.get_default_profile_name", return_value="myprof"
+        with (
+            patch(
+                "blackfish.server.asgi.resolve_default_section", return_value="myprof"
+            ),
+            patch("blackfish.server.asgi._get_profiles_config") as mock_get_config,
         ):
-            with patch("blackfish.server.asgi._get_profiles_config") as mock_get_config:
-                mock_config = MagicMock()
-                mock_config.__contains__ = MagicMock(return_value=True)
-                mock_get_config.return_value = mock_config
+            mock_config = MagicMock()
+            mock_config.__contains__ = MagicMock(return_value=True)
+            mock_get_config.return_value = mock_config
 
-                response = await client.delete("/api/profiles/myprof")
+            response = await client.delete("/api/profiles/myprof")
 
-                assert response.status_code == 409
-                assert "default profile" in response.json()["detail"]
+            assert response.status_code == 409
+            assert "default profile" in response.json()["detail"]
 
     async def test_delete_default_with_force(self, client: AsyncTestClient):
         """DELETE removes the default profile when force=true."""
-        with patch(
-            "blackfish.server.asgi.get_default_profile_name", return_value="myprof"
+        with (
+            patch(
+                "blackfish.server.asgi.resolve_default_section", return_value="myprof"
+            ),
+            patch("blackfish.server.asgi._get_profiles_config") as mock_get_config,
+            patch("blackfish.server.asgi._save_profiles_config") as mock_save_config,
         ):
-            with (
-                patch("blackfish.server.asgi._get_profiles_config") as mock_get_config,
-                patch(
-                    "blackfish.server.asgi._save_profiles_config"
-                ) as mock_save_config,
-            ):
-                mock_config = MagicMock()
-                mock_config.__contains__ = MagicMock(return_value=True)
-                mock_get_config.return_value = mock_config
+            mock_config = MagicMock()
+            mock_config.__contains__ = MagicMock(return_value=True)
+            mock_get_config.return_value = mock_config
 
-                response = await client.delete("/api/profiles/myprof?force=true")
+            response = await client.delete("/api/profiles/myprof?force=true")
 
-                assert response.status_code == 200
-                mock_save_config.assert_called_once()
+            assert response.status_code == 200
+            mock_save_config.assert_called_once()
 
     async def test_set_default_endpoint(self, client: AsyncTestClient):
         """PUT /api/profiles/{name}/default flags the named profile exclusively."""

--- a/lib/tests/api/test_profiles.py
+++ b/lib/tests/api/test_profiles.py
@@ -634,6 +634,74 @@ class TestDeleteProfileAPI:
             assert response.status_code == 404
 
 
+class TestDefaultFlagAPI:
+    """Tests for default-flag behavior across the profile endpoints."""
+
+    async def test_delete_refuses_default(self, client: AsyncTestClient):
+        """DELETE refuses to remove the default profile without force=true."""
+        with patch(
+            "blackfish.server.asgi.get_default_profile_name", return_value="myprof"
+        ):
+            with patch("blackfish.server.asgi._get_profiles_config") as mock_get_config:
+                mock_config = MagicMock()
+                mock_config.__contains__ = MagicMock(return_value=True)
+                mock_get_config.return_value = mock_config
+
+                response = await client.delete("/api/profiles/myprof")
+
+                assert response.status_code == 409
+                assert "default profile" in response.json()["detail"]
+
+    async def test_delete_default_with_force(self, client: AsyncTestClient):
+        """DELETE removes the default profile when force=true."""
+        with patch(
+            "blackfish.server.asgi.get_default_profile_name", return_value="myprof"
+        ):
+            with (
+                patch("blackfish.server.asgi._get_profiles_config") as mock_get_config,
+                patch(
+                    "blackfish.server.asgi._save_profiles_config"
+                ) as mock_save_config,
+            ):
+                mock_config = MagicMock()
+                mock_config.__contains__ = MagicMock(return_value=True)
+                mock_get_config.return_value = mock_config
+
+                response = await client.delete("/api/profiles/myprof?force=true")
+
+                assert response.status_code == 200
+                mock_save_config.assert_called_once()
+
+    async def test_set_default_endpoint(self, client: AsyncTestClient):
+        """PUT /api/profiles/{name}/default flags the named profile exclusively."""
+        with (
+            patch("blackfish.server.asgi._get_profiles_config") as mock_get_config,
+            patch("blackfish.server.asgi._save_profiles_config") as mock_save_config,
+            patch("blackfish.server.asgi.set_exclusive_default") as mock_set_exclusive,
+        ):
+            mock_config = MagicMock()
+            mock_config.__contains__ = MagicMock(return_value=True)
+            mock_get_config.return_value = mock_config
+
+            response = await client.put("/api/profiles/myprof/default")
+
+            assert response.status_code == 200
+            assert response.json()["status"] == "ok"
+            mock_set_exclusive.assert_called_once_with(mock_config, "myprof")
+            mock_save_config.assert_called_once()
+
+    async def test_set_default_not_found(self, client: AsyncTestClient):
+        """PUT /api/profiles/{name}/default returns 404 if the profile is missing."""
+        with patch("blackfish.server.asgi._get_profiles_config") as mock_get_config:
+            mock_config = MagicMock()
+            mock_config.__contains__ = MagicMock(return_value=False)
+            mock_get_config.return_value = mock_config
+
+            response = await client.put("/api/profiles/nope/default")
+
+            assert response.status_code == 404
+
+
 class TestRepairProfileAPI:
     """Test cases for the PUT /api/profiles/{name}/repair endpoint."""
 

--- a/lib/tests/cli/test_cli_models.py
+++ b/lib/tests/cli/test_cli_models.py
@@ -256,6 +256,10 @@ def test_add_model(
         patch(
             "blackfish.server.models.profile.deserialize_profile"
         ) as mock_deserialize_profile,
+        patch(
+            "blackfish.cli.__main__.resolve_profile_or_exit",
+            side_effect=lambda _home, name: name if name is not None else "default",
+        ),
         patch("blackfish.server.models.model.add_model") as mock_add_model,
         patch("blackfish.cli.__main__.requests.post") as mock_post,
     ):
@@ -443,6 +447,10 @@ def test_remove_model(
         patch(
             "blackfish.server.models.profile.deserialize_profile"
         ) as mock_deserialize_profile,
+        patch(
+            "blackfish.cli.__main__.resolve_profile_or_exit",
+            side_effect=lambda _home, name: name if name is not None else "default",
+        ),
         patch("blackfish.server.models.model.remove_model") as mock_remove_model,
         patch("blackfish.cli.__main__.requests.delete") as mock_delete,
     ):

--- a/lib/tests/cli/test_cli_models.py
+++ b/lib/tests/cli/test_cli_models.py
@@ -560,6 +560,10 @@ def test_add_model_connection_error(cli_runner):
         patch(
             "blackfish.server.models.profile.deserialize_profile"
         ) as mock_deserialize_profile,
+        patch(
+            "blackfish.cli.__main__.resolve_profile_or_exit",
+            side_effect=lambda _home, name: name if name is not None else "default",
+        ),
         patch("blackfish.server.models.model.add_model") as mock_add_model,
         patch("blackfish.cli.__main__.requests.post") as mock_post,
         patch("blackfish.server.config.config") as mock_config,
@@ -597,6 +601,10 @@ def test_remove_model_connection_error(cli_runner):
         patch(
             "blackfish.server.models.profile.deserialize_profile"
         ) as mock_deserialize_profile,
+        patch(
+            "blackfish.cli.__main__.resolve_profile_or_exit",
+            side_effect=lambda _home, name: name if name is not None else "default",
+        ),
         patch("blackfish.server.models.model.remove_model") as mock_remove_model,
         patch("blackfish.cli.__main__.requests.delete") as mock_delete,
         patch("blackfish.server.config.config") as mock_config,

--- a/lib/tests/cli/test_cli_profiles.py
+++ b/lib/tests/cli/test_cli_profiles.py
@@ -545,6 +545,37 @@ class TestDefaultResolution:
         assert profiles["beta"].default is False
 
 
+class TestResolveProfileOrExit:
+    """`resolve_profile_or_exit` is the shared fallback for `--profile` options."""
+
+    def test_returns_explicit_profile_unchanged(self, temp_home_dir):
+        from blackfish.cli.profile import resolve_profile_or_exit
+
+        # An explicit name is returned without touching the config.
+        assert resolve_profile_or_exit(temp_home_dir, "myprof") == "myprof"
+
+    def test_resolves_default_when_unset(self, temp_home_dir):
+        from blackfish.cli.profile import resolve_profile_or_exit
+
+        config = (
+            "[alpha]\nschema = local\nhome_dir = /h\ncache_dir = /c\ndefault = true\n"
+        )
+        with open(os.path.join(temp_home_dir, "profiles.cfg"), "w") as f:
+            f.write(config)
+
+        assert resolve_profile_or_exit(temp_home_dir, None) == "alpha"
+
+    def test_exits_when_no_profiles_configured(self, temp_home_dir):
+        from blackfish.cli.profile import resolve_profile_or_exit
+
+        with open(os.path.join(temp_home_dir, "profiles.cfg"), "w") as f:
+            f.write("")
+
+        with pytest.raises(SystemExit) as exc_info:
+            resolve_profile_or_exit(temp_home_dir, None)
+        assert exc_info.value.code == 1
+
+
 class TestProfileUpdatePreservesDefault:
     """`blackfish profile update` should preserve the `default` flag."""
 
@@ -658,6 +689,8 @@ class TestProfileDefaultCommand:
             assert result.exit_code == 0
             with open(profiles_path, "r") as f:
                 assert "[default]" not in f.read()
+            # No remaining profile is flagged default -> user is warned.
+            assert "No default profile is set" in result.output
 
 
 class TestProfileUpgrade:

--- a/lib/tests/cli/test_cli_profiles.py
+++ b/lib/tests/cli/test_cli_profiles.py
@@ -480,6 +480,186 @@ cache_dir = /tmp/mixed/cache
             )  # Should use 'schema' field, not 'type'
 
 
+class TestDefaultResolution:
+    """Tests for explicit `default = true` flag and resolution fallback."""
+
+    def test_resolver_prefers_flag(self, temp_home_dir):
+        from blackfish.server.models.profile import get_default_profile_name
+
+        config = (
+            "[alpha]\nschema = local\nhome_dir = /h\ncache_dir = /c\n\n"
+            "[beta]\nschema = local\nhome_dir = /h\ncache_dir = /c\n"
+            "default = true\n"
+        )
+        with open(os.path.join(temp_home_dir, "profiles.cfg"), "w") as f:
+            f.write(config)
+
+        assert get_default_profile_name(temp_home_dir) == "beta"
+
+    def test_resolver_falls_back_to_name(self, temp_home_dir):
+        from blackfish.server.models.profile import get_default_profile_name
+
+        config = (
+            "[alpha]\nschema = local\nhome_dir = /h\ncache_dir = /c\n\n"
+            "[default]\nschema = local\nhome_dir = /h\ncache_dir = /c\n"
+        )
+        with open(os.path.join(temp_home_dir, "profiles.cfg"), "w") as f:
+            f.write(config)
+
+        assert get_default_profile_name(temp_home_dir) == "default"
+
+    def test_resolver_falls_back_to_first_section(self, temp_home_dir):
+        from blackfish.server.models.profile import get_default_profile_name
+
+        config = (
+            "[alpha]\nschema = local\nhome_dir = /h\ncache_dir = /c\n\n"
+            "[beta]\nschema = local\nhome_dir = /h\ncache_dir = /c\n"
+        )
+        with open(os.path.join(temp_home_dir, "profiles.cfg"), "w") as f:
+            f.write(config)
+
+        assert get_default_profile_name(temp_home_dir) == "alpha"
+
+    def test_resolver_returns_none_when_empty(self, temp_home_dir):
+        from blackfish.server.models.profile import get_default_profile_name
+
+        with open(os.path.join(temp_home_dir, "profiles.cfg"), "w") as f:
+            f.write("")
+
+        assert get_default_profile_name(temp_home_dir) is None
+
+    def test_deserialize_reads_default_flag(self, temp_home_dir):
+        from blackfish.server.models.profile import deserialize_profiles
+
+        config = (
+            "[alpha]\nschema = local\nhome_dir = /h\ncache_dir = /c\n"
+            "default = true\n\n"
+            "[beta]\nschema = local\nhome_dir = /h\ncache_dir = /c\n"
+            "default = false\n"
+        )
+        with open(os.path.join(temp_home_dir, "profiles.cfg"), "w") as f:
+            f.write(config)
+
+        profiles = {p.name: p for p in deserialize_profiles(temp_home_dir)}
+        assert profiles["alpha"].default is True
+        assert profiles["beta"].default is False
+
+
+class TestProfileUpdatePreservesDefault:
+    """`blackfish profile update` should preserve the `default` flag."""
+
+    @patch("blackfish.cli.profile.input")
+    @patch("blackfish.cli.profile.asyncio.run")
+    def test_update_preserves_default_flag(
+        self, mock_asyncio_run, mock_input, cli_runner, temp_home_dir
+    ):
+        # Existing config: 'default' section flagged default=true.
+        config = (
+            "[default]\n"
+            "schema = local\n"
+            "home_dir = /tmp/test/home\n"
+            "cache_dir = /tmp/test/cache\n"
+            "default = true\n"
+        )
+        profiles_path = os.path.join(temp_home_dir, "profiles.cfg")
+        with open(profiles_path, "w") as f:
+            f.write(config)
+
+        # Accept defaults for both prompts (home, cache).
+        mock_input.side_effect = ["", ""]
+
+        with patch("blackfish.cli.__main__.config") as mock_config:
+            mock_config.HOME_DIR = temp_home_dir
+
+            result = cli_runner.invoke(main, ["profile", "update", "--name", "default"])
+            assert result.exit_code == 0
+
+            import configparser
+
+            parsed = configparser.ConfigParser()
+            parsed.read(profiles_path)
+            assert parsed["default"]["default"] == "true"
+
+
+class TestProfileDefaultCommand:
+    """Tests for `blackfish profile default <name>`."""
+
+    def test_set_default_assigns_exclusive_flag(
+        self, cli_runner, temp_home_dir, mock_profiles_config
+    ):
+        profiles_path = os.path.join(temp_home_dir, "profiles.cfg")
+
+        with patch("blackfish.cli.__main__.config") as mock_config:
+            mock_config.HOME_DIR = temp_home_dir
+
+            with open(profiles_path, "w") as f:
+                f.write(mock_profiles_config)
+
+            result = cli_runner.invoke(main, ["profile", "default", "slurm-test"])
+            assert result.exit_code == 0
+
+            import configparser
+
+            parsed = configparser.ConfigParser()
+            parsed.read(profiles_path)
+            assert parsed["slurm-test"]["default"] == "true"
+            assert parsed["default"]["default"] == "false"
+
+    def test_set_default_not_found(
+        self, cli_runner, temp_home_dir, mock_profiles_config
+    ):
+        profiles_path = os.path.join(temp_home_dir, "profiles.cfg")
+
+        with patch("blackfish.cli.__main__.config") as mock_config:
+            mock_config.HOME_DIR = temp_home_dir
+
+            with open(profiles_path, "w") as f:
+                f.write(mock_profiles_config)
+
+            result = cli_runner.invoke(main, ["profile", "default", "nope"])
+            assert result.exit_code == 1
+            assert "Profile nope not found" in result.output
+
+    def test_delete_refuses_default(
+        self, cli_runner, temp_home_dir, mock_profiles_config
+    ):
+        # `default` profile is the resolved default (by legacy name); refuse rm.
+        profiles_path = os.path.join(temp_home_dir, "profiles.cfg")
+
+        with patch("blackfish.cli.__main__.config") as mock_config:
+            mock_config.HOME_DIR = temp_home_dir
+
+            with open(profiles_path, "w") as f:
+                f.write(mock_profiles_config)
+
+            result = cli_runner.invoke(main, ["profile", "rm", "--name", "default"])
+            assert result.exit_code == 1
+            assert "is the default profile" in result.output
+
+            with open(profiles_path, "r") as f:
+                assert "[default]" in f.read()
+
+    @patch("blackfish.cli.profile.input")
+    def test_delete_force_removes_default(
+        self, mock_input, cli_runner, temp_home_dir, mock_profiles_config
+    ):
+        mock_input.return_value = "y"
+        profiles_path = os.path.join(temp_home_dir, "profiles.cfg")
+
+        with patch("blackfish.cli.__main__.config") as mock_config:
+            mock_config.HOME_DIR = temp_home_dir
+
+            with open(profiles_path, "w") as f:
+                f.write(mock_profiles_config)
+
+            result = cli_runner.invoke(
+                main, ["profile", "rm", "--name", "default", "--force"]
+            )
+            assert result.exit_code == 0
+            with open(profiles_path, "r") as f:
+                assert "[default]" not in f.read()
+
+
 class TestProfileUpgrade:
     """Test profile upgrade command."""
 

--- a/web/src/components/SettingsSlideOver.jsx
+++ b/web/src/components/SettingsSlideOver.jsx
@@ -492,9 +492,9 @@ function ProfilesSection() {
                     </button>
                     <button
                       onClick={() => setDeleteConfirm(p.name)}
-                      className={`p-1.5 ${p.name === "default" ? "text-gray-200 dark:text-gray-600 cursor-not-allowed" : "text-gray-400 hover:text-red-500"}`}
-                      title={p.name === "default" ? "Cannot delete default profile" : "Delete"}
-                      disabled={p.name === "default"}
+                      className={`p-1.5 ${p.default ? "text-gray-200 dark:text-gray-600 cursor-not-allowed" : "text-gray-400 hover:text-red-500"}`}
+                      title={p.default ? "Cannot delete default profile" : "Delete"}
+                      disabled={p.default}
                     >
                       <TrashIcon className="h-5 w-5" />
                     </button>


### PR DESCRIPTION
## Summary
- Adds a `default: bool` field to profile sections in `profiles.cfg`, replacing the implicit "the profile named `default` is the default" convention. Any profile can now be the default and profiles can be named freely.
- Resolution order: `default = true` flag → profile literally named `default` (legacy) → first declared section. The one-default invariant is enforced at write sites (CLI add/delete, API POST/DELETE/PUT, new `default` commands/endpoints).
- Updates the Python client, frontend, CLI options, and API endpoints to use the resolved default instead of hardcoding `"default"`.

## Changes
- **Model** ([profile.py](lib/src/blackfish/server/models/profile.py)): adds `default` field, `get_default_profile_name()` / `resolve_default_section()` resolvers, and shared `section_is_default` / `has_any_default` / `set_exclusive_default` helpers.
- **CLI**: `profile add` flags the first profile as default; `profile rm` refuses to delete the default unless `--force` (and warns if a force-delete leaves no default); new `profile default <name>` command; `profile ls` shows a `(default)` marker; `profile update` preserves the flag across rewrites; `--profile` options across `run` / `model add` / `model rm` / `batch run` resolve via a shared `resolve_profile_or_exit` helper.
- **API**: `POST /api/profiles` flags the first profile; `PUT /api/profiles/{name}` preserves the existing flag; `DELETE /api/profiles/{name}` refuses to delete the default (use `?force=true` to override); new `PUT /api/profiles/{name}/default`.
- **Python client**: `launch_service(profile_name=...)` accepts `None` and resolves the default.
- **Frontend**: `SettingsSlideOver` disables delete on `p.default` instead of `p.name === "default"`.
- **Docs**: updates `usage/cli.md` (new `default` field, `profile default` command, `rm` refusal/`--force`) and `usage/ui.md`.

## Breaking changes
- `blackfish profile rm` now **requires** `--name`. Previously it defaulted to `--name default`; an unqualified `blackfish profile rm` no longer deletes the `default` profile. This is intentional — silently deleting the default on a bare invocation is unsafe now that the default can be any profile.

## Backward compatibility
Existing `profiles.cfg` files without a `default = true` line continue to work via the legacy-name fallback. No file migration; new flags are only written when users explicitly add, update, or set a default.

## Test plan
- [x] `uv run just lint` (lib)
- [x] `uv run just test` (819 passed, 8 skipped)
- [x] `npm run lint` (web — no new warnings)
- [x] `npm test` (297 passed)
- [x] New tests cover the resolver fallback chain, `resolve_profile_or_exit` (including the "no profiles configured" exit), default-flag preservation on update, `profile default`, rm-refusal / force-delete warning, and the API set-default / delete-guard paths.

## Follow-up
- #337 — Settings UI control to change the default profile (the `PUT /api/profiles/{name}/default` endpoint lands here; the UI control does not).

Closes #316.