### PR TITLE
fix(lib): decouple uvicorn --reload from BLACKFISH_DEBUG

### DIFF
--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -212,13 +212,17 @@ profile.add_command(rename_profile, "rename")
 
 @main.command()
 @click.option(
-    "--reload",
+    "--reload/--no-reload",
     "-r",
-    is_flag=True,
-    default=False,
-    help="Automatically reload changes to the application.",
+    default=None,
+    help=(
+        "Automatically reload changes to the application. "
+        "Defaults to on when BLACKFISH_DEBUG=1, off otherwise. "
+        "Pass --no-reload to disable on shared/HPC filesystems where "
+        "the watcher's lstat polling can starve the event loop."
+    ),
 )
-def start(reload: bool) -> None:  # pragma: no cover
+def start(reload: bool | None) -> None:  # pragma: no cover
     """Start the blackfish app.
 
     Application configuration is based on the following local environment variables:
@@ -315,7 +319,8 @@ def start(reload: bool) -> None:  # pragma: no cover
     except Exception as e:
         logger.warning(f"TigerFlow version check failed: {e}")
 
-    reload = True if config.DEBUG else reload
+    if reload is None:
+        reload = config.DEBUG
 
     if __name__ == "blackfish.cli.__main__":
         uvicorn.run(


### PR DESCRIPTION
## Summary
- `--reload` becomes tri-state (`--reload` / `--no-reload` / unset). Unset defers to `BLACKFISH_DEBUG`, so the dev-loop default is unchanged.
- `--no-reload` lets HPC users disable the StatReload watcher, whose ~250ms `lstat` polling over GPFS/Lustre can starve the event loop and cause intermittent request hangs.

## Test plan
- [x] `uv run just lint` — passes
- [x] `uv run just test` — 892 passed, 8 skipped
- [x] Confirm `blackfish start --no-reload` on Della no longer exhibits the hang

Closes #369