### PR TITLE
fix(lib): catch API connection errors in CLI commands

### DIFF
--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -449,7 +449,12 @@ def stop(service_id: str) -> None:  # pragma: no cover
     except ValueError:
         # If it's not a valid UUID, try to find a matching service by abbreviated ID
         with yaspin(text="Looking up service...") as spinner:
-            res = requests.get(f"http://{config.HOST}:{config.PORT}/api/services")
+            try:
+                res = requests.get(f"http://{config.HOST}:{config.PORT}/api/services")
+            except requests.exceptions.ConnectionError:
+                spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
+                spinner.fail(f"{LogSymbols.ERROR.value}")
+                return
             if not res.ok:
                 spinner.text = f"Failed to fetch services (status={res.status_code})."
                 spinner.fail(f"{LogSymbols.ERROR.value}")
@@ -472,10 +477,15 @@ def stop(service_id: str) -> None:  # pragma: no cover
                 spinner.ok(f"{LogSymbols.SUCCESS.value}")
 
     with yaspin(text="Stopping service...") as spinner:
-        res = requests.put(
-            f"http://{config.HOST}:{config.PORT}/api/services/{full_service_id}/stop",
-            json={},
-        )
+        try:
+            res = requests.put(
+                f"http://{config.HOST}:{config.PORT}/api/services/{full_service_id}/stop",
+                json={},
+            )
+        except requests.exceptions.ConnectionError:
+            spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
+            spinner.fail(f"{LogSymbols.ERROR.value}")
+            return
         if not res.ok:
             spinner.text = f"Failed to stop service {full_service_id[:DISPLAY_ID_LENGTH]} (status={res.status_code})."
             spinner.fail(f"{LogSymbols.ERROR.value}")
@@ -508,10 +518,15 @@ def rm(filters: Optional[str] = None) -> None:  # pragma: no cover
         params = None
 
     with yaspin(text="Deleting service...") as spinner:
-        res = requests.delete(
-            f"http://{config.HOST}:{config.PORT}/api/services",
-            params=params,
-        )
+        try:
+            res = requests.delete(
+                f"http://{config.HOST}:{config.PORT}/api/services",
+                params=params,
+            )
+        except requests.exceptions.ConnectionError:
+            spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
+            spinner.fail(f"{LogSymbols.ERROR.value}")
+            return
         if not res.ok:
             spinner.text = f"Failed to remove services (status={res.status_code})."
             spinner.fail(f"{LogSymbols.ERROR.value}")
@@ -546,7 +561,14 @@ def prune() -> None:  # pragma: no cover
         return
 
     with yaspin(text="Deleting service...") as spinner:
-        res = requests.delete(f"http://{config.HOST}:{config.PORT}/api/services/prune")
+        try:
+            res = requests.delete(
+                f"http://{config.HOST}:{config.PORT}/api/services/prune"
+            )
+        except requests.exceptions.ConnectionError:
+            spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
+            spinner.fail(f"{LogSymbols.ERROR.value}")
+            return
         if not res.ok:
             spinner.text = f"Failed to prune services (status={res.status_code})"
             spinner.fail(f"{LogSymbols.ERROR.value}")
@@ -570,10 +592,15 @@ def details(service_id: str) -> None:  # pragma: no cover
     from blackfish.server.job import SlurmJob, LocalJob
 
     with yaspin(text="Fetching service...") as spinner:
-        res = requests.get(
-            f"http://{config.HOST}:{config.PORT}/api/services/{service_id}",
-            params={"refresh": "true"},
-        )  # fresh data 🥬
+        try:
+            res = requests.get(
+                f"http://{config.HOST}:{config.PORT}/api/services/{service_id}",
+                params={"refresh": "true"},
+            )  # fresh data 🥬
+        except requests.exceptions.ConnectionError:
+            spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
+            spinner.fail(f"{LogSymbols.ERROR.value}")
+            return
         if not res.ok:
             spinner.text = (
                 f"Failed to fetch service {service_id} (status={res.status_code})."
@@ -694,9 +721,14 @@ def ls(filters: Optional[str], all: bool = False) -> None:  # pragma: no cover
 
     with yaspin(text="Fetching services...") as spinner:
         params["refresh"] = "true"
-        res = requests.get(
-            f"http://{config.HOST}:{config.PORT}/api/services", params=params
-        )  # fresh data 🥬
+        try:
+            res = requests.get(
+                f"http://{config.HOST}:{config.PORT}/api/services", params=params
+            )  # fresh data 🥬
+        except requests.exceptions.ConnectionError:
+            spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
+            spinner.fail(f"{LogSymbols.ERROR.value}")
+            return
         if not res.ok:
             spinner.text = f"Failed to fetch services. Status code: {res.status_code}."
             spinner.fail(f"{LogSymbols.ERROR.value}")

--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -451,7 +451,7 @@ def stop(service_id: str) -> None:  # pragma: no cover
         with yaspin(text="Looking up service...") as spinner:
             try:
                 res = requests.get(f"http://{config.HOST}:{config.PORT}/api/services")
-            except requests.exceptions.ConnectionError:
+            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
                 spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
                 spinner.fail(f"{LogSymbols.ERROR.value}")
                 return
@@ -482,7 +482,7 @@ def stop(service_id: str) -> None:  # pragma: no cover
                 f"http://{config.HOST}:{config.PORT}/api/services/{full_service_id}/stop",
                 json={},
             )
-        except requests.exceptions.ConnectionError:
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
             spinner.fail(f"{LogSymbols.ERROR.value}")
             return
@@ -523,7 +523,7 @@ def rm(filters: Optional[str] = None) -> None:  # pragma: no cover
                 f"http://{config.HOST}:{config.PORT}/api/services",
                 params=params,
             )
-        except requests.exceptions.ConnectionError:
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
             spinner.fail(f"{LogSymbols.ERROR.value}")
             return
@@ -565,7 +565,7 @@ def prune() -> None:  # pragma: no cover
             res = requests.delete(
                 f"http://{config.HOST}:{config.PORT}/api/services/prune"
             )
-        except requests.exceptions.ConnectionError:
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
             spinner.fail(f"{LogSymbols.ERROR.value}")
             return
@@ -597,7 +597,7 @@ def details(service_id: str) -> None:  # pragma: no cover
                 f"http://{config.HOST}:{config.PORT}/api/services/{service_id}",
                 params={"refresh": "true"},
             )  # fresh data 🥬
-        except requests.exceptions.ConnectionError:
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
             spinner.fail(f"{LogSymbols.ERROR.value}")
             return
@@ -725,7 +725,7 @@ def ls(filters: Optional[str], all: bool = False) -> None:  # pragma: no cover
             res = requests.get(
                 f"http://{config.HOST}:{config.PORT}/api/services", params=params
             )  # fresh data 🥬
-        except requests.exceptions.ConnectionError:
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
             spinner.fail(f"{LogSymbols.ERROR.value}")
             return
@@ -836,7 +836,7 @@ def models_ls(
                 spinner.text = f"Blackfish API encountered an error: {res.status_code}"
                 spinner.fail(f"{LogSymbols.ERROR.value}")
                 return
-        except requests.exceptions.ConnectionError:
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
             spinner.fail(f"{LogSymbols.ERROR.value}")
             return
@@ -960,7 +960,7 @@ def models_add(
             else:
                 spinner.text = f"Added model {repo_id}."
                 spinner.ok(f"{LogSymbols.SUCCESS.value}")
-        except requests.exceptions.ConnectionError:
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
             spinner.fail(f"{LogSymbols.ERROR.value}")
             return
@@ -1055,7 +1055,7 @@ def models_remove(
                     else:
                         spinner.text = "Database update failed. Will retry automatically on next `blackfish model ls --refresh` run."
                         spinner.ok(f"{LogSymbols.SUCCESS.value}")
-            except requests.exceptions.ConnectionError:
+            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
                 spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
                 spinner.fail(f"{LogSymbols.ERROR.value}")
                 return

--- a/lib/src/blackfish/cli/services/speech_recognition.py
+++ b/lib/src/blackfish/cli/services/speech_recognition.py
@@ -175,7 +175,10 @@ def run_speech_recognition(
                             "grace_period": options.grace_period,
                         },
                     )
-                except requests.exceptions.ConnectionError:
+                except (
+                    requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout,
+                ):
                     spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
                     spinner.fail(f"{LogSymbols.ERROR.value}")
                     return
@@ -232,7 +235,10 @@ def run_speech_recognition(
                             "grace_period": options.grace_period,
                         },
                     )
-                except requests.exceptions.ConnectionError:
+                except (
+                    requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout,
+                ):
                     spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
                     spinner.fail(f"{LogSymbols.ERROR.value}")
                     return

--- a/lib/src/blackfish/cli/services/speech_recognition.py
+++ b/lib/src/blackfish/cli/services/speech_recognition.py
@@ -161,19 +161,24 @@ def run_speech_recognition(
             click.echo(service.render_job_script(container_config, job_config))
         else:
             with yaspin(text="Starting service...") as spinner:
-                res = requests.post(
-                    f"http://{config.HOST}:{config.PORT}/api/services",
-                    json={
-                        "name": name,
-                        "image": "speech_recognition",
-                        "repo_id": repo_id,
-                        "profile": asdict(profile),
-                        "container_config": asdict(container_config),
-                        "job_config": asdict(job_config),
-                        "mount": options.mount,
-                        "grace_period": options.grace_period,
-                    },
-                )
+                try:
+                    res = requests.post(
+                        f"http://{config.HOST}:{config.PORT}/api/services",
+                        json={
+                            "name": name,
+                            "image": "speech_recognition",
+                            "repo_id": repo_id,
+                            "profile": asdict(profile),
+                            "container_config": asdict(container_config),
+                            "job_config": asdict(job_config),
+                            "mount": options.mount,
+                            "grace_period": options.grace_period,
+                        },
+                    )
+                except requests.exceptions.ConnectionError:
+                    spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
+                    spinner.fail(f"{LogSymbols.ERROR.value}")
+                    return
                 if res.ok:
                     spinner.text = f"Started service: {res.json()['id']}"
                     spinner.ok(f"{LogSymbols.SUCCESS.value}")
@@ -213,19 +218,24 @@ def run_speech_recognition(
             click.echo(service.render_job_script(container_config, job_config))
         else:
             with yaspin(text="Starting service...") as spinner:
-                res = requests.post(
-                    f"http://{config.HOST}:{config.PORT}/api/services",
-                    json={
-                        "name": name,
-                        "image": "speech_recognition",
-                        "repo_id": repo_id,
-                        "profile": asdict(profile),
-                        "container_config": asdict(container_config),
-                        "job_config": asdict(job_config),
-                        "mount": options.mount,
-                        "grace_period": options.grace_period,
-                    },
-                )
+                try:
+                    res = requests.post(
+                        f"http://{config.HOST}:{config.PORT}/api/services",
+                        json={
+                            "name": name,
+                            "image": "speech_recognition",
+                            "repo_id": repo_id,
+                            "profile": asdict(profile),
+                            "container_config": asdict(container_config),
+                            "job_config": asdict(job_config),
+                            "mount": options.mount,
+                            "grace_period": options.grace_period,
+                        },
+                    )
+                except requests.exceptions.ConnectionError:
+                    spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
+                    spinner.fail(f"{LogSymbols.ERROR.value}")
+                    return
                 if res.ok:
                     spinner.text = f"Started service: {res.json()['id']}"
                     spinner.ok(f"{LogSymbols.SUCCESS.value}")

--- a/lib/src/blackfish/cli/services/text_generation.py
+++ b/lib/src/blackfish/cli/services/text_generation.py
@@ -191,19 +191,24 @@ def run_text_generation(
             click.echo(service.render_job_script(container_config, job_config))
         else:
             with yaspin(text="Starting service...") as spinner:
-                res = requests.post(
-                    f"http://{config.HOST}:{config.PORT}/api/services",
-                    json={
-                        "name": name,
-                        "image": "text_generation",
-                        "repo_id": repo_id,
-                        "profile": asdict(profile),
-                        "container_config": asdict(container_config),
-                        "job_config": asdict(job_config),
-                        "mount": options.mount,
-                        "grace_period": options.grace_period,
-                    },
-                )
+                try:
+                    res = requests.post(
+                        f"http://{config.HOST}:{config.PORT}/api/services",
+                        json={
+                            "name": name,
+                            "image": "text_generation",
+                            "repo_id": repo_id,
+                            "profile": asdict(profile),
+                            "container_config": asdict(container_config),
+                            "job_config": asdict(job_config),
+                            "mount": options.mount,
+                            "grace_period": options.grace_period,
+                        },
+                    )
+                except requests.exceptions.ConnectionError:
+                    spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
+                    spinner.fail(f"{LogSymbols.ERROR.value}")
+                    return
                 if res.ok:
                     spinner.text = f"Started service: {res.json()['id']}"
                     spinner.ok(f"{LogSymbols.SUCCESS.value}")
@@ -243,19 +248,24 @@ def run_text_generation(
             click.echo(service.render_job_script(container_config, job_config))
         else:
             with yaspin(text="Starting service...") as spinner:
-                res = requests.post(
-                    f"http://{config.HOST}:{config.PORT}/api/services",
-                    json={
-                        "name": name,
-                        "image": "text_generation",
-                        "repo_id": repo_id,
-                        "profile": asdict(profile),
-                        "container_config": asdict(container_config),
-                        "job_config": asdict(job_config),
-                        "mount": options.mount,
-                        "grace_period": options.grace_period,
-                    },
-                )
+                try:
+                    res = requests.post(
+                        f"http://{config.HOST}:{config.PORT}/api/services",
+                        json={
+                            "name": name,
+                            "image": "text_generation",
+                            "repo_id": repo_id,
+                            "profile": asdict(profile),
+                            "container_config": asdict(container_config),
+                            "job_config": asdict(job_config),
+                            "mount": options.mount,
+                            "grace_period": options.grace_period,
+                        },
+                    )
+                except requests.exceptions.ConnectionError:
+                    spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
+                    spinner.fail(f"{LogSymbols.ERROR.value}")
+                    return
                 if res.ok:
                     spinner.text = f"Started service: {res.json()['id']}"
                     spinner.ok(f"{LogSymbols.SUCCESS.value}")

--- a/lib/src/blackfish/cli/services/text_generation.py
+++ b/lib/src/blackfish/cli/services/text_generation.py
@@ -205,7 +205,10 @@ def run_text_generation(
                             "grace_period": options.grace_period,
                         },
                     )
-                except requests.exceptions.ConnectionError:
+                except (
+                    requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout,
+                ):
                     spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
                     spinner.fail(f"{LogSymbols.ERROR.value}")
                     return
@@ -262,7 +265,10 @@ def run_text_generation(
                             "grace_period": options.grace_period,
                         },
                     )
-                except requests.exceptions.ConnectionError:
+                except (
+                    requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout,
+                ):
                     spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
                     spinner.fail(f"{LogSymbols.ERROR.value}")
                     return

--- a/lib/tests/cli/test_cli_connection_errors.py
+++ b/lib/tests/cli/test_cli_connection_errors.py
@@ -1,0 +1,63 @@
+"""Connection-error handling for CLI commands without dedicated test files.
+
+Covers the `rm`, `prune`, `details`, and `ls` commands, which each make a
+single API request. Parametrized over both `ConnectionError` and `Timeout`,
+since a refused connection and a hung server are handled the same way.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import requests
+from click.testing import CliRunner
+
+from blackfish.cli.__main__ import ls, rm, prune, details
+
+TRANSPORT_ERRORS = [
+    requests.exceptions.ConnectionError,
+    requests.exceptions.Timeout,
+]
+
+
+@pytest.mark.parametrize("exc", TRANSPORT_ERRORS)
+def test_ls_connection_error(exc):
+    """`ls` reports a friendly error when the API is unreachable."""
+    runner = CliRunner()
+    with patch("blackfish.cli.__main__.requests.get", side_effect=exc("boom")):
+        result = runner.invoke(ls, [])
+
+    assert result.exit_code == 0
+    assert "Failed to connect" in result.output
+
+
+@pytest.mark.parametrize("exc", TRANSPORT_ERRORS)
+def test_rm_connection_error(exc):
+    """`rm` reports a friendly error when the API is unreachable."""
+    runner = CliRunner()
+    with patch("blackfish.cli.__main__.requests.delete", side_effect=exc("boom")):
+        result = runner.invoke(rm, [])
+
+    assert result.exit_code == 0
+    assert "Failed to connect" in result.output
+
+
+@pytest.mark.parametrize("exc", TRANSPORT_ERRORS)
+def test_prune_connection_error(exc):
+    """`prune` reports a friendly error when the API is unreachable."""
+    runner = CliRunner()
+    with patch("blackfish.cli.__main__.requests.delete", side_effect=exc("boom")):
+        result = runner.invoke(prune, input="y\n")
+
+    assert result.exit_code == 0
+    assert "Failed to connect" in result.output
+
+
+@pytest.mark.parametrize("exc", TRANSPORT_ERRORS)
+def test_details_connection_error(exc):
+    """`details` reports a friendly error when the API is unreachable."""
+    runner = CliRunner()
+    with patch("blackfish.cli.__main__.requests.get", side_effect=exc("boom")):
+        result = runner.invoke(details, ["abc123"])
+
+    assert result.exit_code == 0
+    assert "Failed to connect" in result.output

--- a/lib/tests/cli/test_cli_run.py
+++ b/lib/tests/cli/test_cli_run.py
@@ -7,6 +7,7 @@ This module tests the CLI commands for running inference services:
 
 import shlex
 import pytest
+import requests
 from unittest.mock import patch, Mock, MagicMock
 from blackfish.cli.__main__ import main
 from blackfish.server.models.profile import LocalProfile, SlurmProfile
@@ -282,6 +283,42 @@ class TestRunTextGeneration:
 
         assert result.exit_code == 0
         assert "Failed to start service" in result.output
+
+    def test_connection_error(self, cli_runner, mock_config, local_profile):
+        """Test that API connection failures are handled gracefully."""
+        cmd = ["run", "-p", "default", "text-generation", "openai/gpt-2"]
+
+        with (
+            patch(
+                "blackfish.server.models.profile.deserialize_profile"
+            ) as mock_deserialize,
+            patch(
+                "blackfish.cli.services.text_generation.get_models"
+            ) as mock_get_models,
+            patch(
+                "blackfish.cli.services.text_generation.get_revisions"
+            ) as mock_get_revisions,
+            patch(
+                "blackfish.cli.services.text_generation.get_latest_commit"
+            ) as mock_get_latest,
+            patch(
+                "blackfish.cli.services.text_generation.get_model_dir"
+            ) as mock_get_model_dir,
+            patch(
+                "blackfish.cli.services.text_generation.requests.post",
+                side_effect=requests.exceptions.ConnectionError("refused"),
+            ),
+        ):
+            mock_deserialize.return_value = local_profile
+            mock_get_models.return_value = ["openai/gpt-2"]
+            mock_get_revisions.return_value = ["abc123"]
+            mock_get_latest.return_value = "abc123"
+            mock_get_model_dir.return_value = "/path/to/model"
+
+            result = cli_runner.invoke(main, cmd)
+
+        assert result.exit_code == 0
+        assert "Failed to connect" in result.output
 
     def test_missing_repo_id(self, cli_runner, mock_config, local_profile):
         """Test error when repo_id argument is missing."""
@@ -780,6 +817,42 @@ class TestRunSpeechRecognition:
 
         assert result.exit_code == 0
         assert "Failed to start service" in result.output
+
+    def test_connection_error(self, cli_runner, mock_config, local_profile):
+        """Test that API connection failures are handled gracefully."""
+        cmd = ["run", "-p", "default", "speech-recognition", "openai/whisper-tiny"]
+
+        with (
+            patch(
+                "blackfish.server.models.profile.deserialize_profile"
+            ) as mock_deserialize,
+            patch(
+                "blackfish.cli.services.speech_recognition.get_models"
+            ) as mock_get_models,
+            patch(
+                "blackfish.cli.services.speech_recognition.get_revisions"
+            ) as mock_get_revisions,
+            patch(
+                "blackfish.cli.services.speech_recognition.get_latest_commit"
+            ) as mock_get_latest,
+            patch(
+                "blackfish.cli.services.speech_recognition.get_model_dir"
+            ) as mock_get_model_dir,
+            patch(
+                "blackfish.cli.services.speech_recognition.requests.post",
+                side_effect=requests.exceptions.ConnectionError("refused"),
+            ),
+        ):
+            mock_deserialize.return_value = local_profile
+            mock_get_models.return_value = ["openai/whisper-tiny"]
+            mock_get_revisions.return_value = ["abc123"]
+            mock_get_latest.return_value = "abc123"
+            mock_get_model_dir.return_value = "/path/to/models/whisper-tiny"
+
+            result = cli_runner.invoke(main, cmd)
+
+        assert result.exit_code == 0
+        assert "Failed to connect" in result.output
 
     def test_missing_repo_id(self, cli_runner, mock_config, local_profile):
         """Test error when repo_id argument is missing."""

--- a/lib/tests/cli/test_cli_stop.py
+++ b/lib/tests/cli/test_cli_stop.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch, MagicMock
+import requests
 from click.testing import CliRunner
 
 
@@ -178,3 +179,30 @@ class TestStopCLI:
             mock_put.assert_called_once_with(
                 f"http://localhost:8000/api/services/{full_uuid}/stop", json={}
             )
+
+    def test_stop_lookup_connection_error(self):
+        """Connection failures while looking up a service are handled gracefully."""
+        runner = CliRunner()
+
+        with patch(
+            "blackfish.cli.__main__.requests.get",
+            side_effect=requests.exceptions.ConnectionError("refused"),
+        ):
+            result = runner.invoke(stop, ["4c22"])
+
+            assert result.exit_code == 0
+            assert "Failed to connect" in result.output
+
+    def test_stop_connection_error(self):
+        """Connection failures while stopping a service are handled gracefully."""
+        runner = CliRunner()
+        full_uuid = "4c2216ea-df22-4bf6-bcea-56964df12af5"
+
+        with patch(
+            "blackfish.cli.__main__.requests.put",
+            side_effect=requests.exceptions.ConnectionError("refused"),
+        ):
+            result = runner.invoke(stop, [full_uuid])
+
+            assert result.exit_code == 0
+            assert "Failed to connect" in result.output


### PR DESCRIPTION
## Summary

- CLI commands checked `res.ok` but crashed with a raw traceback when the API was unreachable (e.g. ports out of sync), since `requests` raises `ConnectionError` before any response exists.
- Wrapped the previously-unhandled API calls in `stop`, `rm`, `prune`, `details`, `ls`, and the `run text-generation` / `run speech-recognition` commands with `try/except`, matching the existing inline pattern in `batch.py`.
- On a connection failure each command now fails the spinner with a friendly "Is Blackfish running on port X?" message and exits cleanly.

## Test plan

- [x] `just lint` (pre-commit hooks pass)
- [x] `just test` (839 passed)
- [x] Added connection-error tests: `stop` (lookup GET + stop PUT) and `run` (text-generation + speech-recognition)
- [x] Manually: stop the API server, run `blackfish ls` / `blackfish stop <id>` — confirm a friendly error instead of a traceback

Closes #126