### PR TITLE
feat: validate profile names (#340)

### DIFF
--- a/lib/src/blackfish/cli/profile.py
+++ b/lib/src/blackfish/cli/profile.py
@@ -19,6 +19,7 @@ from blackfish.server.models.profile import (
     has_any_default,
     section_is_default,
     set_exclusive_default,
+    validate_profile_name,
 )
 from blackfish.server.jobs.client import (
     TigerFlowClient,
@@ -228,6 +229,12 @@ def _create_profile_(app_dir: str, default_name: str = "default") -> bool:
     name = input(f"> name [{default_name}]: ")
     name = default_name if name == "" else name
 
+    try:
+        validate_profile_name(name)
+    except ValueError as e:
+        print(f"{LogSymbols.ERROR.value} {e}")
+        return False
+
     if name in profiles:
         print(
             f"{LogSymbols.ERROR.value} Profile named {name} already exists. Try"
@@ -339,6 +346,13 @@ def _auto_profile_(
 ) -> bool:
     profiles = configparser.ConfigParser()
     profiles.read(f"{home_dir}/profiles.cfg")
+
+    if name is not None:
+        try:
+            validate_profile_name(name)
+        except ValueError as e:
+            print(f"{LogSymbols.ERROR.value} {e}")
+            return False
 
     if name in profiles:
         print(

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -100,6 +100,7 @@ from blackfish.server.models.profile import (
     resolve_default_section,
     section_is_default,
     set_exclusive_default,
+    validate_profile_name,
     SlurmProfile,
     LocalProfile,
     BlackfishProfile as Profile,
@@ -2649,6 +2650,11 @@ async def create_profile(data: ProfileRequest) -> Profile:
     """
     config = _get_profiles_config()
 
+    try:
+        validate_profile_name(data.name)
+    except ValueError as e:
+        raise ValidationException(detail=str(e))
+
     if data.name in config:
         raise ClientException(
             status_code=HTTP_409_CONFLICT,
@@ -2946,8 +2952,10 @@ async def rename_profile(
     if name not in config:
         raise NotFoundException(detail=f"Profile '{name}' not found.")
 
-    if not new_name:
-        raise ValidationException(detail="New profile name must not be empty.")
+    try:
+        validate_profile_name(new_name)
+    except ValueError as e:
+        raise ValidationException(detail=str(e))
 
     if new_name == name:
         raise ValidationException(

--- a/lib/src/blackfish/server/models/profile.py
+++ b/lib/src/blackfish/server/models/profile.py
@@ -4,6 +4,26 @@ from dataclasses import dataclass
 from typing import Union
 from configparser import ConfigParser
 import os
+import re
+
+
+_VALID_PROFILE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+_PROFILE_NAME_RULE = (
+    "Profile names may only contain letters, digits, dots, hyphens, and underscores."
+)
+
+
+def validate_profile_name(name: str) -> None:
+    """Raise ``ValueError`` if ``name`` is not a safe profiles.cfg section name.
+
+    Profile names become INI section headers, so characters meaningful to
+    ConfigParser (``[``, ``]``, ``=``, ``:``, newlines) would corrupt the file.
+    ``DEFAULT`` is also rejected as ConfigParser's reserved section name.
+    """
+    if name == "DEFAULT":
+        raise ValueError("'DEFAULT' is reserved and cannot be used as a profile name.")
+    if not _VALID_PROFILE_NAME.match(name):
+        raise ValueError(f"Invalid profile name '{name}'. {_PROFILE_NAME_RULE}")
 
 
 @dataclass

--- a/lib/tests/api/test_profiles.py
+++ b/lib/tests/api/test_profiles.py
@@ -141,6 +141,20 @@ class TestCreateProfileAPI:
         )
         assert response.status_code in [401, 403] or response.is_redirect
 
+    async def test_create_profile_invalid_name(self, client: AsyncTestClient):
+        """A profile name with ConfigParser-meaningful characters is rejected."""
+        response = await client.post(
+            "/api/profiles",
+            json={
+                "name": "bad[name",
+                "schema_type": "local",
+                "home_dir": "/tmp/test",
+                "cache_dir": "/tmp/cache",
+            },
+        )
+        assert response.status_code == 400
+        assert "Invalid profile name" in response.json()["detail"]
+
     async def test_create_local_profile_success(self, client: AsyncTestClient):
         """Test creating a local profile successfully."""
         with (
@@ -942,6 +956,17 @@ class TestRenameProfileAPI:
                 "/api/profiles/test/rename", json={"new_name": "test"}
             )
         assert response.status_code == 400
+
+    async def test_rename_to_invalid_name_returns_400(self, client: AsyncTestClient):
+        with patch(
+            "blackfish.server.asgi._get_profiles_config",
+            return_value=self._config("test"),
+        ):
+            response = await client.put(
+                "/api/profiles/test/rename", json={"new_name": "bad[name"}
+            )
+        assert response.status_code == 400
+        assert "Invalid profile name" in response.json()["detail"]
 
     async def test_rename_collision_does_not_sweep_db(
         self, client: AsyncTestClient, session

--- a/lib/tests/cli/test_cli_profiles.py
+++ b/lib/tests/cli/test_cli_profiles.py
@@ -5,6 +5,7 @@ import requests
 from unittest.mock import patch, Mock
 from click.testing import CliRunner
 from blackfish.cli.__main__ import main
+from blackfish.server.models.profile import validate_profile_name
 
 
 @pytest.fixture
@@ -250,6 +251,22 @@ class TestProfileAdd:
 
             assert result.exit_code == 1
             assert "Profile named default already exists" in result.output
+
+    @patch("blackfish.cli.profile.input")
+    def test_add_profile_invalid_name(self, mock_input, cli_runner, temp_home_dir):
+        """Test that an invalid profile name is rejected."""
+        mock_input.side_effect = ["bad[name"]
+        profiles_path = os.path.join(temp_home_dir, "profiles.cfg")
+
+        with patch("blackfish.cli.__main__.config") as mock_config:
+            mock_config.HOME_DIR = temp_home_dir
+            with open(profiles_path, "w") as f:
+                f.write("")
+
+            result = cli_runner.invoke(main, ["profile", "add"])
+
+            assert result.exit_code == 1
+            assert "Invalid profile name" in result.output
 
     @patch("blackfish.cli.profile.input")
     @patch("blackfish.cli.profile._setup_profile")
@@ -544,6 +561,25 @@ class TestDefaultResolution:
         profiles = {p.name: p for p in deserialize_profiles(temp_home_dir)}
         assert profiles["alpha"].default is True
         assert profiles["beta"].default is False
+
+
+class TestValidateProfileName:
+    """Unit tests for `validate_profile_name`."""
+
+    @pytest.mark.parametrize(
+        "name",
+        ["default", "della", "my-profile", "my_profile", "della.princeton.edu", "p1"],
+    )
+    def test_accepts_valid_names(self, name):
+        validate_profile_name(name)  # does not raise
+
+    @pytest.mark.parametrize(
+        "name",
+        ["bad[name", "bad]name", "a=b", "a:b", "has space", "", "DEFAULT", "tab\tx"],
+    )
+    def test_rejects_invalid_names(self, name):
+        with pytest.raises(ValueError):
+            validate_profile_name(name)
 
 
 class TestResolveProfileOrExit:

--- a/lib/tests/cli/test_cli_profiles.py
+++ b/lib/tests/cli/test_cli_profiles.py
@@ -268,6 +268,23 @@ class TestProfileAdd:
             assert result.exit_code == 1
             assert "Invalid profile name" in result.output
 
+    def test_auto_profile_rejects_invalid_name(self, temp_home_dir, capsys):
+        """`_auto_profile_` (the `blackfish init --auto` path) rejects bad names."""
+        from blackfish.cli.profile import _auto_profile_
+
+        result = _auto_profile_(
+            app_dir=temp_home_dir,
+            name="bad[name",
+            schema="local",
+            host=None,
+            user=None,
+            home_dir=temp_home_dir,
+            cache_dir="/tmp/cache",
+        )
+
+        assert result is False
+        assert "Invalid profile name" in capsys.readouterr().out
+
     @patch("blackfish.cli.profile.input")
     @patch("blackfish.cli.profile._setup_profile")
     def test_add_profile_invalid_schema(


### PR DESCRIPTION
## Summary
- Profile names become `profiles.cfg` section headers, so a name containing `[`, `]`, `=`, `:`, or whitespace silently corrupts the file. Adds a shared `validate_profile_name()` ([models/profile.py](lib/src/blackfish/server/models/profile.py)) that rejects unsafe names and the reserved `DEFAULT` section.
- Allowed pattern is `^[A-Za-z0-9._-]+$` — letters, digits, dots, hyphens, underscores. Lowercase `default` and dotted names (e.g. `della.princeton.edu`) stay valid; only the exact uppercase `DEFAULT` is rejected.
- The validator raises a plain `ValueError`; callers translate — API → `ValidationException` (400), CLI → printed error.

## Entry points covered
- `POST /api/profiles` (create) and `PUT /api/profiles/{name}/rename`
- CLI `_create_profile_` (interactive `profile add`) and `_auto_profile_` (`blackfish init --auto`)
- CLI `profile rename` inherits the API's 400 — no separate client check

## Notes
- Write-time only: a pre-existing profile with a now-invalid name keeps working until someone renames it. No retroactive rejection.

## Test plan
- [x] `uv run just lint`
- [x] `uv run just test` (852 passed, 8 skipped)
- [x] `TestValidateProfileName` — parametrized valid (incl. dotted, lowercase `default`) and invalid (`[`, `]`, `=`, `:`, whitespace, empty, `DEFAULT`) names
- [x] Entry-point tests: API create / API rename / CLI `profile add` each reject an invalid name

Closes #340.