### PR TITLE
feat: scope profile provisioning to changed fields (#293)

### DIFF
--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -2767,13 +2767,28 @@ async def update_profile(name: str, data: ProfileRequest) -> Profile:
     # Preserve the existing default flag across the rewrite.
     was_default = section_is_default(config, name)
 
+    # Scoped provisioning: only run setup steps whose inputs actually changed,
+    # so a metadata-only edit doesn't re-run the full remote setup chain.
+    existing = config[name]
+    prev_schema = existing.get("schema") or existing.get("type")
+    schema_changed = data.schema_type != prev_schema
+    home_changed = data.home_dir != existing.get("home_dir")
+    cache_changed = data.cache_dir != existing.get("cache_dir")
+
     if data.schema_type == "slurm":
         if not data.host or not data.user:
             raise ValidationException(
                 detail="'host' and 'user' are required for Slurm profiles."
             )
 
-        # Set up directories and TigerFlow if missing
+        host_changed = data.host != existing.get("host")
+        user_changed = data.user != existing.get("user")
+        python_changed = (data.python_path or "python3") != existing.get(
+            "python_path", "python3"
+        )
+        # Changing the target machine invalidates everything provisioned for it.
+        full = schema_changed or host_changed or user_changed
+
         runner: SSHRunner | LocalRunner
         if data.host == "localhost":
             runner = LocalRunner()
@@ -2786,18 +2801,21 @@ async def update_profile(name: str, data: ProfileRequest) -> Profile:
                 home_dir=data.home_dir,
                 cache_dir=data.cache_dir,
             )
-            await profile_mgr.create_directories()
-            await profile_mgr.check_cache()
+            if full or home_changed:
+                await profile_mgr.create_directories()
+            if full or cache_changed:
+                await profile_mgr.check_cache()
 
-            # Install TigerFlow if not present
-            tigerflow = TigerFlowClient(
-                runner=runner,
-                home_dir=data.home_dir,
-                python_path=data.python_path or "python3",
-            )
-            version_ok, current_version = await tigerflow.check_version()
-            if current_version is None:
-                await tigerflow.setup()
+            # Install TigerFlow if not present.
+            if full or python_changed:
+                tigerflow = TigerFlowClient(
+                    runner=runner,
+                    home_dir=data.home_dir,
+                    python_path=data.python_path or "python3",
+                )
+                _, current_version = await tigerflow.check_version()
+                if current_version is None:
+                    await tigerflow.setup()
         except ProfileSetupError as e:
             raise InternalServerException(detail=e.user_message())
         except TigerFlowError as e:
@@ -2826,7 +2844,6 @@ async def update_profile(name: str, data: ProfileRequest) -> Profile:
         )
 
     elif data.schema_type == "local":
-        # Set up directories
         try:
             runner = LocalRunner()
             profile_mgr = ProfileManager(
@@ -2834,8 +2851,10 @@ async def update_profile(name: str, data: ProfileRequest) -> Profile:
                 home_dir=data.home_dir,
                 cache_dir=data.cache_dir,
             )
-            await profile_mgr.create_directories()
-            await profile_mgr.check_cache()
+            if schema_changed or home_changed:
+                await profile_mgr.create_directories()
+            if schema_changed or cache_changed:
+                await profile_mgr.check_cache()
         except ProfileSetupError as e:
             raise InternalServerException(detail=e.user_message())
 

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -2806,8 +2806,10 @@ async def update_profile(name: str, data: ProfileRequest) -> Profile:
             if full or cache_changed:
                 await profile_mgr.check_cache()
 
-            # Install TigerFlow if not present.
-            if full or python_changed:
+            # TigerFlow is installed under home_dir, so a home_dir change needs
+            # it (re)installed at the new location; python_path changes which
+            # interpreter builds its venv.
+            if full or home_changed or python_changed:
                 tigerflow = TigerFlowClient(
                     runner=runner,
                     home_dir=data.home_dir,

--- a/lib/tests/api/test_profiles.py
+++ b/lib/tests/api/test_profiles.py
@@ -640,8 +640,12 @@ class TestScopedProvisioning:
         body.update(overrides)
         return body
 
-    async def _put(self, client, name, section, body):
-        """PUT with mocked config + provisioning; returns (response, mgr, tf_cls)."""
+    async def _put(self, client, name, section, body, tf_version: str | None = "0.1.0"):
+        """PUT with mocked config + provisioning; returns (response, mgr, tf_cls).
+
+        ``tf_version`` is what TigerFlow's ``check_version`` reports — pass
+        ``None`` to simulate TigerFlow being absent (so ``setup`` would run).
+        """
         with (
             patch(
                 "blackfish.server.asgi._get_profiles_config",
@@ -654,7 +658,7 @@ class TestScopedProvisioning:
             mgr = AsyncMock()
             mgr_cls.return_value = mgr
             tf = AsyncMock()
-            tf.check_version.return_value = (True, "0.1.0")
+            tf.check_version.return_value = (tf_version is not None, tf_version)
             tf_cls.return_value = tf
             response = await client.put(f"/api/profiles/{name}", json=body)
         return response, mgr, tf_cls
@@ -668,14 +672,22 @@ class TestScopedProvisioning:
         mgr.create_directories.assert_not_called()
         tf_cls.assert_not_called()
 
-    async def test_home_only_change_runs_dirs_only(self, client):
+    async def test_home_change_reinstalls_tigerflow(self, client):
+        # TigerFlow lives under home_dir, so a home_dir change must reinstall it
+        # at the new location. The new home has no TigerFlow (tf_version=None),
+        # so setup() must run.
         response, mgr, tf_cls = await self._put(
-            client, "prof", self.SLURM, self._slurm_body(home_dir="/home/alice/bf")
+            client,
+            "prof",
+            self.SLURM,
+            self._slurm_body(home_dir="/home/alice/bf"),
+            tf_version=None,
         )
         assert response.status_code == 200
         mgr.create_directories.assert_called_once()
+        tf_cls.return_value.check_version.assert_called_once()
+        tf_cls.return_value.setup.assert_called_once()
         mgr.check_cache.assert_not_called()
-        tf_cls.assert_not_called()
 
     async def test_python_path_change_runs_tigerflow_only(self, client):
         response, mgr, tf_cls = await self._put(

--- a/lib/tests/api/test_profiles.py
+++ b/lib/tests/api/test_profiles.py
@@ -601,6 +601,122 @@ class TestUpdateProfileAPI:
             assert response.status_code == 400
 
 
+class TestScopedProvisioning:
+    """`PUT /api/profiles/{name}` runs only the setup steps whose inputs changed."""
+
+    SLURM = {
+        "schema": "slurm",
+        "host": "cluster.edu",
+        "user": "alice",
+        "home_dir": "/home/alice/.blackfish",
+        "cache_dir": "/scratch/alice",
+        "python_path": "python3",
+        "default": "true",
+    }
+    LOCAL = {
+        "schema": "local",
+        "home_dir": "/home/alice/.blackfish",
+        "cache_dir": "/tmp/cache",
+        "default": "true",
+    }
+
+    @classmethod
+    def _config(cls, name, section):
+        cfg = configparser.ConfigParser()
+        cfg[name] = dict(section)
+        return cfg
+
+    @staticmethod
+    def _slurm_body(**overrides):
+        body = {
+            "name": "prof",
+            "schema_type": "slurm",
+            "host": "cluster.edu",
+            "user": "alice",
+            "home_dir": "/home/alice/.blackfish",
+            "cache_dir": "/scratch/alice",
+            "python_path": "python3",
+        }
+        body.update(overrides)
+        return body
+
+    async def _put(self, client, name, section, body):
+        """PUT with mocked config + provisioning; returns (response, mgr, tf_cls)."""
+        with (
+            patch(
+                "blackfish.server.asgi._get_profiles_config",
+                return_value=self._config(name, section),
+            ),
+            patch("blackfish.server.asgi._save_profiles_config"),
+            patch("blackfish.server.asgi.ProfileManager") as mgr_cls,
+            patch("blackfish.server.asgi.TigerFlowClient") as tf_cls,
+        ):
+            mgr = AsyncMock()
+            mgr_cls.return_value = mgr
+            tf = AsyncMock()
+            tf.check_version.return_value = (True, "0.1.0")
+            tf_cls.return_value = tf
+            response = await client.put(f"/api/profiles/{name}", json=body)
+        return response, mgr, tf_cls
+
+    async def test_cache_only_change_skips_dirs_and_tigerflow(self, client):
+        response, mgr, tf_cls = await self._put(
+            client, "prof", self.SLURM, self._slurm_body(cache_dir="/scratch/new")
+        )
+        assert response.status_code == 200
+        mgr.check_cache.assert_called_once()
+        mgr.create_directories.assert_not_called()
+        tf_cls.assert_not_called()
+
+    async def test_home_only_change_runs_dirs_only(self, client):
+        response, mgr, tf_cls = await self._put(
+            client, "prof", self.SLURM, self._slurm_body(home_dir="/home/alice/bf")
+        )
+        assert response.status_code == 200
+        mgr.create_directories.assert_called_once()
+        mgr.check_cache.assert_not_called()
+        tf_cls.assert_not_called()
+
+    async def test_python_path_change_runs_tigerflow_only(self, client):
+        response, mgr, tf_cls = await self._put(
+            client, "prof", self.SLURM, self._slurm_body(python_path="python3.12")
+        )
+        assert response.status_code == 200
+        tf_cls.return_value.check_version.assert_called_once()
+        mgr.create_directories.assert_not_called()
+        mgr.check_cache.assert_not_called()
+
+    async def test_no_change_skips_all_provisioning(self, client):
+        response, mgr, tf_cls = await self._put(
+            client, "prof", self.SLURM, self._slurm_body()
+        )
+        assert response.status_code == 200
+        mgr.create_directories.assert_not_called()
+        mgr.check_cache.assert_not_called()
+        tf_cls.assert_not_called()
+
+    async def test_host_change_runs_full_chain(self, client):
+        response, mgr, tf_cls = await self._put(
+            client, "prof", self.SLURM, self._slurm_body(host="other.edu")
+        )
+        assert response.status_code == 200
+        mgr.create_directories.assert_called_once()
+        mgr.check_cache.assert_called_once()
+        tf_cls.return_value.check_version.assert_called_once()
+
+    async def test_local_cache_only_change_skips_dirs(self, client):
+        body = {
+            "name": "prof",
+            "schema_type": "local",
+            "home_dir": "/home/alice/.blackfish",
+            "cache_dir": "/tmp/other",
+        }
+        response, mgr, _ = await self._put(client, "prof", self.LOCAL, body)
+        assert response.status_code == 200
+        mgr.check_cache.assert_called_once()
+        mgr.create_directories.assert_not_called()
+
+
 class TestDeleteProfileAPI:
     """Test cases for the DELETE /api/profiles/{name} endpoint."""
 


### PR DESCRIPTION
## Summary
- `PUT /api/profiles/{name}` previously re-ran the full provisioning chain — `create_directories`, `check_cache`, `tigerflow.check_version`, `tigerflow.setup` — on every edit, so a metadata-only change still required a reachable host and a full TigerFlow handshake.
- The handler now diffs the request against the saved section and runs only the steps whose inputs changed.

## Scoped behavior

| Field changed | Steps run |
|---|---|
| `host` / `user` / `schema` | full chain |
| `home_dir` | `create_directories` + TigerFlow reinstall (it lives under `home_dir`) |
| `cache_dir` | `check_cache` |
| `python_path` | `tigerflow.check_version` (+ `setup` if missing) |
| nothing relevant | none — no remote calls |

Only a no-op edit is fully network-free; the others still make one targeted call but skip the rest of the chain (notably the TigerFlow handshake).

## Notes
- `POST /api/profiles` is unchanged — a create has no prior state to diff against.
- The CLI `profile update` uses its own local `_setup_profile` path and is unaffected; this is API-only (the web UI's edit form). No new CLI/API surface, so no docs change.
- Config rollback was considered and dropped: `update_profile` already provisions *before* writing the config, so a provision failure raises before the file is touched.

## Test plan
- [x] `uv run just lint`
- [x] `uv run just test` (834 passed, 8 skipped)
- [x] New `TestScopedProvisioning`: cache-only / home-only / python_path-only / no-change / host-change / local cache-only — each asserts exactly which provisioning steps ran.
- [x] Existing `TestUpdateProfileAPI` unchanged and passing.

Closes #293.
