### PR TITLE
feat(lib): CLI bearer-token auth + centralized API wrappers

### DIFF
--- a/lib/docs/contrib/developer_guide.md
+++ b/lib/docs/contrib/developer_guide.md
@@ -71,7 +71,7 @@ The application and CLI pull settings from environment variables:
 | `BLACKFISH_HOME_DIR` | `~/.blackfish` | Application data directory |
 | `BLACKFISH_DEBUG` | `true` | Run in debug mode (no auth) |
 | `BLACKFISH_CONTAINER_PROVIDER` | `docker` | Container runtime (`docker` or `apptainer`) |
-| `BLACKFISH_AUTH_TOKEN` | — | Authentication token (ignored in debug mode) |
+| `BLACKFISH_AUTH_TOKEN` | — | Authentication token. In non-debug mode, the CLI sends it as `Authorization: Bearer <token>`; the dashboard exchanges it for a session cookie via `/api/login`. Ignored in debug mode. |
 
 ### Database Migrations
 

--- a/lib/docs/usage/cli.md
+++ b/lib/docs/usage/cli.md
@@ -15,6 +15,11 @@ The Blackfish application (i.e., REST API) and command-line interface (CLI) pull
 Running the application in debug mode is recommended for *development only* on shared systems
 as it does not use authentication. In "production mode", Blackfish randomly generates an authentication token.
 
+When the API is running with authentication enabled (i.e., `BLACKFISH_DEBUG=0`), the CLI authenticates
+by sending `BLACKFISH_AUTH_TOKEN` as a Bearer token on each request. Set the same
+`BLACKFISH_AUTH_TOKEN` in the shell where you run CLI commands as the one the server was started
+with — for example, by exporting it in your shell profile or sourcing a shared `.env` file.
+
 !!! note
 
     The settings for the REST API are determined when the Blackfish application is started via `blackfish start`. Subsequent interactions with the API via the command line assume that the CLI is using the same configuration and will fail if this is not the case. For example, if you start Blackfish with `BLACKFISH_PORT=8081` and then try to run commands in a new terminal where `BLACKFISH_PORT` isn't set, the CLI will not be able to communicate with the API.

--- a/lib/docs/usage/cli.md
+++ b/lib/docs/usage/cli.md
@@ -22,6 +22,11 @@ with — for example, by exporting it in your shell profile or sourcing a shared
 
 !!! note
 
+    The CLI communicates with the API over plain HTTP and is only intended
+    to be used with an API running on the same system.
+
+!!! note
+
     The settings for the REST API are determined when the Blackfish application is started via `blackfish start`. Subsequent interactions with the API via the command line assume that the CLI is using the same configuration and will fail if this is not the case. For example, if you start Blackfish with `BLACKFISH_PORT=8081` and then try to run commands in a new terminal where `BLACKFISH_PORT` isn't set, the CLI will not be able to communicate with the API.
 
 ## Profiles

--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -11,6 +11,7 @@ from log_symbols.symbols import LogSymbols
 from typing import Optional, cast
 from dataclasses import asdict
 
+from blackfish.cli import api
 from blackfish.cli.services.text_generation import run_text_generation
 from blackfish.cli.services.speech_recognition import run_speech_recognition
 from blackfish.cli.batch import (
@@ -463,7 +464,7 @@ def stop(service_id: str) -> None:  # pragma: no cover
         # If it's not a valid UUID, try to find a matching service by abbreviated ID
         with yaspin(text="Looking up service...") as spinner:
             try:
-                res = requests.get(f"http://{config.HOST}:{config.PORT}/api/services")
+                res = api.get("/api/services")
             except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
                 spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
                 spinner.fail(f"{LogSymbols.ERROR.value}")
@@ -491,10 +492,7 @@ def stop(service_id: str) -> None:  # pragma: no cover
 
     with yaspin(text="Stopping service...") as spinner:
         try:
-            res = requests.put(
-                f"http://{config.HOST}:{config.PORT}/api/services/{full_service_id}/stop",
-                json={},
-            )
+            res = api.put(f"/api/services/{full_service_id}/stop", json={})
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
             spinner.fail(f"{LogSymbols.ERROR.value}")
@@ -532,10 +530,7 @@ def rm(filters: Optional[str] = None) -> None:  # pragma: no cover
 
     with yaspin(text="Deleting service...") as spinner:
         try:
-            res = requests.delete(
-                f"http://{config.HOST}:{config.PORT}/api/services",
-                params=params,
-            )
+            res = api.delete("/api/services", params=params)
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
             spinner.fail(f"{LogSymbols.ERROR.value}")
@@ -575,9 +570,7 @@ def prune() -> None:  # pragma: no cover
 
     with yaspin(text="Deleting service...") as spinner:
         try:
-            res = requests.delete(
-                f"http://{config.HOST}:{config.PORT}/api/services/prune"
-            )
+            res = api.delete("/api/services/prune")
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
             spinner.fail(f"{LogSymbols.ERROR.value}")
@@ -606,8 +599,8 @@ def details(service_id: str) -> None:  # pragma: no cover
 
     with yaspin(text="Fetching service...") as spinner:
         try:
-            res = requests.get(
-                f"http://{config.HOST}:{config.PORT}/api/services/{service_id}",
+            res = api.get(
+                f"/api/services/{service_id}",
                 params={"refresh": "true"},
             )  # fresh data 🥬
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
@@ -735,9 +728,7 @@ def ls(filters: Optional[str], all: bool = False) -> None:  # pragma: no cover
     with yaspin(text="Fetching services...") as spinner:
         params["refresh"] = "true"
         try:
-            res = requests.get(
-                f"http://{config.HOST}:{config.PORT}/api/services", params=params
-            )  # fresh data 🥬
+            res = api.get("/api/services", params=params)  # fresh data 🥬
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
             spinner.fail(f"{LogSymbols.ERROR.value}")
@@ -834,17 +825,15 @@ def models_ls(
 
     from prettytable import PrettyTable, TableStyle
 
-    params = f"refresh={refresh}"
+    params: dict[str, str] = {"refresh": str(refresh)}
     if profile is not None:
-        params += f"&profile={profile}"
+        params["profile"] = profile
     if image is not None:
-        params += f"&image={image}"
+        params["image"] = image
 
     with yaspin(text="Fetching models") as spinner:
         try:
-            res = requests.get(
-                f"http://{config.HOST}:{config.PORT}/api/models?{params}"
-            )
+            res = api.get("/api/models", params=params)
             if not res.ok:
                 spinner.text = f"Blackfish API encountered an error: {res.status_code}"
                 spinner.fail(f"{LogSymbols.ERROR.value}")
@@ -956,8 +945,8 @@ def models_add(
 
     with yaspin(text="Inserting model to database...") as spinner:
         try:
-            res = requests.post(
-                f"http://{config.HOST}:{config.PORT}/api/models",
+            res = api.post(
+                "/api/models",
                 json={
                     "repo": model.repo,
                     "profile": model.profile,
@@ -1050,8 +1039,8 @@ def models_remove(
     if success:
         with yaspin(text="Updating database...") as spinner:
             try:
-                res = requests.delete(
-                    f"http://{config.HOST}:{config.PORT}/api/models",
+                res = api.delete(
+                    "/api/models",
                     params={
                         "repo_id": repo_id,
                         "profile": profile,

--- a/lib/src/blackfish/cli/api.py
+++ b/lib/src/blackfish/cli/api.py
@@ -1,0 +1,67 @@
+"""HTTP wrappers for CLI → backend calls.
+
+Centralizes the two things every CLI request needs: the base URL
+(`http://{HOST}:{PORT}`) and the bearer token from
+``BLACKFISH_AUTH_TOKEN``. The token is read fresh from the environment
+on each call rather than from the config singleton — the singleton nulls
+``AUTH_TOKEN`` when ``BLACKFISH_DEBUG=1``, but the CLI's local debug flag
+shouldn't gate whether it presents credentials to a remote server.
+
+Only ``get``/``post``/``put``/``delete`` are wrapped, with the kwargs
+the CLI actually uses (``params``, ``json``). Add more as needed —
+don't reach for generic ``**kwargs``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+
+from blackfish.server.config import config
+
+
+def _url(path: str) -> str:
+    return f"http://{config.HOST}:{config.PORT}{path}"
+
+
+def _headers() -> dict[str, str]:
+    token = os.getenv("BLACKFISH_AUTH_TOKEN")
+    if token:
+        return {"Authorization": f"Bearer {token}"}
+    return {}
+
+
+def get(
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+) -> requests.Response:
+    return requests.get(_url(path), headers=_headers(), params=params)
+
+
+def post(
+    path: str,
+    *,
+    json: Any = None,
+    params: dict[str, Any] | None = None,
+) -> requests.Response:
+    return requests.post(_url(path), headers=_headers(), json=json, params=params)
+
+
+def put(
+    path: str,
+    *,
+    json: Any = None,
+    params: dict[str, Any] | None = None,
+) -> requests.Response:
+    return requests.put(_url(path), headers=_headers(), json=json, params=params)
+
+
+def delete(
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+) -> requests.Response:
+    return requests.delete(_url(path), headers=_headers(), params=params)

--- a/lib/src/blackfish/cli/batch.py
+++ b/lib/src/blackfish/cli/batch.py
@@ -11,6 +11,8 @@ from typing import Any, Optional
 
 import requests
 import rich_click as click
+
+from blackfish.cli import api
 from log_symbols.symbols import LogSymbols
 from prettytable import PrettyTable, TableStyle
 from yaspin import yaspin
@@ -61,7 +63,7 @@ def _resolve_job_id(partial_id: str) -> str | None:
     # Query API to find matching jobs
     with yaspin(text="Looking up job...") as spinner:
         try:
-            res = requests.get(f"http://{config.HOST}:{config.PORT}/api/jobs")
+            res = api.get("/api/jobs")
         except requests.exceptions.ConnectionError:
             spinner.text = f"Failed to connect to Blackfish API on port {config.PORT}."
             spinner.fail(f"{LogSymbols.ERROR.value}")
@@ -160,10 +162,7 @@ def list_batch_jobs(
 
     with yaspin(text="Fetching batch jobs...") as spinner:
         try:
-            res = requests.get(
-                f"http://{config.HOST}:{config.PORT}/api/jobs",
-                params=params if params else None,
-            )
+            res = api.get("/api/jobs", params=params if params else None)
         except requests.exceptions.ConnectionError:
             spinner.text = (
                 f"Failed to connect to Blackfish API on port {config.PORT}. "
@@ -237,10 +236,7 @@ def stop_batch_job(job_id: str) -> None:  # pragma: no cover
 
     with yaspin(text="Stopping batch job...") as spinner:
         try:
-            res = requests.put(
-                f"http://{config.HOST}:{config.PORT}/api/jobs/{full_job_id}/stop",
-                json={},
-            )
+            res = api.put(f"/api/jobs/{full_job_id}/stop", json={})
         except requests.exceptions.ConnectionError:
             spinner.text = (
                 f"Failed to connect to Blackfish API on port {config.PORT}. "
@@ -334,10 +330,7 @@ def remove_batch_job(
 
     with yaspin(text="Deleting batch jobs...") as spinner:
         try:
-            res = requests.delete(
-                f"http://{config.HOST}:{config.PORT}/api/jobs",
-                params=params,
-            )
+            res = api.delete("/api/jobs", params=params)
         except requests.exceptions.ConnectionError:
             spinner.text = (
                 f"Failed to connect to Blackfish API on port {config.PORT}. "
@@ -583,8 +576,8 @@ def run_batch_job(
     # Build and submit the job
     with yaspin(text="Starting batch job...") as spinner:
         try:
-            res = requests.post(
-                f"http://{config.HOST}:{config.PORT}/api/jobs",
+            res = api.post(
+                "/api/jobs",
                 json={
                     "name": name,
                     "task": task,

--- a/lib/src/blackfish/cli/profile.py
+++ b/lib/src/blackfish/cli/profile.py
@@ -10,6 +10,7 @@ from log_symbols.symbols import LogSymbols
 from yaspin import yaspin
 import requests
 
+from blackfish.cli import api
 from blackfish.server.config import config
 from blackfish.server.setup import ProfileManager, ProfileSetupError
 from blackfish.server.models.profile import (
@@ -761,8 +762,8 @@ def rename_profile(old_name: str, new_name: str) -> None:  # pragma: no cover
     """
 
     try:
-        res = requests.put(
-            f"http://{config.HOST}:{config.PORT}/api/profiles/{old_name}/rename",
+        res = api.put(
+            f"/api/profiles/{old_name}/rename",
             json={"new_name": new_name},
         )
     except requests.exceptions.ConnectionError:

--- a/lib/src/blackfish/cli/services/speech_recognition.py
+++ b/lib/src/blackfish/cli/services/speech_recognition.py
@@ -6,6 +6,8 @@ import rich_click as click
 from rich_click import Context
 import requests
 from random import randint
+
+from blackfish.cli import api
 from yaspin import yaspin
 from log_symbols.symbols import LogSymbols
 from dataclasses import asdict
@@ -162,8 +164,8 @@ def run_speech_recognition(
         else:
             with yaspin(text="Starting service...") as spinner:
                 try:
-                    res = requests.post(
-                        f"http://{config.HOST}:{config.PORT}/api/services",
+                    res = api.post(
+                        "/api/services",
                         json={
                             "name": name,
                             "image": "speech_recognition",
@@ -222,8 +224,8 @@ def run_speech_recognition(
         else:
             with yaspin(text="Starting service...") as spinner:
                 try:
-                    res = requests.post(
-                        f"http://{config.HOST}:{config.PORT}/api/services",
+                    res = api.post(
+                        "/api/services",
                         json={
                             "name": name,
                             "image": "speech_recognition",

--- a/lib/src/blackfish/cli/services/text_generation.py
+++ b/lib/src/blackfish/cli/services/text_generation.py
@@ -6,6 +6,8 @@ import rich_click as click
 from rich_click import Context
 import requests
 from random import randint
+
+from blackfish.cli import api
 from yaspin import yaspin
 from log_symbols.symbols import LogSymbols
 from dataclasses import asdict
@@ -192,8 +194,8 @@ def run_text_generation(
         else:
             with yaspin(text="Starting service...") as spinner:
                 try:
-                    res = requests.post(
-                        f"http://{config.HOST}:{config.PORT}/api/services",
+                    res = api.post(
+                        "/api/services",
                         json={
                             "name": name,
                             "image": "text_generation",
@@ -252,8 +254,8 @@ def run_text_generation(
         else:
             with yaspin(text="Starting service...") as spinner:
                 try:
-                    res = requests.post(
-                        f"http://{config.HOST}:{config.PORT}/api/services",
+                    res = api.post(
+                        "/api/services",
                         json={
                             "name": name,
                             "image": "text_generation",

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -203,6 +203,16 @@ def auth_guard(connection: ASGIConnection, _: BaseRouteHandler) -> None:  # type
     if AUTH_TOKEN is None:
         logger.error("AUTH_TOKEN is not set. Cannot authenticate user.")
         raise InternalServerException(detail="Authentication token is not set.")
+    # Bearer header takes precedence — used by the CLI and other scripted
+    # clients. Falls back to the session cookie, which is what the dashboard
+    # sets via /api/login.
+    auth_header = connection.headers.get("authorization")
+    if auth_header and auth_header.lower().startswith("bearer "):
+        bearer = auth_header.split(" ", 1)[1].strip()
+        if bcrypt.checkpw(bearer.encode(), AUTH_TOKEN):
+            return
+        logger.debug("Invalid bearer token. Raising NotAuthorizedException.")
+        raise NotAuthorizedException
     token = connection.session.get("token")
     if token is None:
         logger.debug("Session token is None. Raising NotAuthorizedException.")

--- a/lib/tests/api/test_auth.py
+++ b/lib/tests/api/test_auth.py
@@ -104,3 +104,32 @@ class TestAuthenticationAPI:
 
         # Should require authentication (401)
         assert response.status_code == 401
+
+    async def test_bearer_token_authorizes_guarded_endpoint(
+        self, no_auth_client: AsyncTestClient
+    ):
+        """A valid Bearer token should authorize a guarded endpoint without a cookie."""
+        response = await no_auth_client.get(
+            "/api/services",
+            headers={"Authorization": "Bearer sealsaretasty"},
+        )
+        assert response.status_code == 200
+
+    async def test_bearer_token_invalid_is_rejected(
+        self, no_auth_client: AsyncTestClient
+    ):
+        """An invalid Bearer token should be rejected, not fall through to cookie auth."""
+        response = await no_auth_client.get(
+            "/api/services",
+            headers={"Authorization": "Bearer wrong_token"},
+        )
+        assert response.status_code == 401
+
+    async def test_bearer_takes_precedence_over_cookie(self, client: AsyncTestClient):
+        """A bad Bearer header should reject even if a valid session cookie is set."""
+        # `client` is already cookie-authenticated; a bad bearer must still 401.
+        response = await client.get(
+            "/api/services",
+            headers={"Authorization": "Bearer wrong_token"},
+        )
+        assert response.status_code == 401

--- a/lib/tests/cli/test_api.py
+++ b/lib/tests/cli/test_api.py
@@ -1,0 +1,36 @@
+"""Unit tests for the cli.api HTTP wrappers."""
+
+from unittest.mock import patch
+
+import pytest
+
+from blackfish.cli import api
+
+
+def test_headers_with_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BLACKFISH_AUTH_TOKEN", "abc123")
+    assert api._headers() == {"Authorization": "Bearer abc123"}
+
+
+def test_headers_without_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BLACKFISH_AUTH_TOKEN", raising=False)
+    assert api._headers() == {}
+
+
+def test_headers_empty_token_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty BLACKFISH_AUTH_TOKEN should not produce an `Authorization` header.
+
+    `requests` would happily send `Bearer ` (with no token), which the server
+    would reject — but it's cleaner to omit the header entirely.
+    """
+    monkeypatch.setenv("BLACKFISH_AUTH_TOKEN", "")
+    assert api._headers() == {}
+
+
+def test_url_uses_config_host_and_port() -> None:
+    """`_url` should prefix paths with the active config's host/port."""
+    with (
+        patch.object(api.config, "HOST", "example.test"),
+        patch.object(api.config, "PORT", 9999),
+    ):
+        assert api._url("/api/services") == "http://example.test:9999/api/services"

--- a/lib/tests/cli/test_cli_connection_errors.py
+++ b/lib/tests/cli/test_cli_connection_errors.py
@@ -23,7 +23,7 @@ TRANSPORT_ERRORS = [
 def test_ls_connection_error(exc):
     """`ls` reports a friendly error when the API is unreachable."""
     runner = CliRunner()
-    with patch("blackfish.cli.__main__.requests.get", side_effect=exc("boom")):
+    with patch("blackfish.cli.__main__.api.get", side_effect=exc("boom")):
         result = runner.invoke(ls, [])
 
     assert result.exit_code == 0
@@ -34,7 +34,7 @@ def test_ls_connection_error(exc):
 def test_rm_connection_error(exc):
     """`rm` reports a friendly error when the API is unreachable."""
     runner = CliRunner()
-    with patch("blackfish.cli.__main__.requests.delete", side_effect=exc("boom")):
+    with patch("blackfish.cli.__main__.api.delete", side_effect=exc("boom")):
         result = runner.invoke(rm, [])
 
     assert result.exit_code == 0
@@ -45,7 +45,7 @@ def test_rm_connection_error(exc):
 def test_prune_connection_error(exc):
     """`prune` reports a friendly error when the API is unreachable."""
     runner = CliRunner()
-    with patch("blackfish.cli.__main__.requests.delete", side_effect=exc("boom")):
+    with patch("blackfish.cli.__main__.api.delete", side_effect=exc("boom")):
         result = runner.invoke(prune, input="y\n")
 
     assert result.exit_code == 0
@@ -56,7 +56,7 @@ def test_prune_connection_error(exc):
 def test_details_connection_error(exc):
     """`details` reports a friendly error when the API is unreachable."""
     runner = CliRunner()
-    with patch("blackfish.cli.__main__.requests.get", side_effect=exc("boom")):
+    with patch("blackfish.cli.__main__.api.get", side_effect=exc("boom")):
         result = runner.invoke(details, ["abc123"])
 
     assert result.exit_code == 0

--- a/lib/tests/cli/test_cli_models.py
+++ b/lib/tests/cli/test_cli_models.py
@@ -120,7 +120,7 @@ def test_list_models(
     if refresh:
         cmd.append("-r")
 
-    with patch("blackfish.cli.__main__.requests.get") as mock_get:
+    with patch("blackfish.cli.__main__.api.get") as mock_get:
         mock_response_obj = Mock()
         mock_response_obj.ok = mock_response["status_code"] == 200
         mock_response_obj.status_code = mock_response["status_code"]
@@ -129,15 +129,16 @@ def test_list_models(
 
         result = cli_runner.invoke(main, cmd)
 
-    # Verify request was made with correct parameters
+    # Verify request was made with correct path and params
     mock_get.assert_called_once()
-    call_url = mock_get.call_args[0][0]
-    assert f"http://{mock_config.HOST}:{mock_config.PORT}/api/models" in call_url
-    assert f"refresh={refresh}" in call_url
+    call_path = mock_get.call_args[0][0]
+    call_params = mock_get.call_args.kwargs.get("params", {})
+    assert call_path == "/api/models"
+    assert call_params.get("refresh") == str(refresh)
     if profile:
-        assert f"profile={profile}" in call_url
+        assert call_params.get("profile") == profile
     if image:
-        assert f"image={image}" in call_url
+        assert call_params.get("image") == image
 
     assert result.exit_code == expected_exit_code
     assert expected_in_output in result.output
@@ -261,7 +262,7 @@ def test_add_model(
             side_effect=lambda _home, name: name if name is not None else "default",
         ),
         patch("blackfish.server.models.model.add_model") as mock_add_model,
-        patch("blackfish.cli.__main__.requests.post") as mock_post,
+        patch("blackfish.cli.__main__.api.post") as mock_post,
     ):
         # Mock profile deserialization
         if not profile_exists:
@@ -452,7 +453,7 @@ def test_remove_model(
             side_effect=lambda _home, name: name if name is not None else "default",
         ),
         patch("blackfish.server.models.model.remove_model") as mock_remove_model,
-        patch("blackfish.cli.__main__.requests.delete") as mock_delete,
+        patch("blackfish.cli.__main__.api.delete") as mock_delete,
     ):
         # Mock profile deserialization
         if not profile_exists:
@@ -499,10 +500,7 @@ def test_remove_model(
                 # Verify database deletion was attempted
                 mock_delete.assert_called_once()
                 call_args = mock_delete.call_args
-                assert (
-                    f"http://{mock_config.HOST}:{mock_config.PORT}/api/models"
-                    in call_args[0][0]
-                )
+                assert call_args[0][0] == "/api/models"
                 assert call_args[1]["params"]["repo_id"] == repo_id
                 assert call_args[1]["params"]["profile"] == profile
                 assert call_args[1]["params"]["revision"] == revision
@@ -540,7 +538,7 @@ def test_list_models_connection_error(cli_runner):
 
     with (
         patch("blackfish.server.config.config") as mock_config,
-        patch("blackfish.cli.__main__.requests.get") as mock_get,
+        patch("blackfish.cli.__main__.api.get") as mock_get,
     ):
         # Mock config
         mock_config.HOST = "localhost"
@@ -565,7 +563,7 @@ def test_add_model_connection_error(cli_runner):
             side_effect=lambda _home, name: name if name is not None else "default",
         ),
         patch("blackfish.server.models.model.add_model") as mock_add_model,
-        patch("blackfish.cli.__main__.requests.post") as mock_post,
+        patch("blackfish.cli.__main__.api.post") as mock_post,
         patch("blackfish.server.config.config") as mock_config,
     ):
         # Mock config
@@ -606,7 +604,7 @@ def test_remove_model_connection_error(cli_runner):
             side_effect=lambda _home, name: name if name is not None else "default",
         ),
         patch("blackfish.server.models.model.remove_model") as mock_remove_model,
-        patch("blackfish.cli.__main__.requests.delete") as mock_delete,
+        patch("blackfish.cli.__main__.api.delete") as mock_delete,
         patch("blackfish.server.config.config") as mock_config,
     ):
         # Mock config

--- a/lib/tests/cli/test_cli_profiles.py
+++ b/lib/tests/cli/test_cli_profiles.py
@@ -674,7 +674,7 @@ class TestProfileRename:
         mock_response.ok = True
 
         with patch(
-            "blackfish.cli.profile.requests.put", return_value=mock_response
+            "blackfish.cli.profile.api.put", return_value=mock_response
         ) as mock_put:
             result = cli_runner.invoke(main, ["profile", "rename", "old", "new"])
 
@@ -691,7 +691,7 @@ class TestProfileRename:
         mock_response.status_code = 409
         mock_response.json.return_value = {"detail": "Profile 'new' already exists."}
 
-        with patch("blackfish.cli.profile.requests.put", return_value=mock_response):
+        with patch("blackfish.cli.profile.api.put", return_value=mock_response):
             result = cli_runner.invoke(main, ["profile", "rename", "old", "new"])
 
         assert result.exit_code == 1
@@ -699,7 +699,7 @@ class TestProfileRename:
 
     def test_rename_connection_error(self, cli_runner):
         with patch(
-            "blackfish.cli.profile.requests.put",
+            "blackfish.cli.profile.api.put",
             side_effect=requests.exceptions.ConnectionError("refused"),
         ):
             result = cli_runner.invoke(main, ["profile", "rename", "old", "new"])

--- a/lib/tests/cli/test_cli_run.py
+++ b/lib/tests/cli/test_cli_run.py
@@ -189,7 +189,7 @@ class TestRunTextGeneration:
             patch(
                 "blackfish.cli.services.text_generation.get_model_dir"
             ) as mock_get_model_dir,
-            patch("blackfish.cli.services.text_generation.requests.post") as mock_post,
+            patch("blackfish.cli.services.text_generation.api.post") as mock_post,
         ):
             mock_deserialize.return_value = local_profile
             mock_get_models.return_value = ["openai/gpt-2"]
@@ -227,7 +227,7 @@ class TestRunTextGeneration:
             patch(
                 "blackfish.cli.services.text_generation.get_model_dir"
             ) as mock_get_model_dir,
-            patch("blackfish.cli.services.text_generation.requests.post") as mock_post,
+            patch("blackfish.cli.services.text_generation.api.post") as mock_post,
         ):
             mock_deserialize.return_value = slurm_profile
             mock_get_models.return_value = ["openai/gpt-2"]
@@ -265,7 +265,7 @@ class TestRunTextGeneration:
             patch(
                 "blackfish.cli.services.text_generation.get_model_dir"
             ) as mock_get_model_dir,
-            patch("blackfish.cli.services.text_generation.requests.post") as mock_post,
+            patch("blackfish.cli.services.text_generation.api.post") as mock_post,
         ):
             mock_deserialize.return_value = local_profile
             mock_get_models.return_value = ["openai/gpt-2"]
@@ -305,7 +305,7 @@ class TestRunTextGeneration:
                 "blackfish.cli.services.text_generation.get_model_dir"
             ) as mock_get_model_dir,
             patch(
-                "blackfish.cli.services.text_generation.requests.post",
+                "blackfish.cli.services.text_generation.api.post",
                 side_effect=requests.exceptions.ConnectionError("refused"),
             ),
         ):
@@ -360,7 +360,7 @@ class TestRunTextGeneration:
             patch(
                 "blackfish.cli.services.text_generation.get_model_dir"
             ) as mock_get_model_dir,
-            patch("blackfish.cli.services.text_generation.requests.post") as mock_post,
+            patch("blackfish.cli.services.text_generation.api.post") as mock_post,
         ):
             mock_deserialize.return_value = local_profile
             mock_get_models.return_value = ["openai/gpt-2"]
@@ -411,7 +411,7 @@ class TestRunTextGeneration:
             patch(
                 "blackfish.cli.services.text_generation.get_model_dir"
             ) as mock_get_model_dir,
-            patch("blackfish.cli.services.text_generation.requests.post") as mock_post,
+            patch("blackfish.cli.services.text_generation.api.post") as mock_post,
         ):
             mock_deserialize.return_value = local_profile
             mock_get_models.return_value = ["openai/gpt-2"]
@@ -467,7 +467,7 @@ class TestRunTextGeneration:
             patch(
                 "blackfish.cli.services.text_generation.get_model_dir"
             ) as mock_get_model_dir,
-            patch("blackfish.cli.services.text_generation.requests.post") as mock_post,
+            patch("blackfish.cli.services.text_generation.api.post") as mock_post,
         ):
             mock_deserialize.return_value = local_profile
             mock_get_models.return_value = ["openai/gpt-2"]
@@ -511,7 +511,7 @@ class TestRunTextGeneration:
             patch(
                 "blackfish.cli.services.text_generation.get_model_dir"
             ) as mock_get_model_dir,
-            patch("blackfish.cli.services.text_generation.requests.post") as mock_post,
+            patch("blackfish.cli.services.text_generation.api.post") as mock_post,
         ):
             mock_deserialize.return_value = local_profile
             mock_get_models.return_value = ["openai/gpt-2"]
@@ -717,9 +717,7 @@ class TestRunSpeechRecognition:
             patch(
                 "blackfish.cli.services.speech_recognition.get_model_dir"
             ) as mock_get_model_dir,
-            patch(
-                "blackfish.cli.services.speech_recognition.requests.post"
-            ) as mock_post,
+            patch("blackfish.cli.services.speech_recognition.api.post") as mock_post,
         ):
             mock_deserialize.return_value = local_profile
             mock_get_models.return_value = ["openai/whisper-tiny"]
@@ -757,9 +755,7 @@ class TestRunSpeechRecognition:
             patch(
                 "blackfish.cli.services.speech_recognition.get_model_dir"
             ) as mock_get_model_dir,
-            patch(
-                "blackfish.cli.services.speech_recognition.requests.post"
-            ) as mock_post,
+            patch("blackfish.cli.services.speech_recognition.api.post") as mock_post,
         ):
             mock_deserialize.return_value = slurm_profile
             mock_get_models.return_value = ["openai/whisper-tiny"]
@@ -797,9 +793,7 @@ class TestRunSpeechRecognition:
             patch(
                 "blackfish.cli.services.speech_recognition.get_model_dir"
             ) as mock_get_model_dir,
-            patch(
-                "blackfish.cli.services.speech_recognition.requests.post"
-            ) as mock_post,
+            patch("blackfish.cli.services.speech_recognition.api.post") as mock_post,
         ):
             mock_deserialize.return_value = local_profile
             mock_get_models.return_value = ["openai/whisper-tiny"]
@@ -839,7 +833,7 @@ class TestRunSpeechRecognition:
                 "blackfish.cli.services.speech_recognition.get_model_dir"
             ) as mock_get_model_dir,
             patch(
-                "blackfish.cli.services.speech_recognition.requests.post",
+                "blackfish.cli.services.speech_recognition.api.post",
                 side_effect=requests.exceptions.ConnectionError("refused"),
             ),
         ):
@@ -894,9 +888,7 @@ class TestRunSpeechRecognition:
             patch(
                 "blackfish.cli.services.speech_recognition.get_model_dir"
             ) as mock_get_model_dir,
-            patch(
-                "blackfish.cli.services.speech_recognition.requests.post"
-            ) as mock_post,
+            patch("blackfish.cli.services.speech_recognition.api.post") as mock_post,
         ):
             mock_deserialize.return_value = local_profile
             mock_get_models.return_value = ["openai/whisper-tiny"]
@@ -936,9 +928,7 @@ class TestRunSpeechRecognition:
             patch(
                 "blackfish.cli.services.speech_recognition.get_model_dir"
             ) as mock_get_model_dir,
-            patch(
-                "blackfish.cli.services.speech_recognition.requests.post"
-            ) as mock_post,
+            patch("blackfish.cli.services.speech_recognition.api.post") as mock_post,
         ):
             mock_deserialize.return_value = local_profile
             mock_get_models.return_value = ["openai/whisper-tiny"]
@@ -1009,9 +999,7 @@ class TestRunSpeechRecognition:
             patch(
                 "blackfish.cli.services.speech_recognition.get_model_dir"
             ) as mock_get_model_dir,
-            patch(
-                "blackfish.cli.services.speech_recognition.requests.post"
-            ) as mock_post,
+            patch("blackfish.cli.services.speech_recognition.api.post") as mock_post,
         ):
             mock_deserialize.return_value = local_profile
             mock_get_models.return_value = ["openai/whisper-tiny"]
@@ -1077,7 +1065,7 @@ class TestRunGroupOptions:
             patch(
                 "blackfish.cli.services.text_generation.get_model_dir"
             ) as mock_get_model_dir,
-            patch("blackfish.cli.services.text_generation.requests.post") as mock_post,
+            patch("blackfish.cli.services.text_generation.api.post") as mock_post,
         ):
             mock_deserialize.return_value = slurm_profile
             mock_get_models.return_value = ["openai/gpt-2"]
@@ -1132,7 +1120,7 @@ class TestRunGroupOptions:
             patch(
                 "blackfish.cli.services.text_generation.get_model_dir"
             ) as mock_get_model_dir,
-            patch("blackfish.cli.services.text_generation.requests.post") as mock_post,
+            patch("blackfish.cli.services.text_generation.api.post") as mock_post,
         ):
             mock_deserialize.return_value = local_profile
             mock_get_models.return_value = ["openai/gpt-2"]
@@ -1179,7 +1167,7 @@ class TestRunGroupOptions:
             patch(
                 "blackfish.cli.services.text_generation.get_model_dir"
             ) as mock_get_model_dir,
-            patch("blackfish.cli.services.text_generation.requests.post") as mock_post,
+            patch("blackfish.cli.services.text_generation.api.post") as mock_post,
         ):
             mock_deserialize.return_value = local_profile
             mock_get_models.return_value = ["openai/gpt-2"]

--- a/lib/tests/cli/test_cli_stop.py
+++ b/lib/tests/cli/test_cli_stop.py
@@ -15,16 +15,14 @@ class TestStopCLI:
         full_uuid = "4c2216ea-df22-4bf6-bcea-56964df12af5"
 
         # Mock the PUT request to the stop endpoint
-        with patch("blackfish.cli.__main__.requests.put") as mock_put:
+        with patch("blackfish.cli.__main__.api.put") as mock_put:
             mock_put.return_value.ok = True
             mock_put.return_value.status_code = 200
 
             result = runner.invoke(stop, [full_uuid])
 
             assert result.exit_code == 0
-            mock_put.assert_called_once_with(
-                f"http://localhost:8000/api/services/{full_uuid}/stop", json={}
-            )
+            mock_put.assert_called_once_with(f"/api/services/{full_uuid}/stop", json={})
 
     def test_stop_with_abbreviated_id_single_match(self):
         """Test stopping a service with an abbreviated ID that matches exactly one service."""
@@ -46,19 +44,17 @@ class TestStopCLI:
 
         with (
             patch(
-                "blackfish.cli.__main__.requests.get", return_value=mock_get_response
+                "blackfish.cli.__main__.api.get", return_value=mock_get_response
             ) as mock_get,
             patch(
-                "blackfish.cli.__main__.requests.put", return_value=mock_put_response
+                "blackfish.cli.__main__.api.put", return_value=mock_put_response
             ) as mock_put,
         ):
             result = runner.invoke(stop, [abbreviated_id])
 
             assert result.exit_code == 0
-            mock_get.assert_called_once_with("http://localhost:8000/api/services")
-            mock_put.assert_called_once_with(
-                f"http://localhost:8000/api/services/{full_uuid}/stop", json={}
-            )
+            mock_get.assert_called_once_with("/api/services")
+            mock_put.assert_called_once_with(f"/api/services/{full_uuid}/stop", json={})
 
     def test_stop_with_abbreviated_id_multiple_matches(self):
         """Test stopping a service with an abbreviated ID that matches multiple services."""
@@ -74,12 +70,12 @@ class TestStopCLI:
         ]
 
         with patch(
-            "blackfish.cli.__main__.requests.get", return_value=mock_get_response
+            "blackfish.cli.__main__.api.get", return_value=mock_get_response
         ) as mock_get:
             result = runner.invoke(stop, [abbreviated_id])
 
             assert result.exit_code == 0
-            mock_get.assert_called_once_with("http://localhost:8000/api/services")
+            mock_get.assert_called_once_with("/api/services")
             # Should show an error message about multiple matches
             assert "Multiple services match" in result.output
 
@@ -94,12 +90,12 @@ class TestStopCLI:
         mock_get_response.json.return_value = []
 
         with patch(
-            "blackfish.cli.__main__.requests.get", return_value=mock_get_response
+            "blackfish.cli.__main__.api.get", return_value=mock_get_response
         ) as mock_get:
             result = runner.invoke(stop, [abbreviated_id])
 
             assert result.exit_code == 0
-            mock_get.assert_called_once_with("http://localhost:8000/api/services")
+            mock_get.assert_called_once_with("/api/services")
             # Should show an error message about no matches
             assert "No service found matching" in result.output
 
@@ -114,12 +110,12 @@ class TestStopCLI:
         mock_get_response.status_code = 500
 
         with patch(
-            "blackfish.cli.__main__.requests.get", return_value=mock_get_response
+            "blackfish.cli.__main__.api.get", return_value=mock_get_response
         ) as mock_get:
             result = runner.invoke(stop, [abbreviated_id])
 
             assert result.exit_code == 0
-            mock_get.assert_called_once_with("http://localhost:8000/api/services")
+            mock_get.assert_called_once_with("/api/services")
             # Should show an error message about fetching services
             assert "Failed to fetch services" in result.output
 
@@ -134,14 +130,12 @@ class TestStopCLI:
         mock_put_response.status_code = 404
 
         with patch(
-            "blackfish.cli.__main__.requests.put", return_value=mock_put_response
+            "blackfish.cli.__main__.api.put", return_value=mock_put_response
         ) as mock_put:
             result = runner.invoke(stop, [full_uuid])
 
             assert result.exit_code == 0
-            mock_put.assert_called_once_with(
-                f"http://localhost:8000/api/services/{full_uuid}/stop", json={}
-            )
+            mock_put.assert_called_once_with(f"/api/services/{full_uuid}/stop", json={})
             # Should show an error message about stopping the service
             assert "Failed to stop service" in result.output
 
@@ -166,26 +160,24 @@ class TestStopCLI:
 
         with (
             patch(
-                "blackfish.cli.__main__.requests.get", return_value=mock_get_response
+                "blackfish.cli.__main__.api.get", return_value=mock_get_response
             ) as mock_get,
             patch(
-                "blackfish.cli.__main__.requests.put", return_value=mock_put_response
+                "blackfish.cli.__main__.api.put", return_value=mock_put_response
             ) as mock_put,
         ):
             result = runner.invoke(stop, [abbreviated_id])
 
             assert result.exit_code == 0
-            mock_get.assert_called_once_with("http://localhost:8000/api/services")
-            mock_put.assert_called_once_with(
-                f"http://localhost:8000/api/services/{full_uuid}/stop", json={}
-            )
+            mock_get.assert_called_once_with("/api/services")
+            mock_put.assert_called_once_with(f"/api/services/{full_uuid}/stop", json={})
 
     def test_stop_lookup_connection_error(self):
         """Connection failures while looking up a service are handled gracefully."""
         runner = CliRunner()
 
         with patch(
-            "blackfish.cli.__main__.requests.get",
+            "blackfish.cli.__main__.api.get",
             side_effect=requests.exceptions.ConnectionError("refused"),
         ):
             result = runner.invoke(stop, ["4c22"])
@@ -199,7 +191,7 @@ class TestStopCLI:
         full_uuid = "4c2216ea-df22-4bf6-bcea-56964df12af5"
 
         with patch(
-            "blackfish.cli.__main__.requests.put",
+            "blackfish.cli.__main__.api.put",
             side_effect=requests.exceptions.ConnectionError("refused"),
         ):
             result = runner.invoke(stop, [full_uuid])

--- a/lib/tests/dev/cli/test_jobs.py
+++ b/lib/tests/dev/cli/test_jobs.py
@@ -160,7 +160,7 @@ def test_cli_batch_stop(
 
     # Mock the requests.put call
     with (
-        patch("blackfish.cli.__main__.requests.put") as mock_put,
+        patch("blackfish.cli.__main__.api.put") as mock_put,
         patch("blackfish.cli.__main__.config") as mock_config,
         patch(
             "blackfish.server.models.profile.deserialize_profile"
@@ -287,7 +287,7 @@ def test_cli_batch_rm(
 
     # Mock the requests.delete call for valid cases
     with (
-        patch("blackfish.cli.__main__.requests.delete") as mock_delete,
+        patch("blackfish.cli.__main__.api.delete") as mock_delete,
         patch("blackfish.cli.__main__.config") as mock_config,
         patch(
             "blackfish.server.models.profile.deserialize_profile"
@@ -345,7 +345,7 @@ def test_cli_batch_rm_with_errors_displayed(cli_runner):
     ]
 
     with (
-        patch("blackfish.cli.__main__.requests.delete") as mock_delete,
+        patch("blackfish.cli.__main__.api.delete") as mock_delete,
         patch("blackfish.cli.__main__.config") as mock_config,
         patch(
             "blackfish.server.models.profile.deserialize_profile"


### PR DESCRIPTION
## Summary
- Server `auth_guard` now accepts `Authorization: Bearer <token>` in addition to the session cookie; bearer takes precedence, and a bad bearer is rejected rather than falling through to cookie auth.
- New `cli/api.py` owns the base URL and injects the bearer header from `BLACKFISH_AUTH_TOKEN`. All ~20 CLI request sites migrated.
- Token is read fresh from the env (not from `config.AUTH_TOKEN`) so the CLI's local DEBUG flag doesn't gate whether credentials get sent to a remote server.

## Test plan
- [x] `uv run just lint` — passes
- [x] `uv run pytest --ignore=tests/dev` — 895 passed, 8 skipped (3 new bearer auth tests)
- [ ] Smoke-test against a non-DEBUG server end-to-end on Della

Closes #370