### PR TITLE
feat(lib): set SQLite PRAGMAs for production concurrency

### DIFF
--- a/lib/docs/assets/img/coverage.svg
+++ b/lib/docs/assets/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">61%</text>
-        <text x="80" y="14">61%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">68%</text>
+        <text x="80" y="14">68%</text>
     </g>
 </svg>

--- a/lib/docs/assets/img/coverage.svg
+++ b/lib/docs/assets/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">68%</text>
-        <text x="80" y="14">68%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">61%</text>
+        <text x="80" y="14">61%</text>
     </g>
 </svg>

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -80,6 +80,11 @@ contract = [
 build.artifacts = [ "src/blackfish/build/**" ]
 build.targets.wheel.packages = [ "src/blackfish" ]
 
+[tool.coverage.run]
+omit = [
+  "src/blackfish/server/db/migrations/*",
+]
+
 [tool.pyproject-fmt]
 max_supported_python = "3.13"
 

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -80,11 +80,6 @@ contract = [
 build.artifacts = [ "src/blackfish/build/**" ]
 build.targets.wheel.packages = [ "src/blackfish" ]
 
-[tool.coverage.run]
-omit = [
-  "src/blackfish/server/db/migrations/*",
-]
-
 [tool.pyproject-fmt]
 max_supported_python = "3.13"
 
@@ -94,3 +89,8 @@ strict = true
 show_error_codes = true
 warn_unreachable = true
 ignore_missing_imports = true
+
+[tool.coverage]
+run.omit = [
+  "src/blackfish/server/db/migrations/*",
+]

--- a/lib/src/blackfish/client.py
+++ b/lib/src/blackfish/client.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+# Registers SQLite PRAGMA listener on SQLAlchemy's Engine class.
+# Must be imported before any engine opens a connection.
+import blackfish.server.db  # noqa: F401
+
 import sys
 import asyncio
 import atexit

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+# Registers SQLite PRAGMA listener on SQLAlchemy's Engine class.
+# Must be imported before any engine opens a connection.
+import blackfish.server.db  # noqa: F401
+
 import configparser
 import os
 from os import urandom

--- a/lib/src/blackfish/server/bootstrap.py
+++ b/lib/src/blackfish/server/bootstrap.py
@@ -13,6 +13,10 @@ only touches the application directory.
 
 from __future__ import annotations
 
+# Registers SQLite PRAGMA listener on SQLAlchemy's Engine class.
+# Must be imported before any engine opens a connection.
+import blackfish.server.db  # noqa: F401
+
 import configparser
 import importlib.metadata
 import os

--- a/lib/src/blackfish/server/db/__init__.py
+++ b/lib/src/blackfish/server/db/__init__.py
@@ -31,8 +31,10 @@ def _set_sqlite_pragmas(dbapi_connection: Any, _connection_record: Any) -> None:
     if "sqlite" not in type(dbapi_connection).__module__:
         return
     cursor = dbapi_connection.cursor()
-    cursor.execute("PRAGMA journal_mode=WAL")
-    cursor.execute("PRAGMA busy_timeout=5000")
-    cursor.execute("PRAGMA foreign_keys=ON")
-    cursor.execute("PRAGMA synchronous=NORMAL")
-    cursor.close()
+    try:
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA busy_timeout=5000")
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.execute("PRAGMA synchronous=NORMAL")
+    finally:
+        cursor.close()

--- a/lib/src/blackfish/server/db/__init__.py
+++ b/lib/src/blackfish/server/db/__init__.py
@@ -1,0 +1,38 @@
+"""SQLite PRAGMA setup for every SQLAlchemy engine in the process.
+
+Importing this module registers a global ``connect`` event listener on
+SQLAlchemy's base :class:`~sqlalchemy.engine.Engine` class. On every new
+SQLite DBAPI connection (sync ``sqlite3`` or async ``aiosqlite``) the
+listener applies:
+
+- ``journal_mode=WAL``    — readers and writers don't block each other
+- ``busy_timeout=5000``   — wait up to 5s on lock contention instead of
+                            raising ``OperationalError: database is locked``
+- ``foreign_keys=ON``     — enforce FK constraints (off by SQLite default)
+- ``synchronous=NORMAL``  — faster writes in WAL mode with adequate durability
+                            for a workstation use case
+
+The listener must be registered before any engine opens a connection, so
+each process entry point imports this module for its side effect.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+
+
+@event.listens_for(Engine, "connect")
+def _set_sqlite_pragmas(dbapi_connection: Any, _connection_record: Any) -> None:
+    # The dbapi connection's class lives in `sqlite3`, `aiosqlite.core`, or
+    # — when SQLAlchemy wraps an async driver — `sqlalchemy.dialects.sqlite.*`.
+    if "sqlite" not in type(dbapi_connection).__module__:
+        return
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA journal_mode=WAL")
+    cursor.execute("PRAGMA busy_timeout=5000")
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.execute("PRAGMA synchronous=NORMAL")
+    cursor.close()

--- a/lib/src/blackfish/server/db/migrations/env.py
+++ b/lib/src/blackfish/server/db/migrations/env.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+# Registers SQLite PRAGMA listener on SQLAlchemy's Engine class.
+# Must be imported before any engine opens a connection.
+import blackfish.server.db  # noqa: F401
+
 import asyncio
 from typing import TYPE_CHECKING, cast
 

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -1,3 +1,7 @@
+# Registers SQLite PRAGMA listener on SQLAlchemy's Engine class.
+# Must be imported before any engine opens a connection.
+import blackfish.server.db  # noqa: F401
+
 from pathlib import Path
 from dotenv import load_dotenv
 import pytest

--- a/lib/tests/unit/test_sqlite_pragmas.py
+++ b/lib/tests/unit/test_sqlite_pragmas.py
@@ -1,0 +1,42 @@
+"""Smoke tests for the global SQLite PRAGMA listener.
+
+Verifies that importing ``blackfish.server.db`` causes every new SQLite
+connection — sync ``sqlite3`` or async ``aiosqlite`` — to come up with the
+PRAGMAs the app relies on for concurrency and FK enforcement.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+import blackfish.server.db  # noqa: F401  # registers the listener
+
+EXPECTED = {
+    "journal_mode": "wal",
+    "busy_timeout": 5000,
+    "foreign_keys": 1,
+    "synchronous": 1,  # NORMAL
+}
+
+
+def test_pragmas_set_on_sync_sqlite(tmp_path: Path) -> None:
+    engine = create_engine(f"sqlite:///{tmp_path / 'app.sqlite'}")
+    with engine.connect() as conn:
+        for pragma, expected in EXPECTED.items():
+            value = conn.execute(text(f"PRAGMA {pragma}")).scalar()
+            assert value == expected, f"{pragma}: got {value!r}, want {expected!r}"
+
+
+@pytest.mark.anyio
+async def test_pragmas_set_on_aiosqlite(tmp_path: Path) -> None:
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'app.sqlite'}")
+    async with engine.connect() as conn:
+        for pragma, expected in EXPECTED.items():
+            result = await conn.execute(text(f"PRAGMA {pragma}"))
+            value = result.scalar()
+            assert value == expected, f"{pragma}: got {value!r}, want {expected!r}"
+    await engine.dispose()


### PR DESCRIPTION
## Summary
- Register a global SQLAlchemy `Engine` `connect` listener that applies `journal_mode=WAL`, `busy_timeout=5000`, `foreign_keys=ON`, and `synchronous=NORMAL` on every new SQLite connection. Fixes the v1.0 blocker where two concurrent writers would surface `OperationalError: database is locked`.
- Side-effect import the listener module from the five entry points that create engines: `asgi.py`, `client.py`, `bootstrap.py`, `migrations/env.py`, and `tests/conftest.py`. (`bootstrap.py` was missing from the issue's inventory; it creates an `SQLAlchemyAsyncConfig` on the CLI migration path.)
- Add a smoke test that opens both a sync and async file-backed SQLite engine and asserts each PRAGMA, so accidental removal fails CI.

## Test plan
- [x] `uv run pytest` — 867 passed, 8 skipped
- [x] `uv run pre-commit run --all-files` — passes (ruff, mypy strict, codespell)
- [x] Smoke test: `tests/unit/test_sqlite_pragmas.py` passes for both sync `sqlite3` and async `aiosqlite`
- [x] Manual: `sqlite3 ~/.blackfish/app.sqlite "PRAGMA journal_mode"` → `wal` after running the server; sidecar `-wal`/`-shm` files present
- [x] Manual: one-liner against `app.sqlite` using a listener-loaded engine returns `wal`, `5000`, `1`, `1` for each PRAGMA

Closes #288