### PR TITLE
fix(lib): set PYTHONNOUSERSITE=1 in apptainer service launches

### DIFF
--- a/lib/src/blackfish/server/templates/speech_recognition_local.sh
+++ b/lib/src/blackfish/server/templates/speech_recognition_local.sh
@@ -15,6 +15,7 @@ docker run -d {{ '--runtime nvidia --gpus all' if job_config.gres else '' }} \
   --port {{ container_config.port }}
 {%- elif provider == 'apptainer' %}
 apptainer instance run {{ ' --nv' if job_config.gres > 0 else '' }} \
+  --env PYTHONNOUSERSITE=1 \
   --bind {{ mount }}:/data/audio \
   --bind {{ container_config.model_dir }}:/data/models \
   {{ profile.cache_dir }}/images/{{ image.sif }} \

--- a/lib/src/blackfish/server/templates/speech_recognition_slurm.sh
+++ b/lib/src/blackfish/server/templates/speech_recognition_slurm.sh
@@ -4,6 +4,7 @@
 XDG_RUNTIME_DIR=""
 
 apptainer run {{ ' --nv' if job_config.gres > 0 else '' }} \
+  --env PYTHONNOUSERSITE=1 \
   --bind {{ mount }}:/data/audio \
   --bind {{ container_config.model_dir }}:/data/models \
   {{ profile.cache_dir }}/images/{{ image.sif }} \

--- a/lib/src/blackfish/server/templates/text_generation_local.sh
+++ b/lib/src/blackfish/server/templates/text_generation_local.sh
@@ -13,6 +13,7 @@ docker run -d {{ '--runtime nvidia --gpus all' if job_config.gres else '' }} \
 {%- elif provider == 'apptainer' %}
 export SINGULARITY_NO_EVAL=1
 apptainer instance run {{ ' --nv' if job_config.gres > 0 else '' }} \
+  --env PYTHONNOUSERSITE=1 \
   --bind {{ container_config.model_dir }}:/data \
   {{ profile.cache_dir }}/images/{{ image.sif }} \
   {{ name }} \

--- a/lib/src/blackfish/server/templates/text_generation_slurm.sh
+++ b/lib/src/blackfish/server/templates/text_generation_slurm.sh
@@ -2,6 +2,7 @@
 {% block command %}
 export SINGULARITY_NO_EVAL=1
 apptainer run {{ '--nv' if job_config.gres else '' }} \
+  --env PYTHONNOUSERSITE=1 \
   --bind {{ container_config.model_dir }}:/data \
   {{ profile.cache_dir }}/images/{{ image.sif }} \
   --model /data/snapshots/{{ container_config['revision'] }} \


### PR DESCRIPTION
## Summary

- Apptainer bind-mounts `\$HOME` by default, so packages installed via `pip install --user` (which land in `~/.local/lib/python3.12/site-packages`) shadow the container image's own site-packages.
- Observed in the wild: a user had `huggingface-hub==1.16` in their user-site, which got picked up inside the vLLM image and broke transformers' `huggingface-hub<1.0` version check, causing the service to fail on startup.
- Adds `--env PYTHONNOUSERSITE=1` to all four active apptainer invocations (text-generation and speech-recognition × slurm/local). Python then ignores `~/.local/.../site-packages` regardless of `\$HOME` being mounted. Minimal, targeted change — does not touch `--cleanenv` or `--no-home`, which would have broader side effects.
- Same fix has been shipped as v0.5.2 for users on the 0.5.x line.

## Test plan

- [x] \`uv run just lint\` passes
- [x] \`uv run just test\` passes (892 passed, 8 skipped)
- [x] Manual: launch a text-generation service on a cluster with a host \`~/.local/lib/python3.12/site-packages/huggingface_hub\` present; confirm the container imports the image's huggingface_hub rather than the host's
- [x] Manual: confirm existing services (no user-site conflict) still launch normally