### PR TITLE
refactor(lib): make SlurmJob/LocalJob methods and Service.get_job async

### DIFF
--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -585,6 +585,7 @@ def prune() -> None:  # pragma: no cover
 def details(service_id: str) -> None:  # pragma: no cover
     """Show detailed service information."""
 
+    import asyncio
     from uuid import UUID
     from datetime import datetime
     import json
@@ -616,7 +617,7 @@ def details(service_id: str) -> None:  # pragma: no cover
     body["updated_at"] = datetime.fromisoformat(body["updated_at"])
     body["id"] = UUID(body["id"])
     service = Service(**body)
-    job = service.get_job()
+    job = asyncio.run(service.get_job())
     profile = service.get_profile()
     data = {
         "name": service.name,

--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import rich_click as click
 from rich_click import Context
 import configparser
@@ -241,7 +242,6 @@ def start(reload: bool) -> None:  # pragma: no cover
     _warn_if_no_profiles(config.HOME_DIR)
 
     # Check TigerFlow versions on Slurm profiles
-    import asyncio
     from blackfish.server.jobs.client import (
         TigerFlowClient,
         TigerFlowError,
@@ -585,7 +585,6 @@ def prune() -> None:  # pragma: no cover
 def details(service_id: str) -> None:  # pragma: no cover
     """Show detailed service information."""
 
-    import asyncio
     from uuid import UUID
     from datetime import datetime
     import json

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -1241,9 +1241,9 @@ async def delete_service(
 
             # Attempt job clean up; don't fail whole operation if this doesn't work!
             try:
-                job = service.get_job()
+                job = await service.get_job()
                 if job is not None:
-                    job.remove()
+                    await job.remove()
             except Exception as e:
                 logger.warning(f"Unable to remove job for service {service.id}: {e}")
 
@@ -1304,9 +1304,9 @@ async def prune_services(session: AsyncSession, state: State) -> int:
 
         # Attempt job clean up; don't fail whole operation if this doesn't work!
         try:
-            job = service.get_job()
+            job = await service.get_job()
             if job is not None:
-                job.remove()
+                await job.remove()
         except Exception as e:
             logger.warning(f"Unable to remove job for service {service.id.hex}: {e}")
 

--- a/lib/src/blackfish/server/job.py
+++ b/lib/src/blackfish/server/job.py
@@ -1,6 +1,7 @@
 import os
 import json
 import subprocess
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 from enum import StrEnum, auto
@@ -70,17 +71,17 @@ JobConfig = Union[LocalJobConfig, SlurmJobConfig]
 
 
 @dataclass
-class Job:
+class Job(ABC):
     """Abstract job class."""
 
-    async def cancel(self) -> None:
-        raise NotImplementedError()
+    @abstractmethod
+    async def cancel(self) -> None: ...
 
-    async def update(self, verbose: bool = False) -> Optional[str]:
-        raise NotImplementedError()
+    @abstractmethod
+    async def update(self, verbose: bool = False) -> Optional[str]: ...
 
-    async def remove(self) -> None:
-        raise NotImplementedError()
+    @abstractmethod
+    async def remove(self) -> None: ...
 
 
 def parse_state(res: bytes) -> JobState:

--- a/lib/src/blackfish/server/job.py
+++ b/lib/src/blackfish/server/job.py
@@ -1,5 +1,4 @@
 import os
-import time
 import json
 import subprocess
 from dataclasses import dataclass
@@ -74,13 +73,13 @@ JobConfig = Union[LocalJobConfig, SlurmJobConfig]
 class Job:
     """Abstract job class."""
 
-    def cancel(self) -> None:
+    async def cancel(self) -> None:
         raise NotImplementedError()
 
-    def update(self, verbose: bool = False) -> Optional[str]:
+    async def update(self, verbose: bool = False) -> Optional[str]:
         raise NotImplementedError()
 
-    def remove(self) -> None:
+    async def remove(self) -> None:
         raise NotImplementedError()
 
 
@@ -113,7 +112,7 @@ class SlurmJob(Job):
     def is_local(self) -> bool:
         return self.host == "localhost"
 
-    def update(self, verbose: bool = False) -> Optional[str]:
+    async def update(self, verbose: bool = False) -> Optional[str]:
         """Attempt to update the job state from Slurm accounting and return the new
         state (or current state if the update fails).
 
@@ -174,8 +173,8 @@ class SlurmJob(Job):
                         f"Job state updated from {format_state(self.state)} to RUNNING"
                         f" (job_id={self.job_id}). Fetching node and port."
                     )
-                self.fetch_node()
-                self.fetch_port()
+                await self.fetch_node()
+                await self.fetch_port()
             elif self.state is not None and self.state != new_state:
                 if verbose:
                     logger.debug(
@@ -191,7 +190,7 @@ class SlurmJob(Job):
 
         return self.state
 
-    def fetch_node(self) -> Optional[str]:
+    async def fetch_node(self) -> Optional[str]:
         """Attempt to update the job node from Slurm accounting and return the new
         node (or the current node if the update fails).
 
@@ -247,7 +246,7 @@ class SlurmJob(Job):
         return self.node
 
     # TODO: fetch_port doesn't seem to be a SlurmJob method because it only depends on the service.
-    def fetch_port(self) -> Optional[int]:
+    async def fetch_port(self) -> Optional[int]:
         """Attempt to update the job port and return the new port (or the current
         port if the update fails)
 
@@ -284,36 +283,7 @@ class SlurmJob(Job):
 
         return self.port
 
-    def wait(self, period: int = 5) -> dict[str, bool]:
-        """Wait for the job to start, re-checking the job's status every `period` seconds."""
-
-        logger.debug(f"waiting for job {self.job_id} to start")
-        time.sleep(period)  # wait for slurm to accept job
-        while True:
-            self.update()
-            if self.state == JobState.MISSING:
-                logger.debug(
-                    f"job {self.job_id} state is missing. Re-trying in"
-                    f" {period} seconds."
-                )
-            elif self.state == JobState.PENDING:
-                logger.debug(
-                    f"job {self.job_id} is pending. Re-trying in {period} seconds."
-                )
-            elif self.state == JobState.RUNNING:
-                logger.debug(f"job {self.job_id} is running.")
-                self.fetch_node()
-                self.fetch_port()
-                return {"ok": True}
-            else:
-                logger.debug(
-                    f"job {self.job_id} failed (state={format_state(self.state)})."
-                )
-                return {"ok": False}
-
-            time.sleep(period)
-
-    def cancel(self) -> None:
+    async def cancel(self) -> None:
         """Cancel a Slurm job by issuing the `scancel` command on the remote host.
 
         This method logs a warning if the update fails, but does not raise an exception.
@@ -331,7 +301,7 @@ class SlurmJob(Job):
                 f"Failed to cancel job (job_id={self.job_id}, code={e.returncode})."
             )
 
-    def remove(self) -> None:
+    async def remove(self) -> None:
         pass
 
 
@@ -347,7 +317,7 @@ class LocalJob(Job):
     )
     options: Optional[JobConfig] = None
 
-    def update(self, verbose: bool = False) -> Optional[str]:
+    async def update(self, verbose: bool = False) -> Optional[str]:
         if verbose:
             logger.debug(f"Updating job state (job_id={self.job_id})")
         try:
@@ -401,7 +371,7 @@ class LocalJob(Job):
 
         return self.state
 
-    def cancel(self) -> None:
+    async def cancel(self) -> None:
         try:
             logger.debug(f"Canceling job {self.job_id}")
             if self.provider == ContainerProvider.Docker:
@@ -417,7 +387,7 @@ class LocalJob(Job):
                 f"Failed to cancel job (job_id={self.job_id}, code={e.returncode})."
             )
 
-    def remove(self) -> None:
+    async def remove(self) -> None:
         try:
             logger.debug(f"Removing job {self.job_id}")
             if self.provider == ContainerProvider.Docker:

--- a/lib/src/blackfish/server/services/base.py
+++ b/lib/src/blackfish/server/services/base.py
@@ -325,9 +325,9 @@ class Service(UUIDAuditBase):
                 f"Unable to stop service {self.id} because `job_id` is missing."
             )
 
-        job = self.get_job(verbose=True)
+        job = await self.get_job(verbose=True)
         if job is not None:
-            job.cancel()
+            await job.cancel()
 
         if self.scheduler == JobScheduler.Slurm:
             await self.close_tunnel(session)
@@ -396,7 +396,7 @@ class Service(UUIDAuditBase):
 
         # The logic for cases below is quite similar and can be extracted into
         # reusable functions in places, e.g., for running and failed jobs.
-        job = self.get_job(verbose=True)
+        job = await self.get_job(verbose=True)
         if isinstance(job, SlurmJob):
             if job.state == JobState.PENDING:
                 logger.debug(
@@ -654,7 +654,7 @@ class Service(UUIDAuditBase):
         )
         self.port = None
 
-    def get_job(self, verbose: bool = False) -> Job | None:
+    async def get_job(self, verbose: bool = False) -> Job | None:
         """Fetch the job backing the service."""
 
         job: Job
@@ -676,7 +676,7 @@ class Service(UUIDAuditBase):
             else:
                 return None
 
-        job.update(verbose=verbose)
+        await job.update(verbose=verbose)
         return job
 
     def render_job_script(

--- a/lib/tests/unit/test_job.py
+++ b/lib/tests/unit/test_job.py
@@ -55,7 +55,7 @@ async def test_update_change(mock_check_output, mock_fetch_node, mock_fetch_port
 async def test_update_warning(
     mock_check_output, mock_fetch_node, mock_fetch_port, mock_warning
 ):
-    mock_check_output.side_effect = subprocess.CalledProcessError(None, None)
+    mock_check_output.side_effect = subprocess.CalledProcessError(1, "ssh")
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
     await job.update()
     mock_warning.assert_called()
@@ -82,7 +82,7 @@ async def test_fetch_node_some(mock_check_output):
 @mock.patch("logging.Logger.warning")
 @mock.patch("subprocess.check_output")
 async def test_fetch_node_warning(mock_check_output, mock_warning):
-    mock_check_output.side_effect = subprocess.CalledProcessError(None, None)
+    mock_check_output.side_effect = subprocess.CalledProcessError(1, "ssh")
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
     await job.fetch_node()
     mock_warning.assert_called()
@@ -107,7 +107,7 @@ async def test_fetch_port_some(mock_check_output):
 @mock.patch("logging.Logger.warning")
 @mock.patch("subprocess.check_output")
 async def test_fetch_port_warning(mock_check_output, mock_warning):
-    mock_check_output.side_effect = subprocess.CalledProcessError(None, None)
+    mock_check_output.side_effect = subprocess.CalledProcessError(1, "ssh")
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
     await job.fetch_port()
     mock_warning.assert_called()
@@ -116,7 +116,7 @@ async def test_fetch_port_warning(mock_check_output, mock_warning):
 @mock.patch("logging.Logger.warning")
 @mock.patch("subprocess.check_output")
 async def test_cancel_warning(mock_check_output, mock_warning):
-    mock_check_output.side_effect = subprocess.CalledProcessError(None, None)
+    mock_check_output.side_effect = subprocess.CalledProcessError(1, "ssh")
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
-    await job.update()
+    await job.cancel()
     mock_warning.assert_called()

--- a/lib/tests/unit/test_job.py
+++ b/lib/tests/unit/test_job.py
@@ -1,16 +1,20 @@
 import subprocess
 from unittest import mock
 
+import pytest
+
 from blackfish.server.job import JobState, SlurmJob
+
+pytestmark = pytest.mark.anyio
 
 
 @mock.patch.object(SlurmJob, "fetch_port")
 @mock.patch.object(SlurmJob, "fetch_node")
 @mock.patch("subprocess.check_output")
-def test_update_none(mock_check_output, mock_fetch_node, mock_fetch_port):
+async def test_update_none(mock_check_output, mock_fetch_node, mock_fetch_port):
     mock_check_output.return_value = b""
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
-    job.update()
+    await job.update()
     assert job.state == JobState.MISSING
     mock_fetch_node.assert_not_called()
     mock_fetch_port.assert_not_called()
@@ -19,12 +23,12 @@ def test_update_none(mock_check_output, mock_fetch_node, mock_fetch_port):
 @mock.patch.object(SlurmJob, "fetch_port")
 @mock.patch.object(SlurmJob, "fetch_node")
 @mock.patch("subprocess.check_output")
-def test_update_no_change(mock_check_output, mock_fetch_node, mock_fetch_port):
+async def test_update_no_change(mock_check_output, mock_fetch_node, mock_fetch_port):
     mock_check_output.return_value = b"RUNNING"
     job = SlurmJob(
         job_id=1, user="test", host="test", state=JobState.RUNNING, data_dir="test"
     )
-    job.update()
+    await job.update()
     assert job.state == JobState.RUNNING
     mock_fetch_node.assert_not_called()
     mock_fetch_port.assert_not_called()
@@ -33,12 +37,12 @@ def test_update_no_change(mock_check_output, mock_fetch_node, mock_fetch_port):
 @mock.patch.object(SlurmJob, "fetch_port")
 @mock.patch.object(SlurmJob, "fetch_node")
 @mock.patch("subprocess.check_output")
-def test_update_change(mock_check_output, mock_fetch_node, mock_fetch_port):
+async def test_update_change(mock_check_output, mock_fetch_node, mock_fetch_port):
     mock_check_output.return_value = b"RUNNING"
     job = SlurmJob(
         job_id=1, user="test", host="test", state=JobState.PENDING, data_dir="test"
     )
-    job.update()
+    await job.update()
     assert job.state == JobState.RUNNING
     mock_fetch_node.assert_called()
     mock_fetch_port.assert_called()
@@ -48,71 +52,71 @@ def test_update_change(mock_check_output, mock_fetch_node, mock_fetch_port):
 @mock.patch.object(SlurmJob, "fetch_port")
 @mock.patch.object(SlurmJob, "fetch_node")
 @mock.patch("subprocess.check_output")
-def test_update_warning(
+async def test_update_warning(
     mock_check_output, mock_fetch_node, mock_fetch_port, mock_warning
 ):
     mock_check_output.side_effect = subprocess.CalledProcessError(None, None)
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
-    job.update()
+    await job.update()
     mock_warning.assert_called()
     mock_fetch_node.assert_not_called()
     mock_fetch_port.assert_not_called()
 
 
 @mock.patch("subprocess.check_output")
-def test_fetch_node_none(mock_check_output):
+async def test_fetch_node_none(mock_check_output):
     mock_check_output.return_value = b""
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
-    job.fetch_node()
+    await job.fetch_node()
     assert job.node is None
 
 
 @mock.patch("subprocess.check_output")
-def test_fetch_node_some(mock_check_output):
+async def test_fetch_node_some(mock_check_output):
     mock_check_output.return_value = b"56622858"
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
-    job.fetch_node()
+    await job.fetch_node()
     assert job.node == "56622858"
 
 
 @mock.patch("logging.Logger.warning")
 @mock.patch("subprocess.check_output")
-def test_fetch_node_warning(mock_check_output, mock_warning):
+async def test_fetch_node_warning(mock_check_output, mock_warning):
     mock_check_output.side_effect = subprocess.CalledProcessError(None, None)
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
-    job.fetch_node()
+    await job.fetch_node()
     mock_warning.assert_called()
 
 
 @mock.patch("subprocess.check_output")
-def test_fetch_port_none(mock_check_output):
+async def test_fetch_port_none(mock_check_output):
     mock_check_output.return_value = b""
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
-    job.fetch_port()
+    await job.fetch_port()
     assert job.port is None
 
 
 @mock.patch("subprocess.check_output")
-def test_fetch_port_some(mock_check_output):
+async def test_fetch_port_some(mock_check_output):
     mock_check_output.return_value = b"8081"
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
-    job.fetch_port()
+    await job.fetch_port()
     assert job.port == 8081
 
 
 @mock.patch("logging.Logger.warning")
 @mock.patch("subprocess.check_output")
-def test_fetch_port_warning(mock_check_output, mock_warning):
+async def test_fetch_port_warning(mock_check_output, mock_warning):
     mock_check_output.side_effect = subprocess.CalledProcessError(None, None)
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
-    job.fetch_port()
+    await job.fetch_port()
     mock_warning.assert_called()
 
 
 @mock.patch("logging.Logger.warning")
 @mock.patch("subprocess.check_output")
-def test_cancel_warning(mock_check_output, mock_warning):
+async def test_cancel_warning(mock_check_output, mock_warning):
     mock_check_output.side_effect = subprocess.CalledProcessError(None, None)
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
-    job.update()
+    await job.update()
     mock_warning.assert_called()


### PR DESCRIPTION
## Summary
- Convert `cancel` / `update` / `remove` / `fetch_node` / `fetch_port` on `Job`, `SlurmJob`, `LocalJob` to `async def`, plus `Service.get_job`. Propagate `await` to all callers (`services/base.py:stop` and `:refresh`, `asgi.py:delete_service` and `:prune_services`). The sync `details` CLI command bridges the now-async `get_job` with `asyncio.run`.
- Delete the unused `SlurmJob.wait` method (no external callers per LSP) so this PR doesn't need to pull in `asyncio` just to convert it.
- Update `tests/unit/test_job.py`: `async def` tests with `pytestmark = pytest.mark.anyio`. `mock.patch.object` auto-creates `AsyncMock` for async methods, so the patches need no other change.

**No behavior change.** Every `subprocess.check_output` call is still a sync blocking call running on the event loop. This PR is the plumbing change that unblocks #296 to swap in true async subprocess via the new `remote.py` module.

## Test plan
- [x] `uv run pytest` — 867 passed, 8 skipped
- [x] `uv run pre-commit run --all-files` — passes (ruff, mypy strict, codespell)
- [x] All `test_job.py` tests converted and passing (11/11)

Closes #349