### PR TITLE
feat: profile settings UX improvements

### DIFF
--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -2966,11 +2966,16 @@ async def rename_profile(
             sa.update(model).where(model.profile == name).values(profile=new_name)
         )
 
-    # Rewrite the section header, preserving all keys. A failure here raises,
-    # rolling back the DB updates above via the request transaction.
-    config[new_name] = {k: v for k, v in config[name].items()}
-    del config[name]
-    _save_profiles_config(config)
+    # Rewrite the section, preserving its position in the file. configparser
+    # appends new sections, so a naive add-then-delete would move the renamed
+    # profile to the end of the list; rebuild in original order instead. A
+    # failure here raises, rolling back the DB updates above via the request
+    # transaction.
+    renamed = configparser.ConfigParser()
+    for section in config.sections():
+        target = new_name if section == name else section
+        renamed[target] = {k: v for k, v in config[section].items()}
+    _save_profiles_config(renamed)
 
     return {
         "status": "ok",

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -2970,7 +2970,8 @@ async def rename_profile(
     # appends new sections, so a naive add-then-delete would move the renamed
     # profile to the end of the list; rebuild in original order instead. A
     # failure here raises, rolling back the DB updates above via the request
-    # transaction.
+    # transaction. profiles.cfg uses no [DEFAULT] section, so sections() is
+    # exhaustive here.
     renamed = configparser.ConfigParser()
     for section in config.sections():
         target = new_name if section == name else section

--- a/lib/tests/api/test_profiles.py
+++ b/lib/tests/api/test_profiles.py
@@ -895,6 +895,23 @@ class TestRenameProfileAPI:
             assert await self._count(session, model, "test") == 0
             assert await self._count(session, model, "renamed") > 0
 
+    async def test_rename_preserves_profile_order(self, client: AsyncTestClient):
+        """Renaming keeps the profile in its original position in the file."""
+        with (
+            patch(
+                "blackfish.server.asgi._get_profiles_config",
+                return_value=self._config("test", "middle", "default"),
+            ),
+            patch("blackfish.server.asgi._save_profiles_config") as mock_save,
+        ):
+            response = await client.put(
+                "/api/profiles/test/rename", json={"new_name": "renamed"}
+            )
+
+        assert response.status_code == 200
+        saved_config = mock_save.call_args.args[0]
+        assert saved_config.sections() == ["renamed", "middle", "default"]
+
     async def test_rename_collision_returns_409(self, client: AsyncTestClient):
         """Renaming onto an existing profile name is rejected."""
         with patch(

--- a/web/src/components/SettingsSlideOver.jsx
+++ b/web/src/components/SettingsSlideOver.jsx
@@ -92,7 +92,10 @@ const schemaTypes = [
 function ProfileForm({ profile, existingNames = [], onSave, onCancel }) {
   const isNew = !profile;
   const { setBusy } = useSettingsBusy();
-  const initialFormData = {
+  // Mount-time snapshot of the loaded profile — the baseline for dirty
+  // tracking. `profile` is stable for the form's lifetime (the parent
+  // unmounts the form on save/cancel rather than mutating the prop).
+  const [initialFormData] = useState(() => ({
     name: profile?.name || "",
     schema_type: profile?.schema || "local",
     home_dir: profile?.home_dir || "",
@@ -100,14 +103,19 @@ function ProfileForm({ profile, existingNames = [], onSave, onCancel }) {
     host: profile?.host || "",
     user: profile?.user || "",
     python_path: profile?.python_path || "",
-  };
+  }));
   const [formData, setFormData] = useState(initialFormData);
   const [error, setError] = useState(null);
   const [fieldErrors, setFieldErrors] = useState({});
   const [saving, setSaving] = useState(false);
 
   const selectedType = schemaTypes.find((t) => t.id === formData.schema_type) || schemaTypes[0];
-  const isDirty = JSON.stringify(formData) !== JSON.stringify(initialFormData);
+  // Single source of truth for what changed, so the Save-button `isDirty`
+  // guard and the `configChanged` API gate below cannot drift apart.
+  const changedKeys = Object.keys(formData).filter(
+    (key) => formData[key] !== initialFormData[key]
+  );
+  const isDirty = changedKeys.length > 0;
 
   const validateForm = () => {
     const errors = {};
@@ -167,19 +175,13 @@ function ProfileForm({ profile, existingNames = [], onSave, onCancel }) {
     // Renaming is a separate endpoint from the config update — the PUT route
     // rejects name changes — so an edit can involve two independent calls.
     const nameChanged = !isNew && nextName !== profile.name;
-    const configChanged =
-      !isNew &&
-      (formData.schema_type !== (profile.schema || "local") ||
-        formData.home_dir !== (profile.home_dir || "") ||
-        formData.cache_dir !== (profile.cache_dir || "") ||
-        formData.host !== (profile.host || "") ||
-        formData.user !== (profile.user || "") ||
-        formData.python_path !== (profile.python_path || ""));
+    const configChanged = !isNew && changedKeys.some((key) => key !== "name");
 
     setSaving(true);
     setBusy(true);
     let phase = isNew ? "create" : "update";
     let configSaved = false;
+    let succeeded = false;
     try {
       if (isNew) {
         await createProfile(data);
@@ -193,7 +195,7 @@ function ProfileForm({ profile, existingNames = [], onSave, onCancel }) {
           await renameProfile(profile.name, nextName);
         }
       }
-      onSave(isNew ? { name: nextName } : { previousName: profile.name, name: nextName });
+      succeeded = true;
     } catch (err) {
       if (phase === "rename") {
         setError(
@@ -210,6 +212,12 @@ function ProfileForm({ profile, existingNames = [], onSave, onCancel }) {
     } finally {
       setSaving(false);
       setBusy(false);
+    }
+
+    // Called outside the try/catch: a throw inside onSave (e.g. mutate())
+    // must not be reported as a save failure when the save itself succeeded.
+    if (succeeded) {
+      onSave(isNew ? { name: nextName } : { previousName: profile.name, name: nextName });
     }
   };
 
@@ -366,8 +374,8 @@ function ProfileForm({ profile, existingNames = [], onSave, onCancel }) {
 
       {saving && (
         <p className="text-xs text-gray-500 dark:text-gray-400">
-          Setting up the profile. Installing TigerFlow can take a few minutes —
-          please keep this panel open until it finishes.
+          Setting up the profile. Installing dependencies can take a few
+          minutes — please keep this panel open until it finishes.
         </p>
       )}
 

--- a/web/src/components/SettingsSlideOver.jsx
+++ b/web/src/components/SettingsSlideOver.jsx
@@ -31,6 +31,7 @@ import { useTheme } from "@/providers/ThemeProvider";
 import { ProfileContext } from "@/components/ProfileSelect";
 import { useProfiles } from "@/lib/loaders";
 import Notification from "@/components/Notification";
+import Alert from "@/components/Alert";
 import { createProfile, updateProfile, renameProfile, deleteProfile, setDefaultProfile, fetchHfTokenStatus, setHfToken, deleteHfToken, fetchAppInfo } from "@/lib/requests";
 import { blackfishApiURL } from "@/config";
 
@@ -197,18 +198,19 @@ function ProfileForm({ profile, existingNames = [], onSave, onCancel }) {
       }
       succeeded = true;
     } catch (err) {
+      let title;
+      let detail = err.message;
       if (phase === "rename") {
-        setError(
-          configSaved
-            ? `${err.message} Configuration changes were saved, but the profile was not renamed.`
-            : `${err.message} The profile name was not changed.`
-        );
+        title = "Failed to rename profile.";
+        if (configSaved) {
+          detail = `${err.message} Your configuration changes were saved; only the name change failed.`;
+        }
+      } else if (isNew) {
+        title = "Failed to create profile.";
       } else {
-        setError(
-          `${err.message} The profile was not ${isNew ? "created" : "saved"} — ` +
-            "your previous configuration is unchanged."
-        );
+        title = "Failed to save profile changes.";
       }
+      setError({ title, detail });
     } finally {
       setSaving(false);
       setBusy(false);
@@ -231,9 +233,9 @@ function ProfileForm({ profile, existingNames = [], onSave, onCancel }) {
           flight, so the form can't be edited, cancelled, or re-submitted. */}
       <fieldset disabled={saving} className="space-y-3 m-0 p-0 border-0 min-w-0">
       {error && (
-        <div className="rounded-md bg-red-50 dark:bg-red-900/20 p-2 text-sm text-red-700 dark:text-red-400">
-          {error}
-        </div>
+        <Alert variant="error" title={error.title}>
+          {error.detail}
+        </Alert>
       )}
 
       {/* Name */}

--- a/web/src/components/SettingsSlideOver.jsx
+++ b/web/src/components/SettingsSlideOver.jsx
@@ -23,6 +23,7 @@ import {
   CheckIcon,
   ChevronUpDownIcon,
   StarIcon,
+  ArrowPathIcon,
 } from "@heroicons/react/24/outline";
 import { StarIcon as StarIconSolid } from "@heroicons/react/24/solid";
 import { useSettings } from "@/providers/SettingsProvider";
@@ -30,12 +31,18 @@ import { useTheme } from "@/providers/ThemeProvider";
 import { ProfileContext } from "@/components/ProfileSelect";
 import { useProfiles } from "@/lib/loaders";
 import Notification from "@/components/Notification";
-import { createProfile, updateProfile, deleteProfile, setDefaultProfile, fetchHfTokenStatus, setHfToken, deleteHfToken, fetchAppInfo } from "@/lib/requests";
+import { createProfile, updateProfile, renameProfile, deleteProfile, setDefaultProfile, fetchHfTokenStatus, setHfToken, deleteHfToken, fetchAppInfo } from "@/lib/requests";
 import { blackfishApiURL } from "@/config";
 
 // Context for toast notifications within Settings
 const NotificationContext = createContext({ showError: () => {}, showSuccess: () => {} });
 const useNotification = () => useContext(NotificationContext);
+
+// Tracks whether a blocking operation (e.g. profile provisioning) is running.
+// While busy, the slide-over refuses to close so the in-flight request can't
+// be orphaned with its result (success or failure) discarded.
+const SettingsBusyContext = createContext({ busy: false, setBusy: () => {} });
+const useSettingsBusy = () => useContext(SettingsBusyContext);
 
 // Theme selector tabs
 const themeOptions = [
@@ -82,9 +89,10 @@ const schemaTypes = [
   { id: "slurm", name: "Slurm" },
 ];
 
-function ProfileForm({ profile, onSave, onCancel }) {
+function ProfileForm({ profile, existingNames = [], onSave, onCancel }) {
   const isNew = !profile;
-  const [formData, setFormData] = useState({
+  const { setBusy } = useSettingsBusy();
+  const initialFormData = {
     name: profile?.name || "",
     schema_type: profile?.schema || "local",
     home_dir: profile?.home_dir || "",
@@ -92,18 +100,25 @@ function ProfileForm({ profile, onSave, onCancel }) {
     host: profile?.host || "",
     user: profile?.user || "",
     python_path: profile?.python_path || "",
-  });
+  };
+  const [formData, setFormData] = useState(initialFormData);
   const [error, setError] = useState(null);
   const [fieldErrors, setFieldErrors] = useState({});
   const [saving, setSaving] = useState(false);
 
   const selectedType = schemaTypes.find((t) => t.id === formData.schema_type) || schemaTypes[0];
+  const isDirty = JSON.stringify(formData) !== JSON.stringify(initialFormData);
 
   const validateForm = () => {
     const errors = {};
 
     // Required fields
-    if (!formData.name.trim()) errors.name = "Name is required";
+    const trimmedName = formData.name.trim();
+    if (!trimmedName) {
+      errors.name = "Name is required";
+    } else if (trimmedName !== profile?.name && existingNames.includes(trimmedName)) {
+      errors.name = "A profile with that name already exists";
+    }
     if (!formData.home_dir.trim()) errors.home_dir = "Home directory is required";
     if (!formData.cache_dir.trim()) errors.cache_dir = "Cache directory is required";
 
@@ -136,32 +151,65 @@ function ProfileForm({ profile, onSave, onCancel }) {
 
     if (!validateForm()) return;
 
+    const nextName = formData.name.trim();
+    const data = {
+      name: nextName,
+      schema_type: formData.schema_type,
+      home_dir: formData.home_dir,
+      cache_dir: formData.cache_dir,
+    };
+    if (formData.schema_type === "slurm") {
+      data.host = formData.host;
+      data.user = formData.user;
+      if (formData.python_path) data.python_path = formData.python_path;
+    }
+
+    // Renaming is a separate endpoint from the config update — the PUT route
+    // rejects name changes — so an edit can involve two independent calls.
+    const nameChanged = !isNew && nextName !== profile.name;
+    const configChanged =
+      !isNew &&
+      (formData.schema_type !== (profile.schema || "local") ||
+        formData.home_dir !== (profile.home_dir || "") ||
+        formData.cache_dir !== (profile.cache_dir || "") ||
+        formData.host !== (profile.host || "") ||
+        formData.user !== (profile.user || "") ||
+        formData.python_path !== (profile.python_path || ""));
+
     setSaving(true);
-
+    setBusy(true);
+    let phase = isNew ? "create" : "update";
+    let configSaved = false;
     try {
-      const data = {
-        name: formData.name,
-        schema_type: formData.schema_type,
-        home_dir: formData.home_dir,
-        cache_dir: formData.cache_dir,
-      };
-
-      if (formData.schema_type === "slurm") {
-        data.host = formData.host;
-        data.user = formData.user;
-        if (formData.python_path) data.python_path = formData.python_path;
-      }
-
       if (isNew) {
         await createProfile(data);
       } else {
-        await updateProfile(profile.name, data);
+        if (configChanged) {
+          await updateProfile(profile.name, { ...data, name: profile.name });
+          configSaved = true;
+        }
+        if (nameChanged) {
+          phase = "rename";
+          await renameProfile(profile.name, nextName);
+        }
       }
-      onSave();
+      onSave(isNew ? { name: nextName } : { previousName: profile.name, name: nextName });
     } catch (err) {
-      setError(err.message);
+      if (phase === "rename") {
+        setError(
+          configSaved
+            ? `${err.message} Configuration changes were saved, but the profile was not renamed.`
+            : `${err.message} The profile name was not changed.`
+        );
+      } else {
+        setError(
+          `${err.message} The profile was not ${isNew ? "created" : "saved"} — ` +
+            "your previous configuration is unchanged."
+        );
+      }
     } finally {
       setSaving(false);
+      setBusy(false);
     }
   };
 
@@ -170,7 +218,10 @@ function ProfileForm({ profile, onSave, onCancel }) {
   const errorClasses = "mt-1 text-xs text-red-600 dark:text-red-400";
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-3">
+    <form onSubmit={handleSubmit}>
+      {/* Disabling the fieldset freezes every control while a save is in
+          flight, so the form can't be edited, cancelled, or re-submitted. */}
+      <fieldset disabled={saving} className="space-y-3 m-0 p-0 border-0 min-w-0">
       {error && (
         <div className="rounded-md bg-red-50 dark:bg-red-900/20 p-2 text-sm text-red-700 dark:text-red-400">
           {error}
@@ -184,7 +235,6 @@ function ProfileForm({ profile, onSave, onCancel }) {
           type="text"
           value={formData.name}
           onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-          disabled={!isNew}
           className={`mt-1 ${inputClasses(fieldErrors.name)}`}
         />
         {fieldErrors.name && <p className={errorClasses}>{fieldErrors.name}</p>}
@@ -314,22 +364,31 @@ function ProfileForm({ profile, onSave, onCancel }) {
         </div>
       )}
 
+      {saving && (
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Setting up the profile. Installing TigerFlow can take a few minutes —
+          please keep this panel open until it finishes.
+        </p>
+      )}
+
       <div className="flex justify-end gap-3 pt-1">
         <button
           type="button"
           onClick={onCancel}
-          className="px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
+          className="px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 disabled:opacity-50"
         >
           Cancel
         </button>
         <button
           type="submit"
-          disabled={saving}
-          className="rounded-md bg-blue-500 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-blue-600 disabled:opacity-50"
+          disabled={saving || !isDirty}
+          className="inline-flex items-center gap-1.5 rounded-md bg-blue-500 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-blue-600 disabled:opacity-50"
         >
-          {saving ? "Saving..." : isNew ? "Create" : "Save"}
+          {saving && <ArrowPathIcon className="h-4 w-4 animate-spin" aria-hidden="true" />}
+          {saving ? "Provisioning…" : isNew ? "Create" : "Save"}
         </button>
       </div>
+      </fieldset>
     </form>
   );
 }
@@ -344,6 +403,7 @@ ProfileForm.propTypes = {
     user: PropTypes.string,
     python_path: PropTypes.string,
   }),
+  existingNames: PropTypes.arrayOf(PropTypes.string),
   onSave: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
 };
@@ -394,11 +454,27 @@ function ProfilesSection() {
     }
   };
 
-  const handleSave = () => {
+  const handleSave = ({ previousName, name } = {}) => {
+    // If the currently-selected profile was renamed, keep the selection
+    // pointed at it under its new name.
+    if (previousName && name && previousName !== name && selectedProfile?.name === previousName) {
+      setProfile({ ...selectedProfile, name });
+    }
     mutate();
     setEditingProfile(null);
     setIsAdding(false);
+    if (name) {
+      if (!previousName) {
+        showSuccess(`Profile "${name}" created`);
+      } else if (previousName !== name) {
+        showSuccess(`Profile renamed to "${name}"`);
+      } else {
+        showSuccess(`Profile "${name}" updated`);
+      }
+    }
   };
+
+  const existingNames = profiles?.map((p) => p.name) ?? [];
 
   const handleSetDefault = async (profileName) => {
     if (settingDefault) return;
@@ -444,7 +520,7 @@ function ProfilesSection() {
       <div>
         {renderHeader()}
         <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4">
-          <ProfileForm onSave={handleSave} onCancel={() => setIsAdding(false)} />
+          <ProfileForm existingNames={existingNames} onSave={handleSave} onCancel={() => setIsAdding(false)} />
         </div>
       </div>
     );
@@ -455,7 +531,7 @@ function ProfilesSection() {
       <div>
         {renderHeader()}
         <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4">
-          <ProfileForm profile={editingProfile} onSave={handleSave} onCancel={() => setEditingProfile(null)} />
+          <ProfileForm profile={editingProfile} existingNames={existingNames} onSave={handleSave} onCancel={() => setEditingProfile(null)} />
         </div>
       </div>
     );
@@ -856,6 +932,7 @@ function AppConfigSection() {
 function SettingsSlideOver() {
   const { isOpen, closeSettings } = useSettings();
   const [notification, setNotification] = useState({ show: false, variant: "error", message: "" });
+  const [busy, setBusy] = useState(false);
 
   // Auto-dismiss notification after 5 seconds
   useEffect(() => {
@@ -877,7 +954,8 @@ function SettingsSlideOver() {
 
   return (
     <NotificationContext.Provider value={{ showError, showSuccess }}>
-      <Dialog open={isOpen} onClose={closeSettings} className="relative z-50">
+      <SettingsBusyContext.Provider value={{ busy, setBusy }}>
+      <Dialog open={isOpen} onClose={busy ? () => {} : closeSettings} className="relative z-50">
       <DialogBackdrop
         transition
         className="fixed inset-0 bg-gray-500 dark:bg-gray-900 bg-opacity-75 dark:bg-opacity-80 transition-opacity duration-300 ease-linear data-[closed]:opacity-0"
@@ -900,7 +978,8 @@ function SettingsSlideOver() {
                       <button
                         type="button"
                         onClick={closeSettings}
-                        className="rounded-md text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 focus:outline-none data-[closed]:opacity-0"
+                        disabled={busy}
+                        className="rounded-md text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 focus:outline-none data-[closed]:opacity-0 disabled:opacity-30 disabled:cursor-not-allowed"
                       >
                         <span className="sr-only">Close panel</span>
                         <XMarkIcon className="h-6 w-6" />
@@ -938,17 +1017,22 @@ function SettingsSlideOver() {
                   </section>
                 </div>
               </div>
+              {/* Rendered inside the DialogPanel: keeps the toast out of the
+                  inert sibling tree (so its dismiss button is clickable) while
+                  also keeping clicks on it from registering as a click-outside
+                  that would close the slide-over. */}
+              <Notification
+                show={notification.show}
+                variant={notification.variant}
+                message={notification.message}
+                onDismiss={() => setNotification((prev) => ({ ...prev, show: false }))}
+              />
             </DialogPanel>
           </div>
         </div>
       </div>
     </Dialog>
-      <Notification
-        show={notification.show}
-        variant={notification.variant}
-        message={notification.message}
-        onDismiss={() => setNotification((prev) => ({ ...prev, show: false }))}
-      />
+      </SettingsBusyContext.Provider>
     </NotificationContext.Provider>
   );
 }

--- a/web/src/lib/requests.js
+++ b/web/src/lib/requests.js
@@ -104,6 +104,28 @@ export async function updateProfile(name, data) {
   return res.json();
 }
 
+/** Rename a profile. */
+export async function renameProfile(name, newName) {
+  const res = await fetch(`${blackfishApiURL}/api/profiles/${encodeURIComponent(name)}/rename`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ new_name: newName }),
+  });
+  if (!res.ok) {
+    let message = "Failed to rename profile.";
+    try {
+      const body = await res.json();
+      if (body.detail) message = body.detail;
+    } catch {
+      // Ignore JSON parse errors
+    }
+    const error = new Error(message);
+    error.status = res.status;
+    throw error;
+  }
+  return res.json();
+}
+
 /** Delete a profile. */
 export async function deleteProfile(name) {
   const res = await fetch(`${blackfishApiURL}/api/profiles/${encodeURIComponent(name)}`, {


### PR DESCRIPTION
## Summary

- Profile **name is now editable** in the Settings edit form. A rename goes through the dedicated `PUT /api/profiles/{name}/rename` endpoint (the config-update `PUT` rejects name changes), so an edit can issue two independent calls — config update first, then rename — with the error banner stating clearly what was and wasn't saved.
- The **Save button is disabled until the form is dirty**, and the whole form + slide-over **freezes while a save is in flight** (fields/Cancel disabled, panel non-dismissable, spinner + "installing TigerFlow may take a few minutes" copy). This closes the gap where closing the panel mid-request orphaned the result.
- **Success toasts** on create/update/rename (previously silent), and the toast renders inside the `DialogPanel` so it isn't `inert` and dismissing it doesn't close the slide-over.
- Backend fix: `rename_profile` rebuilt `profiles.cfg` via add-then-delete, which moved a renamed profile to the end of the list. It now rebuilds the config in original section order.

## Test plan

- [x] Rename a profile in Settings — confirm it keeps its position in the list and shows a success toast.
- [x] Rename the currently-selected profile — confirm the selection follows it.
- [x] Edit a profile without changing anything — Save stays disabled.
- [x] Trigger a provisioning failure — error banner states the profile was not saved; form values persist.
- [x] Start a save — confirm fields/Cancel are frozen and the slide-over can't be closed until it completes.
- [x] Create/update a profile — confirm the success toast appears and can be dismissed without closing the panel.

Closes #295