### PR TITLE
test(lib): mock TigerFlow in test_slurm_auto_setup

### DIFF
--- a/lib/tests/unit/test_setup.py
+++ b/lib/tests/unit/test_setup.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 
@@ -21,7 +23,19 @@ def test_local_auto_setup(tmp_path):
     _auto_profile_(p, "default", "local", None, None, home_dir=p, cache_dir=p)
 
 
-def test_slurm_auto_setup(tmp_path):
+@mock.patch("blackfish.cli.profile.TigerFlowClient")
+def test_slurm_auto_setup(mock_tigerflow_client, tmp_path):
+    # Pretend TigerFlow is already healthy on the remote — otherwise
+    # _setup_profile falls into TigerFlowClient.setup(), which creates a venv
+    # and pip-installs tigerflow/tigerflow-ml for real (network-dependent,
+    # ~20s). The test's purpose is to verify _auto_profile_ wires up a slurm
+    # profile, not to exercise the install path.
+    instance = mock_tigerflow_client.return_value
+    instance.check_health = mock.AsyncMock(
+        return_value=mock.MagicMock(tigerflow="1.0.0", tigerflow_ml="1.0.0")
+    )
+    instance.check_capabilities = mock.AsyncMock()
+
     p = tmp_path / ".blackfish"
     ensure_app_dir(p)
     _auto_profile_(p, "default", "slurm", "localhost", "test", home_dir=p, cache_dir=p)


### PR DESCRIPTION
## Summary
- `test_slurm_auto_setup` was reaching `_setup_profile`'s `setup_tigerflow` branch and running `TigerFlowClient.setup()` — which creates a venv and `pip install`s tigerflow + tigerflow-ml from a git source. About **20 s of real network I/O on every CI run**, plus the flakiness that comes with any network-dependent test.
- Mock `TigerFlowClient` so `check_health` reports healthy and the install path is skipped. The test still exercises `_auto_profile_`'s Slurm wiring (config write, directory setup) — just without the real install.
- Drops the full suite from ~154 s to ~134 s locally (~13 % wall-time reduction, ~14 % of the previous total). The single highest-leverage item out of #360.

## Test plan
- [x] `uv run pytest tests/unit/test_setup.py` — all 4 tests pass; `test_slurm_auto_setup` goes from 21.72 s → 0.02 s
- [x] `uv run pytest` — 892 passed, 8 skipped, 133.89 s
- [x] `uv run pre-commit run --all-files` — passes (ruff, mypy strict)

Part of #360.