### PR TITLE
feat(web): set the default profile from the Settings UI

### DIFF
--- a/web/src/components/ProfileSelect.jsx
+++ b/web/src/components/ProfileSelect.jsx
@@ -30,10 +30,17 @@ const ProfileProvider = ({ children }) => {
     localStorage.removeItem("profile");
   }, []);
 
-  const profile = useMemo(
-    () => profiles?.find((p) => p.name === profileName) ?? null,
-    [profiles, profileName]
-  );
+  // Resolve the active profile: an explicit (persisted) selection wins;
+  // otherwise fall back to the profile flagged `default = true`. The UI only
+  // honors the explicit flag — unlike the CLI, it does not fall back to a
+  // profile named "default" or the first listed profile.
+  const profile = useMemo(() => {
+    if (!profiles) return null;
+    const explicit = profileName
+      ? profiles.find((p) => p.name === profileName)
+      : null;
+    return explicit ?? profiles.find((p) => p.default) ?? null;
+  }, [profiles, profileName]);
 
   const setProfile = useCallback((nextProfile) => {
     const name = nextProfile?.name ?? null;

--- a/web/src/components/ProfileSelect.test.jsx
+++ b/web/src/components/ProfileSelect.test.jsx
@@ -102,6 +102,92 @@ describe("ProfileProvider", () => {
     expect(contextValue.profile).toBeNull();
   });
 
+  it("falls back to the default-flagged profile when no name is stored", () => {
+    const profilesWithDefault = [
+      {name: "test-profile", host: "example.com"},
+      {name: "default-profile", host: "defaulthost.com", default: true},
+    ];
+    vi.mocked(useProfiles).mockReturnValue({
+      profiles: profilesWithDefault,
+      isLoading: false,
+      error: false
+    });
+
+    let contextValue = null;
+    render(
+      <ProfileProvider>
+        <ProfileContext.Consumer>
+          {(value) => {
+            contextValue = value;
+            return <h1>Hello, world!</h1>;
+          }}
+        </ProfileContext.Consumer>
+      </ProfileProvider>
+    );
+
+    expect(contextValue.profile).toEqual(
+      profilesWithDefault.find((p) => p.default)
+    );
+  });
+
+  it("falls back to the default-flagged profile when the stored name is stale", () => {
+    localStorage.setItem("profileName", "deleted-profile");
+    const profilesWithDefault = [
+      {name: "test-profile", host: "example.com"},
+      {name: "default-profile", host: "defaulthost.com", default: true},
+    ];
+    vi.mocked(useProfiles).mockReturnValue({
+      profiles: profilesWithDefault,
+      isLoading: false,
+      error: false
+    });
+
+    let contextValue = null;
+    render(
+      <ProfileProvider>
+        <ProfileContext.Consumer>
+          {(value) => {
+            contextValue = value;
+            return <h1>Hello, world!</h1>;
+          }}
+        </ProfileContext.Consumer>
+      </ProfileProvider>
+    );
+
+    expect(contextValue.profile).toEqual(
+      profilesWithDefault.find((p) => p.default)
+    );
+  });
+
+  it("prefers an explicit stored selection over the default-flagged profile", () => {
+    localStorage.setItem("profileName", "test-profile");
+    const profilesWithDefault = [
+      {name: "test-profile", host: "example.com"},
+      {name: "default-profile", host: "defaulthost.com", default: true},
+    ];
+    vi.mocked(useProfiles).mockReturnValue({
+      profiles: profilesWithDefault,
+      isLoading: false,
+      error: false
+    });
+
+    let contextValue = null;
+    render(
+      <ProfileProvider>
+        <ProfileContext.Consumer>
+          {(value) => {
+            contextValue = value;
+            return <h1>Hello, world!</h1>;
+          }}
+        </ProfileContext.Consumer>
+      </ProfileProvider>
+    );
+
+    expect(contextValue.profile).toEqual(
+      profilesWithDefault.find((p) => p.name === "test-profile")
+    );
+  });
+
   it("removes legacy 'profile' key on mount", () => {
     localStorage.setItem("profile", JSON.stringify({name: "stale", type: "slurm"}));
 

--- a/web/src/components/SettingsSlideOver.jsx
+++ b/web/src/components/SettingsSlideOver.jsx
@@ -24,6 +24,7 @@ import {
   ChevronUpDownIcon,
   StarIcon,
 } from "@heroicons/react/24/outline";
+import { StarIcon as StarIconSolid } from "@heroicons/react/24/solid";
 import { useSettings } from "@/providers/SettingsProvider";
 import { useTheme } from "@/providers/ThemeProvider";
 import { ProfileContext } from "@/components/ProfileSelect";
@@ -474,11 +475,6 @@ function ProfilesSection() {
                 }`}>
                   {p.schema}
                 </span>
-                {p.default && (
-                  <span className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300">
-                    default
-                  </span>
-                )}
               </div>
               <div className="flex items-center gap-1">
                 {deleteConfirm === p.name ? (
@@ -499,7 +495,14 @@ function ProfilesSection() {
                   </>
                 ) : (
                   <>
-                    {!p.default && (
+                    {p.default ? (
+                      <span
+                        className="p-1.5 text-amber-500"
+                        title="Default profile"
+                      >
+                        <StarIconSolid className="h-5 w-5" />
+                      </span>
+                    ) : (
                       <button
                         onClick={() => handleSetDefault(p.name)}
                         className="p-1.5 text-gray-400 hover:text-amber-500"

--- a/web/src/components/SettingsSlideOver.jsx
+++ b/web/src/components/SettingsSlideOver.jsx
@@ -22,13 +22,14 @@ import {
   TrashIcon,
   CheckIcon,
   ChevronUpDownIcon,
+  StarIcon,
 } from "@heroicons/react/24/outline";
 import { useSettings } from "@/providers/SettingsProvider";
 import { useTheme } from "@/providers/ThemeProvider";
 import { ProfileContext } from "@/components/ProfileSelect";
 import { useProfiles } from "@/lib/loaders";
 import Notification from "@/components/Notification";
-import { createProfile, updateProfile, deleteProfile, fetchHfTokenStatus, setHfToken, deleteHfToken, fetchAppInfo } from "@/lib/requests";
+import { createProfile, updateProfile, deleteProfile, setDefaultProfile, fetchHfTokenStatus, setHfToken, deleteHfToken, fetchAppInfo } from "@/lib/requests";
 import { blackfishApiURL } from "@/config";
 
 // Context for toast notifications within Settings
@@ -397,6 +398,16 @@ function ProfilesSection() {
     setIsAdding(false);
   };
 
+  const handleSetDefault = async (profileName) => {
+    try {
+      await setDefaultProfile(profileName);
+      mutate();
+      showSuccess(`Profile "${profileName}" is now the default`);
+    } catch (err) {
+      showError(err.message);
+    }
+  };
+
   const renderHeader = () => (
     <div className="flex items-center justify-between mb-3">
       <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
@@ -463,6 +474,11 @@ function ProfilesSection() {
                 }`}>
                   {p.schema}
                 </span>
+                {p.default && (
+                  <span className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300">
+                    default
+                  </span>
+                )}
               </div>
               <div className="flex items-center gap-1">
                 {deleteConfirm === p.name ? (
@@ -483,6 +499,15 @@ function ProfilesSection() {
                   </>
                 ) : (
                   <>
+                    {!p.default && (
+                      <button
+                        onClick={() => handleSetDefault(p.name)}
+                        className="p-1.5 text-gray-400 hover:text-amber-500"
+                        title="Set as default profile"
+                      >
+                        <StarIcon className="h-5 w-5" />
+                      </button>
+                    )}
                     <button
                       onClick={() => setEditingProfile(p)}
                       className="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"

--- a/web/src/components/SettingsSlideOver.jsx
+++ b/web/src/components/SettingsSlideOver.jsx
@@ -377,6 +377,7 @@ function ProfilesSection() {
   const [editingProfile, setEditingProfile] = useState(null);
   const [isAdding, setIsAdding] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState(null);
+  const [settingDefault, setSettingDefault] = useState(false);
 
   const handleDelete = async (profileName) => {
     try {
@@ -400,12 +401,16 @@ function ProfilesSection() {
   };
 
   const handleSetDefault = async (profileName) => {
+    if (settingDefault) return;
+    setSettingDefault(true);
     try {
       await setDefaultProfile(profileName);
       mutate();
       showSuccess(`Profile "${profileName}" is now the default`);
     } catch (err) {
       showError(err.message);
+    } finally {
+      setSettingDefault(false);
     }
   };
 
@@ -499,14 +504,17 @@ function ProfilesSection() {
                       <span
                         className="p-1.5 text-amber-500"
                         title="Default profile"
+                        aria-label="Default profile"
                       >
                         <StarIconSolid className="h-5 w-5" />
                       </span>
                     ) : (
                       <button
                         onClick={() => handleSetDefault(p.name)}
-                        className="p-1.5 text-gray-400 hover:text-amber-500"
+                        disabled={settingDefault}
+                        className="p-1.5 text-gray-400 hover:text-amber-500 disabled:opacity-50 disabled:cursor-not-allowed"
                         title="Set as default profile"
+                        aria-label="Set as default profile"
                       >
                         <StarIcon className="h-5 w-5" />
                       </button>

--- a/web/src/lib/requests.js
+++ b/web/src/lib/requests.js
@@ -124,6 +124,26 @@ export async function deleteProfile(name) {
   return res.json();
 }
 
+/** Set a profile as the default. */
+export async function setDefaultProfile(name) {
+  const res = await fetch(`${blackfishApiURL}/api/profiles/${encodeURIComponent(name)}/default`, {
+    method: "PUT",
+  });
+  if (!res.ok) {
+    let message = "Failed to set default profile.";
+    try {
+      const body = await res.json();
+      if (body.detail) message = body.detail;
+    } catch {
+      // Ignore JSON parse errors
+    }
+    const error = new Error(message);
+    error.status = res.status;
+    throw error;
+  }
+  return res.json();
+}
+
 /**
  * Translate UI-only container option flags into backend fields. Currently:
  * `disable_thinking` becomes `launch_kwargs: --default-chat-template-kwargs '{...}'`.

--- a/web/src/lib/requests.test.js
+++ b/web/src/lib/requests.test.js
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { buildContainerConfig } from "@/lib/requests";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { buildContainerConfig, setDefaultProfile } from "@/lib/requests";
 
 describe("buildContainerConfig", () => {
   it("strips disable_thinking when false and adds no launch_kwargs", () => {
@@ -26,5 +26,61 @@ describe("buildContainerConfig", () => {
       `--default-chat-template-kwargs '{"enable_thinking": false, "thinking": false}'`
     );
     expect(out.disable_custom_kernels).toBe(false);
+  });
+});
+
+describe("setDefaultProfile", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("PUTs to the encoded profile default endpoint and returns the body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: "my profile", default: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await setDefaultProfile("my profile");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toContain("/api/profiles/my%20profile/default");
+    expect(options).toEqual({ method: "PUT" });
+    expect(result).toEqual({ name: "my profile", default: true });
+  });
+
+  it("throws the server detail message on a non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ detail: "Profile not found." }),
+      })
+    );
+
+    await expect(setDefaultProfile("missing")).rejects.toMatchObject({
+      message: "Profile not found.",
+      status: 404,
+    });
+  });
+
+  it("falls back to a generic message when the error body is not JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => {
+          throw new Error("not json");
+        },
+      })
+    );
+
+    await expect(setDefaultProfile("broken")).rejects.toMatchObject({
+      message: "Failed to set default profile.",
+      status: 500,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds a `setDefaultProfile(name)` request (`PUT /api/profiles/{name}/default`) and surfaces it in the Settings panel: each profile row shows a star — solid/amber on the current default, an outline button elsewhere that flags that profile as default on click. Since exactly one default is enforced server-side, switching is done by starring a different profile.
- `ProfileProvider` now resolves the active profile to the one flagged `default = true` when there is no persisted (explicit) selection. The UI honors only the explicit flag — unlike the CLI it does not fall back to a profile named "default" or the first listed profile.

## Notes
- The default fallback is consulted in a narrow window: first load on a fresh browser, or when a previously-selected profile no longer exists. Once a user picks a profile it is pinned in `localStorage` and their choice always wins.
- Backend endpoint and the one-default invariant already shipped in #316; this PR is frontend-only.

## Test plan
- [x] `npm run lint` (no new warnings)
- [x] `npm test` (297 passed)
- [x] Manually verified: starring a profile sets it as default and updates the indicator; the default profile is used on a fresh browser with no stored selection.

Closes #337.