### PR TITLE
feat: allow profile renames (#317)

### DIFF
--- a/lib/docs/assets/img/coverage.svg
+++ b/lib/docs/assets/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">61%</text>
-        <text x="80" y="14">61%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">68%</text>
+        <text x="80" y="14">68%</text>
     </g>
 </svg>

--- a/lib/docs/usage/cli.md
+++ b/lib/docs/usage/cli.md
@@ -106,7 +106,33 @@ blackfish profile update --name <profile>
 ```
 
 This command updates the default profile if no `--name` is specified. Note that you cannot change
-the `name` or `schema` attributes of a profile.
+the `schema` of a profile. To change a profile's name, use `blackfish profile rename`.
+
+#### rename - Rename a profile
+
+To rename a profile, use the `blackfish profile rename` command, passing the current name followed
+by the new name. For example, to rename the profile `default` to `della`:
+
+```shell
+blackfish profile rename default della
+```
+
+```
+✔ Renamed profile 'default' to 'della'.
+```
+
+A profile name is referenced by the models, downloads, services, and jobs associated with it, so
+renaming cascades the new name to all of them in a single transaction. Because that cascade touches
+the database, this command **requires the Blackfish server to be running** (unlike other `profile`
+subcommands). Renaming fails if the new name is already in use:
+
+```shell
+blackfish profile rename della macbook
+```
+
+```
+✖ Profile 'macbook' already exists.
+```
 
 #### default - Set the default profile
 

--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -28,6 +28,7 @@ from blackfish.cli.profile import (
     upgrade_tigerflow,
     repair_profile,
     set_default_profile,
+    rename_profile,
     resolve_profile_or_exit,
 )
 from blackfish.server.models.profile import get_default_profile_name
@@ -201,6 +202,7 @@ profile.add_command(update_profile, "update")
 profile.add_command(upgrade_tigerflow, "upgrade")
 profile.add_command(repair_profile, "repair")
 profile.add_command(set_default_profile, "default")
+profile.add_command(rename_profile, "rename")
 
 
 @main.command()

--- a/lib/src/blackfish/cli/profile.py
+++ b/lib/src/blackfish/cli/profile.py
@@ -8,7 +8,9 @@ import os
 from enum import StrEnum
 from log_symbols.symbols import LogSymbols
 from yaspin import yaspin
+import requests
 
+from blackfish.server.config import config
 from blackfish.server.setup import ProfileManager, ProfileSetupError
 from blackfish.server.models.profile import (
     SlurmProfile,
@@ -648,9 +650,8 @@ def list_profiles(ctx: Context) -> None:  # pragma: no cover
 def update_profile(ctx: Context, name: str) -> None:  # pragma: no cover
     """Update a profile.
 
-    This command does not permit changes to a profile's name or type. If you wish
-    to rename a profile, you must delete the profile and then re-create
-    it using a new name.
+    This command does not permit changes to a profile's type. To rename a
+    profile, use `blackfish profile rename` instead.
     """
 
     success = _update_profile_(ctx.obj.get("home_dir"), "default", name)
@@ -732,6 +733,46 @@ def set_default_profile(ctx: Context, name: str) -> None:  # pragma: no cover
     with open(os.path.join(home_dir, "profiles.cfg"), "w") as f:
         profiles.write(f)
     print(f"{LogSymbols.SUCCESS.value} '{name}' is now the default profile.")
+
+
+@click.command(name="rename")
+@click.argument("old_name", type=str, required=True)
+@click.argument("new_name", type=str, required=True)
+def rename_profile(old_name: str, new_name: str) -> None:  # pragma: no cover
+    """Rename a profile from OLD_NAME to NEW_NAME.
+
+    Renames the profile and updates the stored profile name on every
+    associated model, download, service and job. This requires the Blackfish
+    server to be running.
+    """
+
+    try:
+        res = requests.put(
+            f"http://{config.HOST}:{config.PORT}/api/profiles/{old_name}/rename",
+            json={"new_name": new_name},
+        )
+    except requests.exceptions.ConnectionError:
+        print(
+            f"{LogSymbols.ERROR.value} Failed to connect to the Blackfish API. Is"
+            f" Blackfish running on port {config.PORT}?"
+        )
+        raise SystemExit(1)
+
+    if res.ok:
+        print(
+            f"{LogSymbols.SUCCESS.value} Renamed profile '{old_name}' to '{new_name}'."
+        )
+        return
+
+    detail = f"Failed to rename profile ({res.status_code})."
+    try:
+        body = res.json()
+        if isinstance(body, dict) and body.get("detail"):
+            detail = body["detail"]
+    except ValueError:
+        pass
+    print(f"{LogSymbols.ERROR.value} {detail}")
+    raise SystemExit(1)
 
 
 @click.command()

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -2619,6 +2619,12 @@ class ProfileRequest(BaseModel):
     python_path: Optional[str] = None  # For remote TigerFlow setup
 
 
+class RenameProfileRequest(BaseModel):
+    """Request model for renaming a profile."""
+
+    new_name: str
+
+
 def _profiles_config_path() -> str:
     """Return path to profiles.cfg."""
     return os.path.join(blackfish_config.HOME_DIR, "profiles.cfg")
@@ -2899,6 +2905,56 @@ async def set_profile_default(name: str) -> dict[str, str]:
     _save_profiles_config(config)
 
     return {"status": "ok", "message": f"'{name}' is now the default profile."}
+
+
+@put("/api/profiles/{name:str}/rename", guards=ENDPOINT_GUARDS)
+async def rename_profile(
+    name: str, data: RenameProfileRequest, session: AsyncSession
+) -> dict[str, str]:
+    """Rename a profile.
+
+    Renames the ``profiles.cfg`` section and cascades the new name to the
+    ``profile`` column on the model, download_task, service and jobs tables.
+    The DB updates and the file rewrite run within the request's transaction:
+    if the file rewrite fails, the DB changes roll back.
+    """
+    new_name = data.new_name.strip()
+
+    config = _get_profiles_config()
+
+    if name not in config:
+        raise NotFoundException(detail=f"Profile '{name}' not found.")
+
+    if not new_name:
+        raise ValidationException(detail="New profile name must not be empty.")
+
+    if new_name == name:
+        raise ValidationException(
+            detail="New profile name is the same as the current name."
+        )
+
+    if new_name in config:
+        raise ClientException(
+            status_code=HTTP_409_CONFLICT,
+            detail=f"Profile '{new_name}' already exists.",
+        )
+
+    # Cascade the new name to every table that stores it as a string.
+    for model in (Model, DownloadTask, Service, BatchJob):
+        await session.execute(
+            sa.update(model).where(model.profile == name).values(profile=new_name)
+        )
+
+    # Rewrite the section header, preserving all keys. A failure here raises,
+    # rolling back the DB updates above via the request transaction.
+    config[new_name] = {k: v for k, v in config[name].items()}
+    del config[name]
+    _save_profiles_config(config)
+
+    return {
+        "status": "ok",
+        "message": f"Profile '{name}' renamed to '{new_name}'.",
+    }
 
 
 @put("/api/profiles/{name:str}/repair", guards=ENDPOINT_GUARDS)
@@ -3522,6 +3578,7 @@ app = Litestar(
         update_profile,
         delete_profile,
         set_profile_default,
+        rename_profile,
         repair_profile,
         upgrade_profile,
         get_cluster_status,

--- a/lib/tests/api/test_profiles.py
+++ b/lib/tests/api/test_profiles.py
@@ -702,6 +702,117 @@ class TestDefaultFlagAPI:
             assert response.status_code == 404
 
 
+class TestRenameProfileAPI:
+    """Test cases for the PUT /api/profiles/{name}/rename endpoint."""
+
+    @staticmethod
+    def _config(*sections):
+        """Build a ConfigParser with the given local-profile sections."""
+        import configparser
+
+        cfg = configparser.ConfigParser()
+        for s in sections:
+            cfg[s] = {"schema": "local", "home_dir": "/h", "cache_dir": "/c"}
+        return cfg
+
+    @staticmethod
+    async def _count(session, model, profile):
+        import sqlalchemy as sa
+
+        res = await session.execute(
+            sa.select(sa.func.count())
+            .select_from(model)
+            .where(model.profile == profile)
+        )
+        return res.scalar()
+
+    async def test_rename_requires_authentication(
+        self, no_auth_client: AsyncTestClient
+    ):
+        response = await no_auth_client.put(
+            "/api/profiles/test/rename", json={"new_name": "x"}
+        )
+        assert response.status_code in [401, 403] or response.is_redirect
+
+    async def test_rename_sweeps_db_tables(self, client: AsyncTestClient, session):
+        """Rename cascades the new name to model, service and job rows."""
+        from blackfish.server.models.model import Model
+        from blackfish.server.services.base import Service
+        from blackfish.server.jobs.base import BatchJob
+
+        # The seeded fixtures use profile "test" on models, services and jobs.
+        for model in (Model, Service, BatchJob):
+            assert await self._count(session, model, "test") > 0
+
+        with (
+            patch(
+                "blackfish.server.asgi._get_profiles_config",
+                return_value=self._config("test", "default"),
+            ),
+            patch("blackfish.server.asgi._save_profiles_config") as mock_save,
+        ):
+            response = await client.put(
+                "/api/profiles/test/rename", json={"new_name": "renamed"}
+            )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "ok"
+        mock_save.assert_called_once()
+
+        for model in (Model, Service, BatchJob):
+            assert await self._count(session, model, "test") == 0
+            assert await self._count(session, model, "renamed") > 0
+
+    async def test_rename_collision_returns_409(self, client: AsyncTestClient):
+        """Renaming onto an existing profile name is rejected."""
+        with patch(
+            "blackfish.server.asgi._get_profiles_config",
+            return_value=self._config("test", "default"),
+        ):
+            response = await client.put(
+                "/api/profiles/test/rename", json={"new_name": "default"}
+            )
+        assert response.status_code == 409
+
+    async def test_rename_not_found_returns_404(self, client: AsyncTestClient):
+        with patch(
+            "blackfish.server.asgi._get_profiles_config",
+            return_value=self._config("default"),
+        ):
+            response = await client.put(
+                "/api/profiles/missing/rename", json={"new_name": "x"}
+            )
+        assert response.status_code == 404
+
+    async def test_rename_to_same_name_returns_400(self, client: AsyncTestClient):
+        with patch(
+            "blackfish.server.asgi._get_profiles_config",
+            return_value=self._config("test"),
+        ):
+            response = await client.put(
+                "/api/profiles/test/rename", json={"new_name": "test"}
+            )
+        assert response.status_code == 400
+
+    async def test_rename_collision_does_not_sweep_db(
+        self, client: AsyncTestClient, session
+    ):
+        """A rejected rename leaves the DB profile names untouched."""
+        from blackfish.server.models.model import Model
+
+        before = await self._count(session, Model, "test")
+        assert before > 0
+
+        with patch(
+            "blackfish.server.asgi._get_profiles_config",
+            return_value=self._config("test", "default"),
+        ):
+            await client.put("/api/profiles/test/rename", json={"new_name": "default"})
+
+        # The collision is rejected before any DB write, so counts are unchanged.
+        assert await self._count(session, Model, "test") == before
+
+
 class TestRepairProfileAPI:
     """Test cases for the PUT /api/profiles/{name}/repair endpoint."""
 

--- a/lib/tests/api/test_profiles.py
+++ b/lib/tests/api/test_profiles.py
@@ -1,6 +1,13 @@
+import configparser
 import pytest
+import sqlalchemy as sa
 from unittest.mock import patch, AsyncMock, MagicMock
 from litestar.testing import AsyncTestClient
+
+from blackfish.server.models.model import Model
+from blackfish.server.models.download import DownloadTask
+from blackfish.server.services.base import Service
+from blackfish.server.jobs.base import BatchJob
 
 pytestmark = pytest.mark.anyio
 
@@ -708,8 +715,6 @@ class TestRenameProfileAPI:
     @staticmethod
     def _config(*sections):
         """Build a ConfigParser with the given local-profile sections."""
-        import configparser
-
         cfg = configparser.ConfigParser()
         for s in sections:
             cfg[s] = {"schema": "local", "home_dir": "/h", "cache_dir": "/c"}
@@ -717,8 +722,6 @@ class TestRenameProfileAPI:
 
     @staticmethod
     async def _count(session, model, profile):
-        import sqlalchemy as sa
-
         res = await session.execute(
             sa.select(sa.func.count())
             .select_from(model)
@@ -735,13 +738,14 @@ class TestRenameProfileAPI:
         assert response.status_code in [401, 403] or response.is_redirect
 
     async def test_rename_sweeps_db_tables(self, client: AsyncTestClient, session):
-        """Rename cascades the new name to model, service and job rows."""
-        from blackfish.server.models.model import Model
-        from blackfish.server.services.base import Service
-        from blackfish.server.jobs.base import BatchJob
+        """Rename cascades the new name to all four profile-referencing tables."""
+        # The seeded fixtures cover model/service/job but not download_task,
+        # so add one download task against the "test" profile.
+        session.add(DownloadTask(repo_id="org/model", profile="test"))
+        await session.commit()
 
-        # The seeded fixtures use profile "test" on models, services and jobs.
-        for model in (Model, Service, BatchJob):
+        tables = (Model, DownloadTask, Service, BatchJob)
+        for model in tables:
             assert await self._count(session, model, "test") > 0
 
         with (
@@ -759,7 +763,7 @@ class TestRenameProfileAPI:
         assert response.json()["status"] == "ok"
         mock_save.assert_called_once()
 
-        for model in (Model, Service, BatchJob):
+        for model in tables:
             assert await self._count(session, model, "test") == 0
             assert await self._count(session, model, "renamed") > 0
 
@@ -798,8 +802,6 @@ class TestRenameProfileAPI:
         self, client: AsyncTestClient, session
     ):
         """A rejected rename leaves the DB profile names untouched."""
-        from blackfish.server.models.model import Model
-
         before = await self._count(session, Model, "test")
         assert before > 0
 

--- a/lib/tests/cli/test_cli_profiles.py
+++ b/lib/tests/cli/test_cli_profiles.py
@@ -612,6 +612,54 @@ class TestProfileUpdatePreservesDefault:
             assert parsed["default"]["default"] == "true"
 
 
+class TestProfileRename:
+    """Tests for `blackfish profile rename <old> <new>`."""
+
+    def test_rename_success(self, cli_runner):
+        from unittest.mock import Mock
+
+        mock_response = Mock()
+        mock_response.ok = True
+
+        with patch(
+            "blackfish.cli.profile.requests.put", return_value=mock_response
+        ) as mock_put:
+            result = cli_runner.invoke(main, ["profile", "rename", "old", "new"])
+
+        assert result.exit_code == 0
+        assert "Renamed profile 'old' to 'new'" in result.output
+        # The command targets the rename endpoint with the new name in the body.
+        url = mock_put.call_args[0][0]
+        assert url.endswith("/api/profiles/old/rename")
+        assert mock_put.call_args.kwargs["json"] == {"new_name": "new"}
+
+    def test_rename_error_response(self, cli_runner):
+        from unittest.mock import Mock
+
+        mock_response = Mock()
+        mock_response.ok = False
+        mock_response.status_code = 409
+        mock_response.json.return_value = {"detail": "Profile 'new' already exists."}
+
+        with patch("blackfish.cli.profile.requests.put", return_value=mock_response):
+            result = cli_runner.invoke(main, ["profile", "rename", "old", "new"])
+
+        assert result.exit_code == 1
+        assert "Profile 'new' already exists." in result.output
+
+    def test_rename_connection_error(self, cli_runner):
+        import requests
+
+        with patch(
+            "blackfish.cli.profile.requests.put",
+            side_effect=requests.exceptions.ConnectionError("refused"),
+        ):
+            result = cli_runner.invoke(main, ["profile", "rename", "old", "new"])
+
+        assert result.exit_code == 1
+        assert "Failed to connect" in result.output
+
+
 class TestProfileDefaultCommand:
     """Tests for `blackfish profile default <name>`."""
 

--- a/lib/tests/cli/test_cli_profiles.py
+++ b/lib/tests/cli/test_cli_profiles.py
@@ -1,7 +1,8 @@
 import pytest
 import tempfile
 import os
-from unittest.mock import patch
+import requests
+from unittest.mock import patch, Mock
 from click.testing import CliRunner
 from blackfish.cli.__main__ import main
 
@@ -616,8 +617,6 @@ class TestProfileRename:
     """Tests for `blackfish profile rename <old> <new>`."""
 
     def test_rename_success(self, cli_runner):
-        from unittest.mock import Mock
-
         mock_response = Mock()
         mock_response.ok = True
 
@@ -634,8 +633,6 @@ class TestProfileRename:
         assert mock_put.call_args.kwargs["json"] == {"new_name": "new"}
 
     def test_rename_error_response(self, cli_runner):
-        from unittest.mock import Mock
-
         mock_response = Mock()
         mock_response.ok = False
         mock_response.status_code = 409
@@ -648,8 +645,6 @@ class TestProfileRename:
         assert "Profile 'new' already exists." in result.output
 
     def test_rename_connection_error(self, cli_runner):
-        import requests
-
         with patch(
             "blackfish.cli.profile.requests.put",
             side_effect=requests.exceptions.ConnectionError("refused"),


### PR DESCRIPTION
## Summary
- Adds `PUT /api/profiles/{name}/rename` and a `blackfish profile rename <old> <new>` CLI command. Renames were previously blocked because a profile's name is a section header in `profiles.cfg` and a string column on four DB tables.
- A rename cascades the new name to the `profile` column on `model`, `download_task`, `service`, and `jobs` in addition to rewriting the `profiles.cfg` section header.
- The DB updates and the INI rewrite run inside the request transaction (DB updates first, then file write), so a file-write failure rolls the DB changes back.

## Changes
- **API** ([asgi.py](lib/src/blackfish/server/asgi.py)): new `rename_profile` endpoint. Validates the new name (non-empty, different, no collision → 409; missing source → 404), sweeps the four tables, rewrites the section header.
- **CLI** ([cli/profile.py](lib/src/blackfish/cli/profile.py)): new `profile rename` command calling the endpoint; handles a down server gracefully. `profile update`'s docstring now points renames here.
- **Docs**: new `rename` section in `usage/cli.md` with worked success/collision examples.

## Notes
- Because the cascade touches the database, `profile rename` **requires the Blackfish server to be running** — unlike other `profile` subcommands, which are file-only. This matches `model add`/`rm`, which already require the server.
- Type/schema changes (slurm ↔ local) remain out of scope per the issue.
- Residual atomicity gap: the request transaction commits in `session_provider`'s context-manager exit, after the handler's file write. A SQLite commit failure there would leave the INI renamed but the DB unchanged — practically never for a local file DB, but not strictly atomic.

## Test plan
- [x] `uv run just lint`
- [x] `uv run just test` (828 passed, 8 skipped)
- [x] API tests: DB sweep across model/service/job, collision (409), not-found (404), same-name (400), no-sweep-on-rejection
- [x] CLI tests: success, error response, connection error

Closes #317.