### PR TITLE
feat(lib): async remote-exec module with timeouts and structured errors

### DIFF
--- a/lib/src/blackfish/server/job.py
+++ b/lib/src/blackfish/server/job.py
@@ -1,11 +1,11 @@
 import os
 import json
-import subprocess
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 from enum import StrEnum, auto
 from typing import Optional, Union
+from blackfish.server import remote
 from blackfish.server.logger import logger
 from blackfish.server.config import ContainerProvider
 
@@ -124,41 +124,25 @@ class SlurmJob(Job):
         """
         if verbose:
             logger.debug(f"Updating job state (job_id={self.job_id}).")
+        sacct_cmd = [
+            "sacct",
+            "-n",
+            "-P",
+            "-X",
+            "-u",
+            self.user,
+            "-j",
+            str(self.job_id),
+            "-o",
+            "State",
+        ]
         try:
             if self.is_local():
-                res = subprocess.check_output(
-                    [
-                        "sacct",
-                        "-n",
-                        "-P",
-                        "-X",
-                        "-u",
-                        self.user,
-                        "-j",
-                        str(self.job_id),
-                        "-o",
-                        "State",
-                    ]
-                )
+                result = await remote.run(sacct_cmd)
             else:
-                res = subprocess.check_output(
-                    [
-                        "ssh",
-                        f"{self.user}@{self.host}",
-                        "sacct",
-                        "-n",
-                        "-P",
-                        "-X",
-                        "-u",
-                        self.user,
-                        "-j",
-                        str(self.job_id),
-                        "-o",
-                        "State",
-                    ]
-                )
+                result = await remote.ssh(f"{self.user}@{self.host}", sacct_cmd)
 
-            new_state = parse_state(res)
+            new_state = parse_state(result.stdout)
             if verbose:
                 logger.debug(
                     f"The current job state is: {format_state(new_state)} (job_id={self.job_id})"
@@ -183,11 +167,8 @@ class SlurmJob(Job):
                         f" (job_id={self.job_id})."
                     )
             self.state = new_state
-        except subprocess.CalledProcessError as e:
-            logger.warning(
-                f"Failed to update job state (job_id={self.job_id},"
-                f" code={e.returncode})."
-            )
+        except remote.RemoteError as e:
+            logger.warning(f"Failed to update job state (job_id={self.job_id}): {e}")
 
         return self.state
 
@@ -198,51 +179,31 @@ class SlurmJob(Job):
         This method logs a warning if the update fails, but does not raise an exception.
         """
         logger.debug(f"Fetching node for job {self.job_id}.")
+        sacct_cmd = [
+            "sacct",
+            "-n",
+            "-P",
+            "-X",
+            "-u",
+            self.user,
+            "-j",
+            str(self.job_id),
+            "-o",
+            "NodeList",
+        ]
         try:
             if self.is_local():
-                res = subprocess.check_output(
-                    [
-                        "sacct",
-                        "-n",
-                        "-P",
-                        "-X",
-                        "-u",
-                        self.user,
-                        "-j",
-                        str(self.job_id),
-                        "-o",
-                        "NodeList",
-                    ],
-                    timeout=10,
-                )
+                result = await remote.run(sacct_cmd, timeout=10)
             else:
-                res = subprocess.check_output(
-                    [
-                        "ssh",
-                        f"{self.user}@{self.host}",
-                        "sacct",
-                        "-n",
-                        "-P",
-                        "-X",
-                        "-u",
-                        self.user,
-                        "-j",
-                        str(self.job_id),
-                        "-o",
-                        "NodeList",
-                    ],
-                    timeout=10,
+                result = await remote.ssh(
+                    f"{self.user}@{self.host}", sacct_cmd, timeout=10
                 )
 
+            res = result.stdout
             self.node = None if res == b"" else res.decode("utf-8").strip()
             logger.debug(f"Job {self.job_id} node set to {self.node}.")
-        except subprocess.TimeoutExpired:
-            logger.warning(f"Timeout fetching node for job {self.job_id}.")
-        except subprocess.CalledProcessError as e:
-            logger.warning(
-                f"Failed to update job node (job_id={self.job_id},"
-                f" code={e.returncode})."
-            )
+        except remote.RemoteError as e:
+            logger.warning(f"Failed to update job node (job_id={self.job_id}): {e}")
 
         return self.node
 
@@ -257,30 +218,18 @@ class SlurmJob(Job):
         This method logs a warning if the update fails, but does not raise an exception.
         """
         logger.debug(f"Fetching port for job {self.job_id}.")
+        ls_cmd = ["ls", os.path.join(self.data_dir, str(self.job_id))]
         try:
             if self.is_local():
-                res = subprocess.check_output(
-                    [
-                        "ls",
-                        os.path.join(self.data_dir, str(self.job_id)),
-                    ]
-                )
+                result = await remote.run(ls_cmd)
             else:
-                res = subprocess.check_output(
-                    [
-                        "ssh",
-                        f"{self.user}@{self.host}",
-                        "ls",
-                        os.path.join(self.data_dir, str(self.job_id)),
-                    ]
-                )
+                result = await remote.ssh(f"{self.user}@{self.host}", ls_cmd)
+
+            res = result.stdout
             self.port = None if res == b"" else int(res.decode("utf-8").strip())
             logger.debug(f"Job {self.job_id} port set to {self.port}")
-        except subprocess.CalledProcessError as e:
-            logger.warning(
-                f"Failed to update job port (job_id={self.job_id},"
-                f" code={e.returncode})."
-            )
+        except remote.RemoteError as e:
+            logger.warning(f"Failed to update job port (job_id={self.job_id}): {e}")
 
         return self.port
 
@@ -289,18 +238,15 @@ class SlurmJob(Job):
 
         This method logs a warning if the update fails, but does not raise an exception.
         """
+        scancel_cmd = ["scancel", str(self.job_id)]
         try:
             logger.debug(f"Canceling job {self.job_id}")
             if self.is_local():
-                subprocess.check_output(["scancel", str(self.job_id)])
+                await remote.run(scancel_cmd)
             else:
-                subprocess.check_output(
-                    ["ssh", f"{self.user}@{self.host}", "scancel", str(self.job_id)]
-                )
-        except subprocess.CalledProcessError as e:
-            logger.warning(
-                f"Failed to cancel job (job_id={self.job_id}, code={e.returncode})."
-            )
+                await remote.ssh(f"{self.user}@{self.host}", scancel_cmd)
+        except remote.RemoteError as e:
+            logger.warning(f"Failed to cancel job (job_id={self.job_id}): {e}")
 
     async def remove(self) -> None:
         pass
@@ -323,7 +269,7 @@ class LocalJob(Job):
             logger.debug(f"Updating job state (job_id={self.job_id})")
         try:
             if self.provider == ContainerProvider.Docker:
-                res = subprocess.check_output(
+                result = await remote.run(
                     [
                         "docker",
                         "inspect",
@@ -331,7 +277,7 @@ class LocalJob(Job):
                         "--format='{{ .State.Status }}'",  # or {{ json .State }}
                     ]
                 )
-                new_state = parse_state(res)
+                new_state = parse_state(result.stdout)
                 if verbose:
                     logger.debug(
                         f"The current job state is: {format_state(new_state)} (job_id={self.job_id})"
@@ -344,10 +290,10 @@ class LocalJob(Job):
                         )
                 self.state = new_state
             elif self.provider == ContainerProvider.Apptainer:
-                res = subprocess.check_output(
+                result = await remote.run(
                     ["apptainer", "instance", "list", "--json", f"{self.name}"]
                 )
-                body = json.loads(res)
+                body = json.loads(result.stdout)
                 if body["instances"] == []:
                     new_state = JobState.STOPPED
                 else:
@@ -364,11 +310,8 @@ class LocalJob(Job):
                             f" (job_id={self.job_id})."
                         )
                 self.state = new_state
-        except subprocess.CalledProcessError as e:
-            logger.warning(
-                f"Failed to update job state (job_id={self.job_id},"
-                f" code={e.returncode})."
-            )
+        except remote.RemoteError as e:
+            logger.warning(f"Failed to update job state (job_id={self.job_id}): {e}")
 
         return self.state
 
@@ -376,26 +319,18 @@ class LocalJob(Job):
         try:
             logger.debug(f"Canceling job {self.job_id}")
             if self.provider == ContainerProvider.Docker:
-                subprocess.check_output(
-                    ["docker", "container", "stop", f"{self.job_id}"]
-                )
+                await remote.run(["docker", "container", "stop", f"{self.job_id}"])
             elif self.provider == ContainerProvider.Apptainer:
-                subprocess.check_output(
-                    ["apptainer", "instance", "stop", f"{self.name}"]
-                )
-        except subprocess.CalledProcessError as e:
-            logger.warning(
-                f"Failed to cancel job (job_id={self.job_id}, code={e.returncode})."
-            )
+                await remote.run(["apptainer", "instance", "stop", f"{self.name}"])
+        except remote.RemoteError as e:
+            logger.warning(f"Failed to cancel job (job_id={self.job_id}): {e}")
 
     async def remove(self) -> None:
         try:
             logger.debug(f"Removing job {self.job_id}")
             if self.provider == ContainerProvider.Docker:
-                subprocess.check_output(["docker", "container", "rm", f"{self.job_id}"])
+                await remote.run(["docker", "container", "rm", f"{self.job_id}"])
             elif self.provider == ContainerProvider.Apptainer:
                 logger.info("Nothing to remove (provider is Apptainer). Skipping.")
-        except subprocess.CalledProcessError as e:
-            logger.warning(
-                f"Failed to remove job (job_id={self.job_id}, code={e.returncode})."
-            )
+        except remote.RemoteError as e:
+            logger.warning(f"Failed to remove job (job_id={self.job_id}): {e}")

--- a/lib/src/blackfish/server/remote.py
+++ b/lib/src/blackfish/server/remote.py
@@ -201,6 +201,9 @@ def _ssh_transport_error(destination: str, stderr: bytes) -> RemoteError:
     """Classify an SSH exit-255 failure as an auth or connection error."""
     detail = stderr.decode("utf-8", "replace").strip()
     lowered = detail.lower()
-    if "permission denied" in lowered or "publickey" in lowered:
-        return RemoteAuthError(f"SSH authentication to {destination!r} failed: {detail}")
+    auth_markers = ("permission denied", "publickey", "authentication failure")
+    if any(marker in lowered for marker in auth_markers):
+        return RemoteAuthError(
+            f"SSH authentication to {destination!r} failed: {detail}"
+        )
     return RemoteConnectionError(f"Could not connect to {destination!r}: {detail}")

--- a/lib/src/blackfish/server/remote.py
+++ b/lib/src/blackfish/server/remote.py
@@ -1,0 +1,206 @@
+"""Async subprocess and SSH/SCP execution with timeouts and structured errors.
+
+Every outbound command in Blackfish — local subprocess, remote exec, remote
+copy — should go through this module rather than calling ``subprocess``
+directly. It provides:
+
+- :func:`run` — run a command locally
+- :func:`ssh` — run a command on a remote host
+- :func:`scp` — copy a file to/from a remote host
+
+All three are built on :func:`asyncio.create_subprocess_exec` for true async,
+cancellable I/O, and all take a mandatory ``timeout``. A hung SSH call no
+longer blocks the event loop — it is cancelled when the timeout elapses.
+
+Failure is reported through a small exception hierarchy:
+
+    RemoteError
+    ├── RemoteTimeout           — the call exceeded its timeout
+    ├── RemoteConnectionError   — SSH transport failed (unreachable / refused / DNS)
+    ├── RemoteAuthError         — SSH transport failed (authentication rejected)
+    └── RemoteCommandError      — the command ran and exited non-zero
+
+Catch :class:`RemoteError` to treat any failure uniformly; catch a subclass to
+distinguish (e.g. a dead login node from a command that merely failed).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+# Default per-call timeout (seconds). Generous enough for slow login nodes,
+# short enough that a truly hung call surfaces quickly.
+DEFAULT_TIMEOUT = 60.0
+
+# SSH exit code reserved for transport-level failure (connection/auth), as
+# opposed to a non-zero exit from the remote command itself.
+_SSH_TRANSPORT_EXIT = 255
+
+# Baked into every ssh/scp invocation:
+# - ConnectTimeout: cap the TCP/handshake wait so an unreachable host fails fast
+# - ServerAliveInterval: detect a dropped connection mid-command
+# - BatchMode: never prompt for a password/passphrase — fail instead of hanging
+_SSH_OPTIONS = [
+    "-o",
+    "ConnectTimeout=10",
+    "-o",
+    "ServerAliveInterval=15",
+    "-o",
+    "BatchMode=yes",
+]
+
+
+class RemoteError(Exception):
+    """Base class for all remote-execution failures."""
+
+
+class RemoteTimeout(RemoteError):
+    """A call exceeded its timeout and was cancelled."""
+
+
+class RemoteConnectionError(RemoteError):
+    """SSH transport failed: host unreachable, connection refused, or DNS failure."""
+
+
+class RemoteAuthError(RemoteError):
+    """SSH transport failed: authentication was rejected."""
+
+
+class RemoteCommandError(RemoteError):
+    """The command ran to completion but exited with a non-zero status."""
+
+    def __init__(
+        self, cmd: list[str], returncode: int, stdout: bytes, stderr: bytes
+    ) -> None:
+        self.cmd = cmd
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        detail = stderr.decode("utf-8", "replace").strip()
+        super().__init__(
+            f"Command {cmd[0]!r} exited with status {returncode}"
+            + (f": {detail}" if detail else "")
+        )
+
+
+@dataclass
+class CompletedProcess:
+    """The result of a successful (exit 0) command."""
+
+    returncode: int
+    stdout: bytes
+    stderr: bytes
+
+
+async def _exec(cmd: list[str], timeout: float) -> tuple[int, bytes, bytes]:
+    """Run ``cmd`` via asyncio, enforcing ``timeout``. Returns (rc, stdout, stderr)."""
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        # Kill the orphaned process before propagating, so a cancelled or
+        # timed-out call doesn't leave a subprocess behind.
+        proc.kill()
+        await proc.wait()
+        raise
+    return proc.returncode or 0, stdout, stderr
+
+
+async def run(cmd: list[str], *, timeout: float = DEFAULT_TIMEOUT) -> CompletedProcess:
+    """Run ``cmd`` locally.
+
+    Args:
+        cmd: the command and its arguments.
+        timeout: seconds to wait before cancelling the call.
+
+    Returns:
+        CompletedProcess on exit 0.
+
+    Raises:
+        RemoteTimeout: the command did not finish within ``timeout``.
+        RemoteCommandError: the command exited non-zero.
+    """
+    try:
+        returncode, stdout, stderr = await _exec(cmd, timeout)
+    except asyncio.TimeoutError:
+        raise RemoteTimeout(f"{cmd[0]!r} timed out after {timeout}s") from None
+    if returncode != 0:
+        raise RemoteCommandError(cmd, returncode, stdout, stderr)
+    return CompletedProcess(returncode, stdout, stderr)
+
+
+async def ssh(
+    destination: str, command: list[str], *, timeout: float = DEFAULT_TIMEOUT
+) -> CompletedProcess:
+    """Run ``command`` on a remote host via SSH.
+
+    Args:
+        destination: the SSH destination, e.g. ``"user@host"`` or ``"host"``.
+        command: the command and its arguments to run on the remote host.
+        timeout: seconds to wait before cancelling the call.
+
+    Returns:
+        CompletedProcess on exit 0.
+
+    Raises:
+        RemoteTimeout: the call did not finish within ``timeout``.
+        RemoteAuthError: SSH authentication was rejected.
+        RemoteConnectionError: the host was unreachable or the connection failed.
+        RemoteCommandError: the remote command ran and exited non-zero.
+    """
+    cmd = ["ssh", *_SSH_OPTIONS, destination, *command]
+    try:
+        returncode, stdout, stderr = await _exec(cmd, timeout)
+    except asyncio.TimeoutError:
+        raise RemoteTimeout(
+            f"ssh to {destination!r} timed out after {timeout}s"
+        ) from None
+    if returncode == _SSH_TRANSPORT_EXIT:
+        raise _ssh_transport_error(destination, stderr)
+    if returncode != 0:
+        raise RemoteCommandError(cmd, returncode, stdout, stderr)
+    return CompletedProcess(returncode, stdout, stderr)
+
+
+async def scp(src: str, dst: str, *, timeout: float = DEFAULT_TIMEOUT) -> None:
+    """Copy a file with SCP.
+
+    Either ``src`` or ``dst`` may be a remote path of the form
+    ``user@host:/path``.
+
+    Args:
+        src: the source path (local or remote).
+        dst: the destination path (local or remote).
+        timeout: seconds to wait before cancelling the call.
+
+    Raises:
+        RemoteTimeout: the copy did not finish within ``timeout``.
+        RemoteAuthError: SSH authentication was rejected.
+        RemoteConnectionError: the host was unreachable or the connection failed.
+        RemoteCommandError: scp ran and exited non-zero for another reason.
+    """
+    cmd = ["scp", *_SSH_OPTIONS, src, dst]
+    try:
+        returncode, stdout, stderr = await _exec(cmd, timeout)
+    except asyncio.TimeoutError:
+        raise RemoteTimeout(
+            f"scp {src!r} -> {dst!r} timed out after {timeout}s"
+        ) from None
+    if returncode == _SSH_TRANSPORT_EXIT:
+        raise _ssh_transport_error(dst, stderr)
+    if returncode != 0:
+        raise RemoteCommandError(cmd, returncode, stdout, stderr)
+
+
+def _ssh_transport_error(destination: str, stderr: bytes) -> RemoteError:
+    """Classify an SSH exit-255 failure as an auth or connection error."""
+    detail = stderr.decode("utf-8", "replace").strip()
+    lowered = detail.lower()
+    if "permission denied" in lowered or "publickey" in lowered:
+        return RemoteAuthError(f"SSH authentication to {destination!r} failed: {detail}")
+    return RemoteConnectionError(f"Could not connect to {destination!r}: {detail}")

--- a/lib/src/blackfish/server/remote.py
+++ b/lib/src/blackfish/server/remote.py
@@ -192,16 +192,24 @@ async def scp(src: str, dst: str, *, timeout: float = DEFAULT_TIMEOUT) -> None:
             f"scp {src!r} -> {dst!r} timed out after {timeout}s"
         ) from None
     if returncode == _SSH_TRANSPORT_EXIT:
-        raise _ssh_transport_error(dst, stderr)
+        # Either src or dst may be the remote endpoint; name both so the
+        # message is unambiguous regardless of copy direction.
+        raise _ssh_transport_error(f"{src} -> {dst}", stderr)
     if returncode != 0:
         raise RemoteCommandError(cmd, returncode, stdout, stderr)
 
 
 def _ssh_transport_error(destination: str, stderr: bytes) -> RemoteError:
-    """Classify an SSH exit-255 failure as an auth or connection error."""
+    """Classify an SSH exit-255 failure as an auth or connection error.
+
+    Best-effort: SSH error wording varies by version and locale, so this
+    matches on a few stable substrings and defaults to a connection error.
+    """
     detail = stderr.decode("utf-8", "replace").strip()
     lowered = detail.lower()
-    auth_markers = ("permission denied", "publickey", "authentication failure")
+    # "authentication fail" covers "authentication failed" and
+    # "...too many authentication failures".
+    auth_markers = ("permission denied", "publickey", "authentication fail")
     if any(marker in lowered for marker in auth_markers):
         return RemoteAuthError(
             f"SSH authentication to {destination!r} failed: {detail}"

--- a/lib/src/blackfish/server/services/base.py
+++ b/lib/src/blackfish/server/services/base.py
@@ -205,7 +205,7 @@ class Service(UUIDAuditBase):
                         f"{self.user}@{self.host}",
                         ["mkdir", "-p", remote_script_dir],
                     )
-                except Exception as e:
+                except remote.RemoteError as e:
                     logger.error(f"Failed to connect to remote host: {e}")
                     raise ServiceLaunchError("ssh", self.host)
 
@@ -214,7 +214,7 @@ class Service(UUIDAuditBase):
                         str(script_path),
                         f"{self.user}@{self.host}:{remote_script_dir}",
                     )
-                except Exception as e:
+                except remote.RemoteError as e:
                     logger.error(f"Failed to copy job script to remote host: {e}")
                     raise ServiceLaunchError("copy", self.host)
 
@@ -232,7 +232,7 @@ class Service(UUIDAuditBase):
                     job_id = result.stdout.decode("utf-8").strip().split()[-1]
                     self.status = ServiceStatus.SUBMITTED
                     self.job_id = job_id
-                except Exception as e:
+                except remote.RemoteError as e:
                     logger.error(f"Failed to submit Slurm job: {e}")
                     raise ServiceLaunchError("submit", self.host)
         else:
@@ -267,7 +267,7 @@ class Service(UUIDAuditBase):
             logger.info("Attempting to start service locally...")
             try:
                 result = await remote.run(["bash", script_path.as_posix()])
-            except Exception as e:
+            except remote.RemoteError as e:
                 logger.error(f"Failed to start container: {e}")
                 raise ServiceLaunchError("container", "localhost")
             if self.provider == ContainerProvider.Docker:

--- a/lib/src/blackfish/server/services/base.py
+++ b/lib/src/blackfish/server/services/base.py
@@ -19,6 +19,7 @@ from jinja2 import Environment, PackageLoader
 
 from litestar.datastructures import State
 
+from blackfish.server import remote
 from blackfish.server.job import (
     Job,
     JobState,
@@ -179,15 +180,15 @@ class Service(UUIDAuditBase):
 
             if self.host == "localhost":
                 logger.debug("Submitting slurm job locally.")
-                res = subprocess.check_output(
+                result = await remote.run(
                     [
                         "sbatch",
                         "--chdir",
-                        script_path.parent,
-                        script_path,
+                        str(script_path.parent),
+                        str(script_path),
                     ]
                 )
-                job_id = res.decode("utf-8").strip().split()[-1]
+                job_id = result.stdout.decode("utf-8").strip().split()[-1]
                 self.status = ServiceStatus.SUBMITTED
                 self.job_id = job_id
             else:
@@ -200,26 +201,18 @@ class Service(UUIDAuditBase):
                 remote_script_dir = os.path.join(profile.home_dir, "jobs", self.id.hex)
 
                 try:
-                    _ = subprocess.check_output(
-                        [
-                            "ssh",
-                            f"{self.user}@{self.host}",
-                            "mkdir",
-                            "-p",
-                            remote_script_dir,
-                        ]
+                    await remote.ssh(
+                        f"{self.user}@{self.host}",
+                        ["mkdir", "-p", remote_script_dir],
                     )
                 except Exception as e:
                     logger.error(f"Failed to connect to remote host: {e}")
                     raise ServiceLaunchError("ssh", self.host)
 
                 try:
-                    _ = subprocess.check_output(
-                        [
-                            "scp",
-                            script_path,
-                            (f"{self.user}@{self.host}:{remote_script_dir}"),
-                        ]
+                    await remote.scp(
+                        str(script_path),
+                        f"{self.user}@{self.host}:{remote_script_dir}",
                     )
                 except Exception as e:
                     logger.error(f"Failed to copy job script to remote host: {e}")
@@ -227,17 +220,16 @@ class Service(UUIDAuditBase):
 
                 logger.debug(f"Submitting batch job to {self.host}.")
                 try:
-                    res = subprocess.check_output(
+                    result = await remote.ssh(
+                        f"{self.user}@{self.host}",
                         [
-                            "ssh",
-                            f"{self.user}@{self.host}",
                             "sbatch",
                             "--chdir",
                             remote_script_dir,
                             os.path.join(remote_script_dir, "start.sh"),
-                        ]
+                        ],
                     )
-                    job_id = res.decode("utf-8").strip().split()[-1]
+                    job_id = result.stdout.decode("utf-8").strip().split()[-1]
                     self.status = ServiceStatus.SUBMITTED
                     self.job_id = job_id
                 except Exception as e:
@@ -274,12 +266,12 @@ class Service(UUIDAuditBase):
                     raise ServiceLaunchError("script", "localhost")
             logger.info("Attempting to start service locally...")
             try:
-                res = subprocess.check_output(["bash", script_path.as_posix()])
+                result = await remote.run(["bash", script_path.as_posix()])
             except Exception as e:
                 logger.error(f"Failed to start container: {e}")
                 raise ServiceLaunchError("container", "localhost")
             if self.provider == ContainerProvider.Docker:
-                job_id = res.decode("utf-8").strip().split()[-1][:12]
+                job_id = result.stdout.decode("utf-8").strip().split()[-1][:12]
             self.status = ServiceStatus.SUBMITTED
             self.job_id = job_id
 

--- a/lib/tests/unit/test_job.py
+++ b/lib/tests/unit/test_job.py
@@ -1,18 +1,26 @@
-import subprocess
 from unittest import mock
 
 import pytest
 
 from blackfish.server.job import JobState, SlurmJob
+from blackfish.server.remote import CompletedProcess, RemoteConnectionError
 
 pytestmark = pytest.mark.anyio
 
 
+def _completed(stdout: bytes = b"") -> CompletedProcess:
+    return CompletedProcess(returncode=0, stdout=stdout, stderr=b"")
+
+
+# The test jobs use host="test" (not localhost), so update/fetch_node/
+# fetch_port/cancel all take the remote SSH branch and call `remote.ssh`.
+
+
 @mock.patch.object(SlurmJob, "fetch_port")
 @mock.patch.object(SlurmJob, "fetch_node")
-@mock.patch("subprocess.check_output")
-async def test_update_none(mock_check_output, mock_fetch_node, mock_fetch_port):
-    mock_check_output.return_value = b""
+@mock.patch("blackfish.server.remote.ssh")
+async def test_update_none(mock_ssh, mock_fetch_node, mock_fetch_port):
+    mock_ssh.return_value = _completed(b"")
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
     await job.update()
     assert job.state == JobState.MISSING
@@ -22,9 +30,9 @@ async def test_update_none(mock_check_output, mock_fetch_node, mock_fetch_port):
 
 @mock.patch.object(SlurmJob, "fetch_port")
 @mock.patch.object(SlurmJob, "fetch_node")
-@mock.patch("subprocess.check_output")
-async def test_update_no_change(mock_check_output, mock_fetch_node, mock_fetch_port):
-    mock_check_output.return_value = b"RUNNING"
+@mock.patch("blackfish.server.remote.ssh")
+async def test_update_no_change(mock_ssh, mock_fetch_node, mock_fetch_port):
+    mock_ssh.return_value = _completed(b"RUNNING")
     job = SlurmJob(
         job_id=1, user="test", host="test", state=JobState.RUNNING, data_dir="test"
     )
@@ -36,9 +44,9 @@ async def test_update_no_change(mock_check_output, mock_fetch_node, mock_fetch_p
 
 @mock.patch.object(SlurmJob, "fetch_port")
 @mock.patch.object(SlurmJob, "fetch_node")
-@mock.patch("subprocess.check_output")
-async def test_update_change(mock_check_output, mock_fetch_node, mock_fetch_port):
-    mock_check_output.return_value = b"RUNNING"
+@mock.patch("blackfish.server.remote.ssh")
+async def test_update_change(mock_ssh, mock_fetch_node, mock_fetch_port):
+    mock_ssh.return_value = _completed(b"RUNNING")
     job = SlurmJob(
         job_id=1, user="test", host="test", state=JobState.PENDING, data_dir="test"
     )
@@ -51,11 +59,9 @@ async def test_update_change(mock_check_output, mock_fetch_node, mock_fetch_port
 @mock.patch("logging.Logger.warning")
 @mock.patch.object(SlurmJob, "fetch_port")
 @mock.patch.object(SlurmJob, "fetch_node")
-@mock.patch("subprocess.check_output")
-async def test_update_warning(
-    mock_check_output, mock_fetch_node, mock_fetch_port, mock_warning
-):
-    mock_check_output.side_effect = subprocess.CalledProcessError(1, "ssh")
+@mock.patch("blackfish.server.remote.ssh")
+async def test_update_warning(mock_ssh, mock_fetch_node, mock_fetch_port, mock_warning):
+    mock_ssh.side_effect = RemoteConnectionError("connection refused")
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
     await job.update()
     mock_warning.assert_called()
@@ -63,60 +69,60 @@ async def test_update_warning(
     mock_fetch_port.assert_not_called()
 
 
-@mock.patch("subprocess.check_output")
-async def test_fetch_node_none(mock_check_output):
-    mock_check_output.return_value = b""
+@mock.patch("blackfish.server.remote.ssh")
+async def test_fetch_node_none(mock_ssh):
+    mock_ssh.return_value = _completed(b"")
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
     await job.fetch_node()
     assert job.node is None
 
 
-@mock.patch("subprocess.check_output")
-async def test_fetch_node_some(mock_check_output):
-    mock_check_output.return_value = b"56622858"
+@mock.patch("blackfish.server.remote.ssh")
+async def test_fetch_node_some(mock_ssh):
+    mock_ssh.return_value = _completed(b"56622858")
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
     await job.fetch_node()
     assert job.node == "56622858"
 
 
 @mock.patch("logging.Logger.warning")
-@mock.patch("subprocess.check_output")
-async def test_fetch_node_warning(mock_check_output, mock_warning):
-    mock_check_output.side_effect = subprocess.CalledProcessError(1, "ssh")
+@mock.patch("blackfish.server.remote.ssh")
+async def test_fetch_node_warning(mock_ssh, mock_warning):
+    mock_ssh.side_effect = RemoteConnectionError("connection refused")
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
     await job.fetch_node()
     mock_warning.assert_called()
 
 
-@mock.patch("subprocess.check_output")
-async def test_fetch_port_none(mock_check_output):
-    mock_check_output.return_value = b""
+@mock.patch("blackfish.server.remote.ssh")
+async def test_fetch_port_none(mock_ssh):
+    mock_ssh.return_value = _completed(b"")
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
     await job.fetch_port()
     assert job.port is None
 
 
-@mock.patch("subprocess.check_output")
-async def test_fetch_port_some(mock_check_output):
-    mock_check_output.return_value = b"8081"
+@mock.patch("blackfish.server.remote.ssh")
+async def test_fetch_port_some(mock_ssh):
+    mock_ssh.return_value = _completed(b"8081")
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
     await job.fetch_port()
     assert job.port == 8081
 
 
 @mock.patch("logging.Logger.warning")
-@mock.patch("subprocess.check_output")
-async def test_fetch_port_warning(mock_check_output, mock_warning):
-    mock_check_output.side_effect = subprocess.CalledProcessError(1, "ssh")
+@mock.patch("blackfish.server.remote.ssh")
+async def test_fetch_port_warning(mock_ssh, mock_warning):
+    mock_ssh.side_effect = RemoteConnectionError("connection refused")
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
     await job.fetch_port()
     mock_warning.assert_called()
 
 
 @mock.patch("logging.Logger.warning")
-@mock.patch("subprocess.check_output")
-async def test_cancel_warning(mock_check_output, mock_warning):
-    mock_check_output.side_effect = subprocess.CalledProcessError(1, "ssh")
+@mock.patch("blackfish.server.remote.ssh")
+async def test_cancel_warning(mock_ssh, mock_warning):
+    mock_ssh.side_effect = RemoteConnectionError("connection refused")
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
     await job.cancel()
     mock_warning.assert_called()

--- a/lib/tests/unit/test_remote.py
+++ b/lib/tests/unit/test_remote.py
@@ -58,9 +58,6 @@ def _patch_exec(proc: FakeProc) -> mock._patch:
     )
 
 
-# --- run: real local subprocesses ---------------------------------------------
-
-
 async def test_run_success() -> None:
     result = await remote.run(["echo", "hello"])
     assert isinstance(result, CompletedProcess)
@@ -86,9 +83,6 @@ async def test_run_cancellation_propagates() -> None:
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
-
-
-# --- ssh: mocked transport ----------------------------------------------------
 
 
 async def test_ssh_success_returns_completed_process() -> None:
@@ -118,11 +112,17 @@ async def test_ssh_connection_failure() -> None:
 
 
 async def test_ssh_remote_command_failure() -> None:
-    proc = FakeProc(returncode=1, stderr=b"sacct: error: invalid job id")
+    proc = FakeProc(
+        returncode=1,
+        stdout=b"partial output",
+        stderr=b"sacct: error: invalid job id",
+    )
     with _patch_exec(proc):
         with pytest.raises(RemoteCommandError) as exc_info:
             await remote.ssh("user@host", ["sacct", "-j", "bad"])
     assert exc_info.value.returncode == 1
+    assert exc_info.value.stdout == b"partial output"
+    assert exc_info.value.stderr == b"sacct: error: invalid job id"
 
 
 async def test_ssh_timeout() -> None:
@@ -133,7 +133,33 @@ async def test_ssh_timeout() -> None:
     assert proc.killed
 
 
-# --- transport-error classification (SSH exit 255) ----------------------------
+async def test_scp_connection_failure() -> None:
+    proc = FakeProc(returncode=255, stderr=b"ssh: Could not resolve hostname host")
+    with _patch_exec(proc):
+        with pytest.raises(RemoteConnectionError):
+            await remote.scp("local.sh", "user@host:/remote/local.sh")
+
+
+async def test_scp_remote_command_failure() -> None:
+    proc = FakeProc(returncode=1, stderr=b"scp: /remote/local.sh: Permission denied")
+    with _patch_exec(proc):
+        with pytest.raises(RemoteCommandError):
+            await remote.scp("local.sh", "user@host:/remote/local.sh")
+
+
+async def test_scp_auth_failure() -> None:
+    proc = FakeProc(returncode=255, stderr=b"Permission denied (publickey).")
+    with _patch_exec(proc):
+        with pytest.raises(RemoteAuthError):
+            await remote.scp("local.sh", "user@host:/remote/local.sh")
+
+
+async def test_scp_timeout() -> None:
+    proc = FakeProc(hang=True)
+    with _patch_exec(proc):
+        with pytest.raises(RemoteTimeout):
+            await remote.scp("local.sh", "user@host:/remote/local.sh", timeout=0.2)
+    assert proc.killed
 
 
 @pytest.mark.parametrize(
@@ -161,20 +187,3 @@ async def test_classify_connection_failure(stderr: bytes) -> None:
     assert isinstance(
         remote._ssh_transport_error("host", stderr), RemoteConnectionError
     )
-
-
-# --- scp: mocked transport ----------------------------------------------------
-
-
-async def test_scp_connection_failure() -> None:
-    proc = FakeProc(returncode=255, stderr=b"ssh: Could not resolve hostname host")
-    with _patch_exec(proc):
-        with pytest.raises(RemoteConnectionError):
-            await remote.scp("local.sh", "user@host:/remote/local.sh")
-
-
-async def test_scp_remote_command_failure() -> None:
-    proc = FakeProc(returncode=1, stderr=b"scp: /remote/local.sh: Permission denied")
-    with _patch_exec(proc):
-        with pytest.raises(RemoteCommandError):
-            await remote.scp("local.sh", "user@host:/remote/local.sh")

--- a/lib/tests/unit/test_remote.py
+++ b/lib/tests/unit/test_remote.py
@@ -91,17 +91,13 @@ async def test_run_cancellation_propagates() -> None:
 # --- ssh: mocked transport ----------------------------------------------------
 
 
-async def test_ssh_success_builds_command_with_options() -> None:
-    proc = FakeProc(returncode=0, stdout=b"RUNNING\n")
-    with _patch_exec(proc) as m:
+async def test_ssh_success_returns_completed_process() -> None:
+    proc = FakeProc(returncode=0, stdout=b"RUNNING\n", stderr=b"")
+    with _patch_exec(proc):
         result = await remote.ssh("user@host", ["sacct", "-j", "1"])
+    assert result.returncode == 0
     assert result.stdout == b"RUNNING\n"
-    argv = m.call_args.args
-    assert argv[0] == "ssh"
-    assert "BatchMode=yes" in argv
-    assert "ConnectTimeout=10" in argv
-    assert "user@host" in argv
-    assert argv[-3:] == ("sacct", "-j", "1")
+    assert result.stderr == b""
 
 
 async def test_ssh_auth_failure() -> None:
@@ -112,7 +108,10 @@ async def test_ssh_auth_failure() -> None:
 
 
 async def test_ssh_connection_failure() -> None:
-    proc = FakeProc(returncode=255, stderr=b"ssh: connect to host port 22: Connection refused")
+    proc = FakeProc(
+        returncode=255,
+        stderr=b"ssh: connect to host port 22: Connection refused",
+    )
     with _patch_exec(proc):
         with pytest.raises(RemoteConnectionError):
             await remote.ssh("user@host", ["sacct"])
@@ -134,21 +133,54 @@ async def test_ssh_timeout() -> None:
     assert proc.killed
 
 
+# --- transport-error classification (SSH exit 255) ----------------------------
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        b"Permission denied (publickey).",
+        b"user@host: Permission denied (publickey,password).",
+        b"Received disconnect from host: 2: Too many authentication failures",
+    ],
+)
+async def test_classify_auth_failure(stderr: bytes) -> None:
+    assert isinstance(remote._ssh_transport_error("host", stderr), RemoteAuthError)
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        b"ssh: connect to host port 22: Connection refused",
+        b"ssh: Could not resolve hostname host: nodename nor servname provided",
+        b"ssh: connect to host port 22: Operation timed out",
+        b"",
+    ],
+)
+async def test_classify_connection_failure(stderr: bytes) -> None:
+    assert isinstance(
+        remote._ssh_transport_error("host", stderr), RemoteConnectionError
+    )
+
+
 # --- scp: mocked transport ----------------------------------------------------
 
 
 async def test_scp_success() -> None:
     proc = FakeProc(returncode=0)
-    with _patch_exec(proc) as m:
+    with _patch_exec(proc):
         await remote.scp("local.sh", "user@host:/remote/local.sh")
-    argv = m.call_args.args
-    assert argv[0] == "scp"
-    assert "BatchMode=yes" in argv
-    assert argv[-2:] == ("local.sh", "user@host:/remote/local.sh")
 
 
 async def test_scp_connection_failure() -> None:
     proc = FakeProc(returncode=255, stderr=b"ssh: Could not resolve hostname host")
     with _patch_exec(proc):
         with pytest.raises(RemoteConnectionError):
+            await remote.scp("local.sh", "user@host:/remote/local.sh")
+
+
+async def test_scp_remote_command_failure() -> None:
+    proc = FakeProc(returncode=1, stderr=b"scp: /remote/local.sh: Permission denied")
+    with _patch_exec(proc):
+        with pytest.raises(RemoteCommandError):
             await remote.scp("local.sh", "user@host:/remote/local.sh")

--- a/lib/tests/unit/test_remote.py
+++ b/lib/tests/unit/test_remote.py
@@ -166,12 +166,6 @@ async def test_classify_connection_failure(stderr: bytes) -> None:
 # --- scp: mocked transport ----------------------------------------------------
 
 
-async def test_scp_success() -> None:
-    proc = FakeProc(returncode=0)
-    with _patch_exec(proc):
-        await remote.scp("local.sh", "user@host:/remote/local.sh")
-
-
 async def test_scp_connection_failure() -> None:
     proc = FakeProc(returncode=255, stderr=b"ssh: Could not resolve hostname host")
     with _patch_exec(proc):

--- a/lib/tests/unit/test_remote.py
+++ b/lib/tests/unit/test_remote.py
@@ -1,0 +1,154 @@
+"""Tests for the async remote-execution module.
+
+`run` is exercised against real local subprocesses (echo / false / sleep).
+`ssh` and `scp` mock `asyncio.create_subprocess_exec` so the transport-error
+classification and command construction can be tested without a remote host.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest import mock
+
+import pytest
+
+from blackfish.server import remote
+from blackfish.server.remote import (
+    CompletedProcess,
+    RemoteAuthError,
+    RemoteCommandError,
+    RemoteConnectionError,
+    RemoteTimeout,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+class FakeProc:
+    """Stand-in for an asyncio subprocess transport."""
+
+    def __init__(
+        self,
+        returncode: int = 0,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+        hang: bool = False,
+    ) -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+        self._hang = hang
+        self.killed = False
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        if self._hang:
+            await asyncio.sleep(3600)
+        return self._stdout, self._stderr
+
+    def kill(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        return self.returncode
+
+
+def _patch_exec(proc: FakeProc) -> mock._patch:
+    return mock.patch(
+        "asyncio.create_subprocess_exec", mock.AsyncMock(return_value=proc)
+    )
+
+
+# --- run: real local subprocesses ---------------------------------------------
+
+
+async def test_run_success() -> None:
+    result = await remote.run(["echo", "hello"])
+    assert isinstance(result, CompletedProcess)
+    assert result.returncode == 0
+    assert result.stdout.strip() == b"hello"
+
+
+async def test_run_nonzero_raises_command_error() -> None:
+    with pytest.raises(RemoteCommandError) as exc_info:
+        await remote.run(["false"])
+    assert exc_info.value.returncode != 0
+    assert exc_info.value.cmd == ["false"]
+
+
+async def test_run_timeout() -> None:
+    with pytest.raises(RemoteTimeout):
+        await remote.run(["sleep", "5"], timeout=0.2)
+
+
+async def test_run_cancellation_propagates() -> None:
+    task = asyncio.create_task(remote.run(["sleep", "5"]))
+    await asyncio.sleep(0.1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+# --- ssh: mocked transport ----------------------------------------------------
+
+
+async def test_ssh_success_builds_command_with_options() -> None:
+    proc = FakeProc(returncode=0, stdout=b"RUNNING\n")
+    with _patch_exec(proc) as m:
+        result = await remote.ssh("user@host", ["sacct", "-j", "1"])
+    assert result.stdout == b"RUNNING\n"
+    argv = m.call_args.args
+    assert argv[0] == "ssh"
+    assert "BatchMode=yes" in argv
+    assert "ConnectTimeout=10" in argv
+    assert "user@host" in argv
+    assert argv[-3:] == ("sacct", "-j", "1")
+
+
+async def test_ssh_auth_failure() -> None:
+    proc = FakeProc(returncode=255, stderr=b"Permission denied (publickey).")
+    with _patch_exec(proc):
+        with pytest.raises(RemoteAuthError):
+            await remote.ssh("user@host", ["sacct"])
+
+
+async def test_ssh_connection_failure() -> None:
+    proc = FakeProc(returncode=255, stderr=b"ssh: connect to host port 22: Connection refused")
+    with _patch_exec(proc):
+        with pytest.raises(RemoteConnectionError):
+            await remote.ssh("user@host", ["sacct"])
+
+
+async def test_ssh_remote_command_failure() -> None:
+    proc = FakeProc(returncode=1, stderr=b"sacct: error: invalid job id")
+    with _patch_exec(proc):
+        with pytest.raises(RemoteCommandError) as exc_info:
+            await remote.ssh("user@host", ["sacct", "-j", "bad"])
+    assert exc_info.value.returncode == 1
+
+
+async def test_ssh_timeout() -> None:
+    proc = FakeProc(hang=True)
+    with _patch_exec(proc):
+        with pytest.raises(RemoteTimeout):
+            await remote.ssh("user@host", ["sacct"], timeout=0.2)
+    assert proc.killed
+
+
+# --- scp: mocked transport ----------------------------------------------------
+
+
+async def test_scp_success() -> None:
+    proc = FakeProc(returncode=0)
+    with _patch_exec(proc) as m:
+        await remote.scp("local.sh", "user@host:/remote/local.sh")
+    argv = m.call_args.args
+    assert argv[0] == "scp"
+    assert "BatchMode=yes" in argv
+    assert argv[-2:] == ("local.sh", "user@host:/remote/local.sh")
+
+
+async def test_scp_connection_failure() -> None:
+    proc = FakeProc(returncode=255, stderr=b"ssh: Could not resolve hostname host")
+    with _patch_exec(proc):
+        with pytest.raises(RemoteConnectionError):
+            await remote.scp("local.sh", "user@host:/remote/local.sh")


### PR DESCRIPTION
## Summary
- New `server/remote.py` — `run` / `ssh` / `scp` built on `asyncio.create_subprocess_exec`, with mandatory timeouts, baked-in SSH options (`ConnectTimeout`, `ServerAliveInterval`, `BatchMode`), and a `RemoteError` hierarchy: `RemoteTimeout`, `RemoteConnectionError`, `RemoteAuthError`, `RemoteCommandError`. A hung SSH call is now cancellable instead of blocking the event loop in a C-level syscall.
- Migrated the `subprocess`/SSH call sites in `job.py` (`SlurmJob`, `LocalJob`) and `services/base.py` (`Service.start`) onto it. `open_tunnel` keeps raw `subprocess` — a backgrounded `ssh -N -f -L` tunnel is a different lifecycle (follow-up #355).
- `jobs/client.py`'s `SSHRunner`/`LocalRunner` consolidation is deferred to follow-up #356 to keep this PR reviewable.

## Test plan
- [x] `uv run pytest` — 878 passed, 8 skipped
- [x] `uv run pre-commit run --all-files` — passes (ruff, mypy strict, codespell)
- [x] New `test_remote.py` covers success, non-zero exit, timeout, cancellation, and SSH auth/connection error classification (11 tests)
- [x] `test_job.py` migrated to mock `remote.ssh` instead of `subprocess.check_output`

Closes #296