### PR TITLE
fix(lib): clean error when a profile's model directories are missing

### DIFF
--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -861,7 +861,10 @@ def models_ls(
             ok = True
             for p in deserialize_profiles(config.HOME_DIR):
                 spinner.text = f"Fetching models for profile '{p.name}'"
-                ok = fetch(p.name) and ok
+                if not fetch(p.name):
+                    # Connection failure: every subsequent call will fail too.
+                    ok = False
+                    break
         else:
             spinner.text = "Fetching models"
             ok = fetch()

--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -831,7 +831,7 @@ def models_ls(
         common_params["image"] = image
 
     all_models: list[dict[str, str]] = []
-    profile_errors: list[tuple[str, str]] = []  # (profile_name, message)
+    profile_errors: list[tuple[str | None, str]] = []  # (profile_name, message)
 
     def fetch(name: str | None = None) -> bool:
         """Issue one request and accumulate results. Returns False on connection failure."""
@@ -848,7 +848,7 @@ def models_ls(
                 detail = res.json().get("detail", "")
             except Exception:
                 pass
-            profile_errors.append((name or "(all)", detail or res.reason))
+            profile_errors.append((name, detail or res.reason))
             return True
         all_models.extend(res.json())
         return True
@@ -884,19 +884,24 @@ def models_ls(
             spinner.ok(f"{LogSymbols.SUCCESS.value}")
 
     for name, message in profile_errors:
-        click.echo(f"{LogSymbols.ERROR.value} Profile '{name}': {message}")
+        if name is None:
+            click.echo(f"{LogSymbols.ERROR.value} {message}")
+        else:
+            click.echo(f"{LogSymbols.ERROR.value} Profile '{name}': {message}")
+
+    if not all_models:
+        if not profile_errors:
+            click.echo(
+                f"{LogSymbols.WARNING.value} No models found. You can try using the"
+                " `--refresh` flag to find newly added models."
+            )
+        return
 
     tab = PrettyTable(field_names=["REPO", "REVISION", "PROFILE", "IMAGE"])
     tab.set_style(TableStyle.PLAIN_COLUMNS)
     for field in tab.field_names:
         tab.align[field] = "l"
     tab.right_padding_width = 3
-
-    if not all_models and not profile_errors:
-        click.echo(
-            f"{LogSymbols.WARNING.value} No models found. You can try using the"
-            " `--refresh` flag to find newly added models."
-        )
 
     for model in all_models:
         tab.add_row(

--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -824,51 +824,76 @@ def models_ls(
     """Show available (downloaded) models."""
 
     from prettytable import PrettyTable, TableStyle
+    from blackfish.server.models.profile import deserialize_profiles
 
-    params: dict[str, str] = {"refresh": str(refresh)}
-    if profile is not None:
-        params["profile"] = profile
+    common_params: dict[str, str] = {"refresh": str(refresh)}
     if image is not None:
-        params["image"] = image
+        common_params["image"] = image
 
-    with yaspin(text="Fetching models") as spinner:
+    all_models: list[dict[str, str]] = []
+    profile_errors: list[tuple[str, str]] = []  # (profile_name, message)
+
+    def fetch(name: str | None = None) -> bool:
+        """Issue one request and accumulate results. Returns False on connection failure."""
+        params = {**common_params}
+        if name is not None:
+            params["profile"] = name
         try:
             res = api.get("/api/models", params=params)
-            if not res.ok:
-                spinner.text = f"Blackfish API encountered an error: {res.status_code}"
-                spinner.fail(f"{LogSymbols.ERROR.value}")
-                return
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-            spinner.text = f"Failed to connect to the Blackfish API. Is Blackfish running on port {config.PORT}?"
+            return False
+        if not res.ok:
+            detail = ""
+            try:
+                detail = res.json().get("detail", "")
+            except Exception:
+                pass
+            profile_errors.append((name or "(all)", detail or res.reason))
+            return True
+        all_models.extend(res.json())
+        return True
+
+    with yaspin(text="Fetching models") as spinner:
+        if profile is not None:
+            spinner.text = f"Fetching models for profile '{profile}'"
+            ok = fetch(profile)
+        elif refresh:
+            ok = True
+            for p in deserialize_profiles(config.HOME_DIR):
+                spinner.text = f"Fetching models for profile '{p.name}'"
+                ok = fetch(p.name) and ok
+        else:
+            spinner.text = "Fetching models"
+            ok = fetch()
+
+        if not ok:
+            spinner.text = (
+                f"Failed to connect to the Blackfish API. "
+                f"Is Blackfish running on port {config.PORT}?"
+            )
             spinner.fail(f"{LogSymbols.ERROR.value}")
             return
+        spinner.text = f"Found {len(all_models)} models."
+        spinner.ok(f"{LogSymbols.SUCCESS.value}")
 
-    tab = PrettyTable(
-        field_names=[
-            "REPO",
-            "REVISION",
-            "PROFILE",
-            "IMAGE",
-        ]
-    )
+    for name, message in profile_errors:
+        click.echo(f"{LogSymbols.ERROR.value} Profile '{name}': {message}")
+
+    tab = PrettyTable(field_names=["REPO", "REVISION", "PROFILE", "IMAGE"])
     tab.set_style(TableStyle.PLAIN_COLUMNS)
     for field in tab.field_names:
         tab.align[field] = "l"
     tab.right_padding_width = 3
 
-    if len(res.json()) == 0:
+    if not all_models:
         click.echo(
-            f"{LogSymbols.WARNING.value} No models found. You can try using the `--refresh` flag to find newly added models."
+            f"{LogSymbols.WARNING.value} No models found. You can try using the"
+            " `--refresh` flag to find newly added models."
         )
 
-    for model in res.json():
+    for model in all_models:
         tab.add_row(
-            [
-                model["repo"],
-                model["revision"],
-                model["profile"],
-                model["image"],
-            ]
+            [model["repo"], model["revision"], model["profile"], model["image"]]
         )
     click.echo(tab)
 

--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -873,8 +873,12 @@ def models_ls(
             )
             spinner.fail(f"{LogSymbols.ERROR.value}")
             return
-        spinner.text = f"Found {len(all_models)} models."
-        spinner.ok(f"{LogSymbols.SUCCESS.value}")
+        suffix = f" ({len(profile_errors)} error(s))" if profile_errors else ""
+        spinner.text = f"Found {len(all_models)} models{suffix}."
+        if profile_errors and not all_models:
+            spinner.fail(f"{LogSymbols.ERROR.value}")
+        else:
+            spinner.ok(f"{LogSymbols.SUCCESS.value}")
 
     for name, message in profile_errors:
         click.echo(f"{LogSymbols.ERROR.value} Profile '{name}': {message}")
@@ -885,7 +889,7 @@ def models_ls(
         tab.align[field] = "l"
     tab.right_padding_width = 3
 
-    if not all_models:
+    if not all_models and not profile_errors:
         click.echo(
             f"{LogSymbols.WARNING.value} No models found. You can try using the"
             " `--refresh` flag to find newly added models."

--- a/lib/src/blackfish/cli/batch.py
+++ b/lib/src/blackfish/cli/batch.py
@@ -484,30 +484,36 @@ def run_batch_job(
         )
         return
 
-    # 2. Validate model exists for profile
-    if model not in get_models(matched_profile):
-        click.echo(
-            f"{LogSymbols.ERROR.value} Model '{model}' is unavailable for profile "
-            f"'{profile}'. Use `blackfish model add` to download it first."
-        )
-        return
-
-    # 3. Resolve revision (use latest if not provided)
-    if revision is None:
-        revisions = get_revisions(model, matched_profile)
-        if not revisions:
+    # 2. Validate model exists, resolve revision, and locate the model
+    # directory. Any of these can fail with FileNotFoundError /
+    # PermissionError if the profile's cache_dir or home_dir is gone.
+    try:
+        if model not in get_models(matched_profile):
             click.echo(
-                f"{LogSymbols.ERROR.value} No revisions found for model '{model}'."
+                f"{LogSymbols.ERROR.value} Model '{model}' is unavailable for profile "
+                f"'{profile}'. Use `blackfish model add` to download it first."
             )
             return
-        revision = get_latest_commit(model, revisions)
-        click.echo(
-            f"{LogSymbols.WARNING.value} No revision provided. "
-            f"Using latest available: {revision}"
-        )
 
-    # 4. Get model directory and derive cache_dir
-    model_dir = get_model_dir(model, revision, matched_profile)
+        if revision is None:
+            revisions = get_revisions(model, matched_profile)
+            if not revisions:
+                click.echo(
+                    f"{LogSymbols.ERROR.value} No revisions found for model '{model}'."
+                )
+                return
+            revision = get_latest_commit(model, revisions)
+            click.echo(
+                f"{LogSymbols.WARNING.value} No revision provided. "
+                f"Using latest available: {revision}"
+            )
+
+        model_dir = get_model_dir(model, revision, matched_profile)
+    except (FileNotFoundError, PermissionError, OSError) as e:
+        click.echo(
+            f"{LogSymbols.ERROR.value} Profile '{profile}': model directories not accessible: {e}"
+        )
+        sys.exit(1)
     if model_dir is None:
         click.echo(
             f"{LogSymbols.ERROR.value} Model directory not found. "

--- a/lib/src/blackfish/cli/services/speech_recognition.py
+++ b/lib/src/blackfish/cli/services/speech_recognition.py
@@ -92,25 +92,32 @@ def run_speech_recognition(
         )
         return
 
-    if repo_id in get_models(profile):
-        if revision is None:
-            revision = get_latest_commit(repo_id, get_revisions(repo_id, profile))
-            click.echo(
-                f"{LogSymbols.WARNING.value} No revision provided. Using latest"
-                f" available commit: {revision}."
-            )
-            model_dir = get_model_dir(repo_id, revision, profile)
-        else:
-            model_dir = get_model_dir(repo_id, revision, profile)
-            if model_dir is None:
+    try:
+        if repo_id in get_models(profile):
+            if revision is None:
+                revision = get_latest_commit(repo_id, get_revisions(repo_id, profile))
                 click.echo(
-                    f"{LogSymbols.ERROR.value} Model directory not found 😔. The requested revision ({revision}) is missing."
+                    f"{LogSymbols.WARNING.value} No revision provided. Using latest"
+                    f" available commit: {revision}."
                 )
-                return
-    else:
+                model_dir = get_model_dir(repo_id, revision, profile)
+            else:
+                model_dir = get_model_dir(repo_id, revision, profile)
+                if model_dir is None:
+                    click.echo(
+                        f"{LogSymbols.ERROR.value} Model directory not found 😔. The requested revision ({revision}) is missing."
+                    )
+                    return
+        else:
+            click.echo(
+                f"{LogSymbols.ERROR.value} Unable to find {repo_id} for profile"
+                f" '{profile.name}'."
+            )
+            return
+    except (FileNotFoundError, PermissionError, OSError) as e:
         click.echo(
-            f"{LogSymbols.ERROR.value} Unable to find {repo_id} for profile"
-            f" '{profile.name}'."
+            f"{LogSymbols.ERROR.value} Profile '{profile.name}': model directories"
+            f" not accessible: {e}"
         )
         return
 

--- a/lib/src/blackfish/cli/services/text_generation.py
+++ b/lib/src/blackfish/cli/services/text_generation.py
@@ -31,24 +31,31 @@ from blackfish.cli.classes import ServiceOptions
 def try_get_model_info(
     profile: BlackfishProfile, repo_id: str, revision: Optional[str] = None
 ) -> Optional[Tuple[str, str]]:
-    if repo_id in get_models(profile):
-        if revision is None:
-            revision = get_latest_commit(repo_id, get_revisions(repo_id, profile))
-            click.echo(
-                f"{LogSymbols.WARNING.value} No revision provided. Using latest"
-                f" available commit: {revision}."
-            )
+    try:
+        if repo_id in get_models(profile):
+            if revision is None:
+                revision = get_latest_commit(repo_id, get_revisions(repo_id, profile))
+                click.echo(
+                    f"{LogSymbols.WARNING.value} No revision provided. Using latest"
+                    f" available commit: {revision}."
+                )
 
-        model_dir = get_model_dir(repo_id, revision, profile)
-        if model_dir is None:
+            model_dir = get_model_dir(repo_id, revision, profile)
+            if model_dir is None:
+                click.echo(
+                    f"{LogSymbols.ERROR.value} Model directory not found 😔. The requested revision ({revision}) is missing."
+                )
+                return None
+        else:
             click.echo(
-                f"{LogSymbols.ERROR.value} Model directory not found 😔. The requested revision ({revision}) is missing."
+                f"{LogSymbols.ERROR.value} Model {repo_id} is unavailable for profile"
+                f" '{profile.name}'. You can try adding it using `blackfish model add`."
             )
             return None
-    else:
+    except (FileNotFoundError, PermissionError, OSError) as e:
         click.echo(
-            f"{LogSymbols.ERROR.value} Model {repo_id} is unavailable for profile"
-            f" '{profile.name}'. You can try adding it using `blackfish model add`."
+            f"{LogSymbols.ERROR.value} Profile '{profile.name}': model directories"
+            f" not accessible: {e}"
         )
         return None
 
@@ -124,25 +131,32 @@ def run_text_generation(
         )
         return
 
-    if repo_id in get_models(profile):
-        if revision is None:
-            revision = get_latest_commit(repo_id, get_revisions(repo_id, profile))
-            click.echo(
-                f"{LogSymbols.WARNING.value} No revision provided. Using latest"
-                f" available commit: {revision}."
-            )
-            model_dir = get_model_dir(repo_id, revision, profile)
-        else:
-            model_dir = get_model_dir(repo_id, revision, profile)
-            if model_dir is None:
+    try:
+        if repo_id in get_models(profile):
+            if revision is None:
+                revision = get_latest_commit(repo_id, get_revisions(repo_id, profile))
                 click.echo(
-                    f"{LogSymbols.ERROR.value} Model directory not found 😔. The requested revision ({revision}) is missing."
+                    f"{LogSymbols.WARNING.value} No revision provided. Using latest"
+                    f" available commit: {revision}."
                 )
-                return
-    else:
+                model_dir = get_model_dir(repo_id, revision, profile)
+            else:
+                model_dir = get_model_dir(repo_id, revision, profile)
+                if model_dir is None:
+                    click.echo(
+                        f"{LogSymbols.ERROR.value} Model directory not found 😔. The requested revision ({revision}) is missing."
+                    )
+                    return
+        else:
+            click.echo(
+                f"{LogSymbols.ERROR.value} Unable to find {repo_id} for profile"
+                f" '{profile.name}'."
+            )
+            return
+    except (FileNotFoundError, PermissionError, OSError) as e:
         click.echo(
-            f"{LogSymbols.ERROR.value} Unable to find {repo_id} for profile"
-            f" '{profile.name}'."
+            f"{LogSymbols.ERROR.value} Profile '{profile.name}': model directories"
+            f" not accessible: {e}"
         )
         return
 

--- a/lib/src/blackfish/cli/services/text_generation.py
+++ b/lib/src/blackfish/cli/services/text_generation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import shlex
-from typing import Optional, Tuple
+from typing import Optional
 import rich_click as click
 from rich_click import Context
 import requests
@@ -26,40 +26,6 @@ from blackfish.server.utils import (
 from blackfish.server.config import BlackfishConfig
 from blackfish.server.job import JobScheduler, JobConfig, SlurmJobConfig, LocalJobConfig
 from blackfish.cli.classes import ServiceOptions
-
-
-def try_get_model_info(
-    profile: BlackfishProfile, repo_id: str, revision: Optional[str] = None
-) -> Optional[Tuple[str, str]]:
-    try:
-        if repo_id in get_models(profile):
-            if revision is None:
-                revision = get_latest_commit(repo_id, get_revisions(repo_id, profile))
-                click.echo(
-                    f"{LogSymbols.WARNING.value} No revision provided. Using latest"
-                    f" available commit: {revision}."
-                )
-
-            model_dir = get_model_dir(repo_id, revision, profile)
-            if model_dir is None:
-                click.echo(
-                    f"{LogSymbols.ERROR.value} Model directory not found 😔. The requested revision ({revision}) is missing."
-                )
-                return None
-        else:
-            click.echo(
-                f"{LogSymbols.ERROR.value} Model {repo_id} is unavailable for profile"
-                f" '{profile.name}'. You can try adding it using `blackfish model add`."
-            )
-            return None
-    except (FileNotFoundError, PermissionError, OSError) as e:
-        click.echo(
-            f"{LogSymbols.ERROR.value} Profile '{profile.name}': model directories"
-            f" not accessible: {e}"
-        )
-        return None
-
-    return model_dir, revision
 
 
 # blackfish run [OPTIONS] text-generation [OPTIONS]

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -1817,7 +1817,7 @@ async def get_models(
             fs_models = await find_models(matched)
         except (FileNotFoundError, PermissionError, OSError) as e:
             raise ValidationException(
-                detail=f"Profile '{profile}': model directories not accessible: {e}"
+                detail=f"Model directories not accessible: {e}"
             ) from e
 
         # 2. Fetch existing models from DB (scoped to this profile — refresh

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -330,20 +330,17 @@ async def find_models(profile: Profile) -> list[Model]:
     and profile set. Image and metadata are not set here - they should be
     populated from the database or fetched from HuggingFace Hub.
 
-    Returns:
-        List of Model objects found on filesystem (image and metadata_ are None)
+    Raises:
+        FileNotFoundError, PermissionError, OSError: if either model
+        directory can't be read. The endpoint surfaces these as a 400.
     """
-    models = []
+    models: list[Model] = []
     seen_revisions: set[str] = set()
 
     def scan_directory(base_dir: str, listdir_fn: Callable[[str], list[str]]) -> None:
         """Scan a directory for model folders and revisions."""
         logger.debug(f"Scanning directory: {base_dir}")
-        try:
-            model_dirs = listdir_fn(base_dir)
-        except (FileNotFoundError, OSError) as e:
-            logger.debug(f"Directory not found or inaccessible: {base_dir} ({e})")
-            return
+        model_dirs = listdir_fn(base_dir)
 
         for model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
             try:
@@ -384,8 +381,8 @@ async def find_models(profile: Profile) -> list[Model]:
         with remote.acquire(profile.host, profile.user) as sess:
             cache_dir = os.path.join(profile.cache_dir, "models")
             home_dir = os.path.join(profile.home_dir, "models")
-            scan_directory(cache_dir, sess.sftp.listdir)
-            scan_directory(home_dir, sess.sftp.listdir)
+            scan_directory(cache_dir, sess.listdir)
+            scan_directory(home_dir, sess.listdir)
     else:
         # Local profile: use os.listdir
         cache_dir = os.path.join(profile.cache_dir, "models")
@@ -1799,33 +1796,33 @@ async def get_models(
 
     res: list[list[Model]] | Result[Tuple[Model]]
     if refresh:
-        # 1. Scan filesystem to get current models
-        if profile is not None:
-            matched = next((p for p in profiles if p.name == profile), None)
-            if matched is None:
-                logger.warning(
-                    f"Profile '{profile}' not found. Returning an empty list."
-                )
-                return list()
-            fs_models = await find_models(matched)
-        else:
-            gathered = await asyncio.gather(
-                *[find_models(p) for p in profiles], return_exceptions=True
+        # Refresh requires a profile — we need to know which one to scan,
+        # and per-profile errors only make sense when the caller picked
+        # one. Multi-profile refresh is handled CLI-side by fanning out
+        # one request per profile.
+        if profile is None:
+            raise ValidationException(
+                detail="`profile` is required when `refresh=true`."
             )
-            fs_models = []
-            for p, result in zip(profiles, gathered):
-                if isinstance(result, Exception):
-                    logger.error(
-                        f"Failed to find models for profile '{p.name}': {result}"
-                    )
-                elif isinstance(result, list):
-                    fs_models.extend(result)
 
-        # 2. Fetch existing models from DB
-        if profile is not None:
-            existing_query = sa.select(Model).where(Model.profile == profile)
-        else:
-            existing_query = sa.select(Model)
+        # 1. Scan filesystem to get current models
+        matched = next((p for p in profiles if p.name == profile), None)
+        if matched is None:
+            raise NotFoundException(detail=f"Profile '{profile}' not found.")
+
+        # If either model directory can't be read, refuse the refresh
+        # rather than returning a partial result. Most often this means
+        # the user deleted cache_dir or home_dir out from under us.
+        try:
+            fs_models = await find_models(matched)
+        except (FileNotFoundError, PermissionError, OSError) as e:
+            raise ValidationException(
+                detail=f"Profile '{profile}': model directories not accessible: {e}"
+            ) from e
+
+        # 2. Fetch existing models from DB (scoped to this profile — refresh
+        # is single-profile, see the validation at the top of this branch).
+        existing_query = sa.select(Model).where(Model.profile == profile)
         existing_result = await session.execute(existing_query)
         db_models = list(existing_result.scalars().all())
 

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -1897,9 +1897,7 @@ async def get_models(
 
         # Re-query to get fresh state after all modifications
         logger.debug(f"Re-querying models (profile={profile}, image={image})")
-        final_query = sa.select(Model)
-        if profile is not None:
-            final_query = final_query.where(Model.profile == profile)
+        final_query = sa.select(Model).where(Model.profile == profile)
         if image is not None:
             compatible = COMPATIBLE_PIPELINES.get(image, [image])
             final_query = final_query.where(Model.image.in_(compatible))

--- a/lib/src/blackfish/server/remote/session.py
+++ b/lib/src/blackfish/server/remote/session.py
@@ -202,6 +202,14 @@ class RemoteSession:
         except Exception as e:
             raise OSError(str(e)) from e
 
+    def listdir(self, path: str) -> list[str]:
+        try:
+            return self.sftp.listdir(path)
+        except (FileNotFoundError, PermissionError):
+            raise
+        except Exception as e:
+            raise OSError(str(e)) from e
+
     def read_bytes(self, path: str) -> bytes:
         try:
             with self.sftp.open(path, "rb") as f:

--- a/lib/src/blackfish/server/utils.py
+++ b/lib/src/blackfish/server/utils.py
@@ -1,7 +1,7 @@
 import os
 import socket
 import datetime
-from typing import Any, Callable, Optional
+from typing import Optional
 from huggingface_hub import ModelCard, list_repo_commits
 from huggingface_hub.errors import RepositoryNotFoundError
 from blackfish.server import remote
@@ -9,34 +9,6 @@ from blackfish.server.models.profile import BlackfishProfile, SlurmProfile
 from blackfish.server.logger import logger
 from yaspin import yaspin
 from log_symbols.symbols import LogSymbols
-
-
-def _safe_listdir(
-    listdir: Callable[[str], list[str]],
-    path: str,
-    spinner: Any,
-    host: str,
-) -> list[str]:
-    """``listdir(path)`` that returns ``[]`` for missing/unreadable directories.
-
-    The model search functions walk two directories (cache + home) per
-    profile; if a user deletes one out from under us, we'd rather warn and
-    skip than abort the whole command. ``spinner.write`` prints above the
-    running spinner line so the warning isn't overwritten by the next
-    ``spinner.text = ...`` update.
-    """
-    try:
-        return listdir(path)
-    except FileNotFoundError:
-        spinner.write(
-            f"  {LogSymbols.WARNING.value} Directory {path} not found on {host}, skipping."
-        )
-        return []
-    except PermissionError:
-        spinner.write(
-            f"  {LogSymbols.WARNING.value} Cannot read {path} on {host}, skipping."
-        )
-        return []
 
 
 def get_latest_commit(repo_id: str, revisions: list[str]) -> str:  # pragma: no cover
@@ -51,25 +23,28 @@ def get_latest_commit(repo_id: str, revisions: list[str]) -> str:  # pragma: no 
 
 
 def get_models(profile: BlackfishProfile) -> list[str]:
-    """Return a list of models available to a given profile."""
+    """Return a list of models available to a given profile.
+
+    Raises ``FileNotFoundError`` / ``PermissionError`` / ``OSError`` if
+    either model directory can't be read; CLI callers translate to a
+    user-facing error.
+    """
     if isinstance(profile, SlurmProfile) and not profile.is_local():
         models = set()
         with yaspin(text=f"Searching {profile.host} for available models") as spinner:
             with remote.acquire(profile.host, profile.user) as sess:
                 default_dir = os.path.join(profile.cache_dir, "models")
                 spinner.text = f"Looking in cache directory {default_dir}"
-                model_dirs = _safe_listdir(
-                    sess.listdir, default_dir, spinner, profile.host
-                )
-                for model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
+                for model_dir in filter(
+                    lambda x: x.startswith("models--"), sess.listdir(default_dir)
+                ):
                     _, namespace, model = model_dir.split("--")
                     models.add(f"{namespace}/{model}")
                 backup_dir = os.path.join(profile.home_dir, "models")
                 spinner.text = f"Looking in home directory {backup_dir}"
-                model_dirs = _safe_listdir(
-                    sess.listdir, backup_dir, spinner, profile.host
-                )
-                for model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
+                for model_dir in filter(
+                    lambda x: x.startswith("models--"), sess.listdir(backup_dir)
+                ):
                     _, namespace, model = model_dir.split("--")
                     models.add(f"{namespace}/{model}")
             spinner.text = f"Found {len(models)} models."
@@ -80,14 +55,16 @@ def get_models(profile: BlackfishProfile) -> list[str]:
         with yaspin(text="Searching localhost for available models") as spinner:
             default_dir = os.path.join(profile.cache_dir, "models")
             spinner.text = f"Looking in cache directory {default_dir}"
-            model_dirs = _safe_listdir(os.listdir, default_dir, spinner, "localhost")
-            for model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
+            for model_dir in filter(
+                lambda x: x.startswith("models--"), os.listdir(default_dir)
+            ):
                 _, namespace, model = model_dir.split("--")
                 models.add(f"{namespace}/{model}")
             backup_dir = os.path.join(profile.home_dir, "models")
             spinner.text = f"Looking in home directory {backup_dir}"
-            model_dirs = _safe_listdir(os.listdir, backup_dir, spinner, "localhost")
-            for model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
+            for model_dir in filter(
+                lambda x: x.startswith("models--"), os.listdir(backup_dir)
+            ):
                 _, namespace, model = model_dir.split("--")
                 models.add(f"{namespace}/{model}")
             spinner.text = f"Found {len(models)} models."
@@ -96,7 +73,11 @@ def get_models(profile: BlackfishProfile) -> list[str]:
 
 
 def get_revisions(repo_id: str, profile: BlackfishProfile) -> list[str]:
-    """Return a list of revisions associated with a given model and profile."""
+    """Return a list of revisions associated with a given model and profile.
+
+    Raises ``FileNotFoundError`` / ``PermissionError`` / ``OSError`` if
+    either model directory can't be read.
+    """
     if isinstance(profile, SlurmProfile) and not profile.is_local():
         revisions = set()
         namespace, model = repo_id.split("/")
@@ -107,31 +88,19 @@ def get_revisions(repo_id: str, profile: BlackfishProfile) -> list[str]:
             with remote.acquire(profile.host, profile.user) as sess:
                 default_dir = os.path.join(profile.cache_dir, "models")
                 spinner.text = f"Looking in cache directory {default_dir}"
-                model_dirs = _safe_listdir(
-                    sess.listdir, default_dir, spinner, profile.host
-                )
-                if model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
+                if model_dir in filter(
+                    lambda x: x.startswith("models--"), sess.listdir(default_dir)
+                ):
                     revisions.update(
-                        _safe_listdir(
-                            sess.listdir,
-                            os.path.join(default_dir, model_dir, "snapshots"),
-                            spinner,
-                            profile.host,
-                        )
+                        sess.listdir(os.path.join(default_dir, model_dir, "snapshots"))
                     )
                 backup_dir = os.path.join(profile.home_dir, "models")
                 spinner.text = f"Looking in home directory {backup_dir}"
-                model_dirs = _safe_listdir(
-                    sess.listdir, backup_dir, spinner, profile.host
-                )
-                if model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
+                if model_dir in filter(
+                    lambda x: x.startswith("models--"), sess.listdir(backup_dir)
+                ):
                     revisions.update(
-                        _safe_listdir(
-                            sess.listdir,
-                            os.path.join(backup_dir, model_dir, "snapshots"),
-                            spinner,
-                            profile.host,
-                        )
+                        sess.listdir(os.path.join(backup_dir, model_dir, "snapshots"))
                     )
             spinner.text = f"Found {len(revisions)} snapshots."
             spinner.ok(f"{LogSymbols.SUCCESS.value}")
@@ -143,27 +112,19 @@ def get_revisions(repo_id: str, profile: BlackfishProfile) -> list[str]:
         with yaspin(text=f"Searching localhost for model {repo_id} commits") as spinner:
             default_dir = os.path.join(profile.cache_dir, "models")
             spinner.text = f"Looking in cache directory {default_dir}"
-            model_dirs = _safe_listdir(os.listdir, default_dir, spinner, "localhost")
-            if model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
+            if model_dir in filter(
+                lambda x: x.startswith("models--"), os.listdir(default_dir)
+            ):
                 revisions.update(
-                    _safe_listdir(
-                        os.listdir,
-                        os.path.join(default_dir, model_dir, "snapshots"),
-                        spinner,
-                        "localhost",
-                    )
+                    os.listdir(os.path.join(default_dir, model_dir, "snapshots"))
                 )
             backup_dir = os.path.join(profile.home_dir, "models")
             spinner.text = f"Looking in home directory {backup_dir}"
-            model_dirs = _safe_listdir(os.listdir, backup_dir, spinner, "localhost")
-            if model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
+            if model_dir in filter(
+                lambda x: x.startswith("models--"), os.listdir(backup_dir)
+            ):
                 revisions.update(
-                    _safe_listdir(
-                        os.listdir,
-                        os.path.join(backup_dir, model_dir, "snapshots"),
-                        spinner,
-                        "localhost",
-                    )
+                    os.listdir(os.path.join(backup_dir, model_dir, "snapshots"))
                 )
             spinner.text = f"Found {len(revisions)} snapshots."
             spinner.ok(f"{LogSymbols.SUCCESS.value}")
@@ -175,7 +136,11 @@ def get_model_dir(
 ) -> Optional[str]:
     """Find the directory of a specific model revision.
 
-    The job launcher needs to know where to find model files, but these can be split across the managed cache and a user's private cache.
+    The job launcher needs to know where to find model files, but these
+    can be split across the managed cache and a user's private cache.
+
+    Raises ``FileNotFoundError`` / ``PermissionError`` / ``OSError`` if
+    either model directory can't be read.
     """
     namespace, model = repo_id.split("/")
     model_dir = f"models--{namespace}--{model}"
@@ -186,28 +151,18 @@ def get_model_dir(
             with remote.acquire(profile.host, profile.user) as sess:
                 default_dir = os.path.join(profile.cache_dir, "models")
                 spinner.text = f"Looking in default directory {default_dir}"
-                if model_dir in _safe_listdir(
-                    sess.listdir, default_dir, spinner, profile.host
-                ):
-                    if revision in _safe_listdir(
-                        sess.listdir,
-                        os.path.join(default_dir, model_dir, "snapshots"),
-                        spinner,
-                        profile.host,
+                if model_dir in sess.listdir(default_dir):
+                    if revision in sess.listdir(
+                        os.path.join(default_dir, model_dir, "snapshots")
                     ):
                         spinner.text = f"Found model {repo_id}!"
                         spinner.ok(f"{LogSymbols.SUCCESS.value}")
                         return os.path.join(default_dir, model_dir)
                 backup_dir = os.path.join(profile.home_dir, "models")
                 spinner.text = f"Looking in backup directory {backup_dir}"
-                if model_dir in _safe_listdir(
-                    sess.listdir, backup_dir, spinner, profile.host
-                ):
-                    if revision in _safe_listdir(
-                        sess.listdir,
-                        os.path.join(backup_dir, model_dir, "snapshots"),
-                        spinner,
-                        profile.host,
+                if model_dir in sess.listdir(backup_dir):
+                    if revision in sess.listdir(
+                        os.path.join(backup_dir, model_dir, "snapshots")
                     ):
                         spinner.text = f"Found model {repo_id}!"
                         spinner.ok(f"{LogSymbols.SUCCESS.value}")
@@ -219,26 +174,18 @@ def get_model_dir(
         with yaspin(text=f"Searching localhost for {repo_id}[{revision}]") as spinner:
             default_dir = os.path.join(profile.cache_dir, "models")
             spinner.text = f"Looking in default directory {default_dir}"
-            if model_dir in _safe_listdir(
-                os.listdir, default_dir, spinner, "localhost"
-            ):
-                if revision in _safe_listdir(
-                    os.listdir,
-                    os.path.join(default_dir, model_dir, "snapshots"),
-                    spinner,
-                    "localhost",
+            if model_dir in os.listdir(default_dir):
+                if revision in os.listdir(
+                    os.path.join(default_dir, model_dir, "snapshots")
                 ):
                     spinner.text = f"Found model {repo_id}!"
                     spinner.ok(f"{LogSymbols.SUCCESS.value}")
                     return os.path.join(default_dir, model_dir)
             backup_dir = os.path.join(profile.home_dir, "models")
             spinner.text = f"Looking in backup directory {backup_dir}"
-            if model_dir in _safe_listdir(os.listdir, backup_dir, spinner, "localhost"):
-                if revision in _safe_listdir(
-                    os.listdir,
-                    os.path.join(backup_dir, model_dir, "snapshots"),
-                    spinner,
-                    "localhost",
+            if model_dir in os.listdir(backup_dir):
+                if revision in os.listdir(
+                    os.path.join(backup_dir, model_dir, "snapshots")
                 ):
                     spinner.text = f"Found model {repo_id}!"
                     spinner.ok(f"{LogSymbols.SUCCESS.value}")

--- a/lib/src/blackfish/server/utils.py
+++ b/lib/src/blackfish/server/utils.py
@@ -1,7 +1,7 @@
 import os
 import socket
 import datetime
-from typing import Optional
+from typing import Any, Callable, Optional
 from huggingface_hub import ModelCard, list_repo_commits
 from huggingface_hub.errors import RepositoryNotFoundError
 from blackfish.server import remote
@@ -9,6 +9,34 @@ from blackfish.server.models.profile import BlackfishProfile, SlurmProfile
 from blackfish.server.logger import logger
 from yaspin import yaspin
 from log_symbols.symbols import LogSymbols
+
+
+def _safe_listdir(
+    listdir: Callable[[str], list[str]],
+    path: str,
+    spinner: Any,
+    host: str,
+) -> list[str]:
+    """``listdir(path)`` that returns ``[]`` for missing/unreadable directories.
+
+    The model search functions walk two directories (cache + home) per
+    profile; if a user deletes one out from under us, we'd rather warn and
+    skip than abort the whole command. ``spinner.write`` prints above the
+    running spinner line so the warning isn't overwritten by the next
+    ``spinner.text = ...`` update.
+    """
+    try:
+        return listdir(path)
+    except FileNotFoundError:
+        spinner.write(
+            f"  {LogSymbols.WARNING.value} Directory {path} not found on {host}, skipping."
+        )
+        return []
+    except PermissionError:
+        spinner.write(
+            f"  {LogSymbols.WARNING.value} Cannot read {path} on {host}, skipping."
+        )
+        return []
 
 
 def get_latest_commit(repo_id: str, revisions: list[str]) -> str:  # pragma: no cover
@@ -28,16 +56,19 @@ def get_models(profile: BlackfishProfile) -> list[str]:
         models = set()
         with yaspin(text=f"Searching {profile.host} for available models") as spinner:
             with remote.acquire(profile.host, profile.user) as sess:
-                sftp = sess.sftp
                 default_dir = os.path.join(profile.cache_dir, "models")
                 spinner.text = f"Looking in cache directory {default_dir}"
-                model_dirs = sftp.listdir(default_dir)
+                model_dirs = _safe_listdir(
+                    sess.listdir, default_dir, spinner, profile.host
+                )
                 for model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
                     _, namespace, model = model_dir.split("--")
                     models.add(f"{namespace}/{model}")
                 backup_dir = os.path.join(profile.home_dir, "models")
                 spinner.text = f"Looking in home directory {backup_dir}"
-                model_dirs = sftp.listdir(backup_dir)
+                model_dirs = _safe_listdir(
+                    sess.listdir, backup_dir, spinner, profile.host
+                )
                 for model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
                     _, namespace, model = model_dir.split("--")
                     models.add(f"{namespace}/{model}")
@@ -49,13 +80,13 @@ def get_models(profile: BlackfishProfile) -> list[str]:
         with yaspin(text="Searching localhost for available models") as spinner:
             default_dir = os.path.join(profile.cache_dir, "models")
             spinner.text = f"Looking in cache directory {default_dir}"
-            model_dirs = os.listdir(default_dir)
+            model_dirs = _safe_listdir(os.listdir, default_dir, spinner, "localhost")
             for model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
                 _, namespace, model = model_dir.split("--")
                 models.add(f"{namespace}/{model}")
             backup_dir = os.path.join(profile.home_dir, "models")
             spinner.text = f"Looking in home directory {backup_dir}"
-            model_dirs = os.listdir(backup_dir)
+            model_dirs = _safe_listdir(os.listdir, backup_dir, spinner, "localhost")
             for model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
                 _, namespace, model = model_dir.split("--")
                 models.add(f"{namespace}/{model}")
@@ -74,20 +105,33 @@ def get_revisions(repo_id: str, profile: BlackfishProfile) -> list[str]:
             text=f"Searching {profile.host} for model {repo_id} commits"
         ) as spinner:
             with remote.acquire(profile.host, profile.user) as sess:
-                sftp = sess.sftp
                 default_dir = os.path.join(profile.cache_dir, "models")
                 spinner.text = f"Looking in cache directory {default_dir}"
-                model_dirs = sftp.listdir(default_dir)
+                model_dirs = _safe_listdir(
+                    sess.listdir, default_dir, spinner, profile.host
+                )
                 if model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
                     revisions.update(
-                        sftp.listdir(os.path.join(default_dir, model_dir, "snapshots"))
+                        _safe_listdir(
+                            sess.listdir,
+                            os.path.join(default_dir, model_dir, "snapshots"),
+                            spinner,
+                            profile.host,
+                        )
                     )
                 backup_dir = os.path.join(profile.home_dir, "models")
                 spinner.text = f"Looking in home directory {backup_dir}"
-                model_dirs = sftp.listdir(backup_dir)
+                model_dirs = _safe_listdir(
+                    sess.listdir, backup_dir, spinner, profile.host
+                )
                 if model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
                     revisions.update(
-                        sftp.listdir(os.path.join(backup_dir, model_dir, "snapshots"))
+                        _safe_listdir(
+                            sess.listdir,
+                            os.path.join(backup_dir, model_dir, "snapshots"),
+                            spinner,
+                            profile.host,
+                        )
                     )
             spinner.text = f"Found {len(revisions)} snapshots."
             spinner.ok(f"{LogSymbols.SUCCESS.value}")
@@ -99,17 +143,27 @@ def get_revisions(repo_id: str, profile: BlackfishProfile) -> list[str]:
         with yaspin(text=f"Searching localhost for model {repo_id} commits") as spinner:
             default_dir = os.path.join(profile.cache_dir, "models")
             spinner.text = f"Looking in cache directory {default_dir}"
-            model_dirs = os.listdir(default_dir)
+            model_dirs = _safe_listdir(os.listdir, default_dir, spinner, "localhost")
             if model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
                 revisions.update(
-                    os.listdir(os.path.join(default_dir, model_dir, "snapshots"))
+                    _safe_listdir(
+                        os.listdir,
+                        os.path.join(default_dir, model_dir, "snapshots"),
+                        spinner,
+                        "localhost",
+                    )
                 )
             backup_dir = os.path.join(profile.home_dir, "models")
             spinner.text = f"Looking in home directory {backup_dir}"
-            model_dirs = os.listdir(backup_dir)
+            model_dirs = _safe_listdir(os.listdir, backup_dir, spinner, "localhost")
             if model_dir in filter(lambda x: x.startswith("models--"), model_dirs):
                 revisions.update(
-                    os.listdir(os.path.join(backup_dir, model_dir, "snapshots"))
+                    _safe_listdir(
+                        os.listdir,
+                        os.path.join(backup_dir, model_dir, "snapshots"),
+                        spinner,
+                        "localhost",
+                    )
                 )
             spinner.text = f"Found {len(revisions)} snapshots."
             spinner.ok(f"{LogSymbols.SUCCESS.value}")
@@ -130,21 +184,30 @@ def get_model_dir(
             text=f"Searching {profile.host} for {repo_id}[{revision}]"
         ) as spinner:
             with remote.acquire(profile.host, profile.user) as sess:
-                sftp = sess.sftp
                 default_dir = os.path.join(profile.cache_dir, "models")
                 spinner.text = f"Looking in default directory {default_dir}"
-                if model_dir in sftp.listdir(default_dir):
-                    if revision in sftp.listdir(
-                        os.path.join(default_dir, model_dir, "snapshots")
+                if model_dir in _safe_listdir(
+                    sess.listdir, default_dir, spinner, profile.host
+                ):
+                    if revision in _safe_listdir(
+                        sess.listdir,
+                        os.path.join(default_dir, model_dir, "snapshots"),
+                        spinner,
+                        profile.host,
                     ):
                         spinner.text = f"Found model {repo_id}!"
                         spinner.ok(f"{LogSymbols.SUCCESS.value}")
                         return os.path.join(default_dir, model_dir)
                 backup_dir = os.path.join(profile.home_dir, "models")
                 spinner.text = f"Looking in backup directory {backup_dir}"
-                if model_dir in sftp.listdir(backup_dir):
-                    if revision in sftp.listdir(
-                        os.path.join(backup_dir, model_dir, "snapshots")
+                if model_dir in _safe_listdir(
+                    sess.listdir, backup_dir, spinner, profile.host
+                ):
+                    if revision in _safe_listdir(
+                        sess.listdir,
+                        os.path.join(backup_dir, model_dir, "snapshots"),
+                        spinner,
+                        profile.host,
                     ):
                         spinner.text = f"Found model {repo_id}!"
                         spinner.ok(f"{LogSymbols.SUCCESS.value}")
@@ -156,18 +219,26 @@ def get_model_dir(
         with yaspin(text=f"Searching localhost for {repo_id}[{revision}]") as spinner:
             default_dir = os.path.join(profile.cache_dir, "models")
             spinner.text = f"Looking in default directory {default_dir}"
-            if model_dir in os.listdir(default_dir):
-                if revision in os.listdir(
-                    os.path.join(default_dir, model_dir, "snapshots")
+            if model_dir in _safe_listdir(
+                os.listdir, default_dir, spinner, "localhost"
+            ):
+                if revision in _safe_listdir(
+                    os.listdir,
+                    os.path.join(default_dir, model_dir, "snapshots"),
+                    spinner,
+                    "localhost",
                 ):
                     spinner.text = f"Found model {repo_id}!"
                     spinner.ok(f"{LogSymbols.SUCCESS.value}")
                     return os.path.join(default_dir, model_dir)
             backup_dir = os.path.join(profile.home_dir, "models")
             spinner.text = f"Looking in backup directory {backup_dir}"
-            if model_dir in os.listdir(backup_dir):
-                if revision in os.listdir(
-                    os.path.join(backup_dir, model_dir, "snapshots")
+            if model_dir in _safe_listdir(os.listdir, backup_dir, spinner, "localhost"):
+                if revision in _safe_listdir(
+                    os.listdir,
+                    os.path.join(backup_dir, model_dir, "snapshots"),
+                    spinner,
+                    "localhost",
                 ):
                     spinner.text = f"Found model {repo_id}!"
                     spinner.ok(f"{LogSymbols.SUCCESS.value}")

--- a/lib/tests/api/test_models.py
+++ b/lib/tests/api/test_models.py
@@ -98,7 +98,7 @@ class TestFetchModelsAPI:
                     repo=existing_repo,
                     profile="default",
                     revision=existing_revision,
-                    image="unknown",  # find_models now returns "unknown"
+                    image="unknown",
                     model_dir="/home/test/.blackfish/models/test",
                     metadata_=None,
                 ),
@@ -216,23 +216,28 @@ class TestFetchModelsAPI:
             for model in result:
                 assert model.get("profile") == "default"
 
-    @pytest.mark.parametrize("refresh", [True, False])
-    async def test_fetch_models_nonexistent_profile(
-        self, refresh, client: AsyncTestClient
-    ):
-        """Test fetching models for nonexistent profile with refresh."""
+    async def test_refresh_without_profile_is_rejected(self, client: AsyncTestClient):
+        """Refresh without ?profile= should 400 — the CLI fans out per-profile."""
+        response = await client.get("/api/models", params={"refresh": True})
+        assert response.status_code == 400
+
+    async def test_refresh_nonexistent_profile_is_404(self, client: AsyncTestClient):
+        """Refresh against an unknown profile name should 404."""
         response = await client.get(
             "/api/models",
-            params={
-                "profile": "nonexistent-profile",
-                "refresh": refresh,
-            },
+            params={"profile": "nonexistent-profile", "refresh": True},
         )
+        assert response.status_code == 404
 
+    async def test_fetch_nonexistent_profile_without_refresh_returns_empty(
+        self, client: AsyncTestClient
+    ):
+        """Non-refresh DB query for an unknown profile name returns empty."""
+        response = await client.get(
+            "/api/models", params={"profile": "nonexistent-profile"}
+        )
         assert response.status_code == 200
-        result = response.json()
-        # Should return empty list for nonexistent profile
-        assert result == []
+        assert response.json() == []
 
     async def test_fetch_models_multiple_parameters(self, client: AsyncTestClient):
         """Test fetching models with multiple filter parameters."""

--- a/lib/tests/cli/test_cli_models.py
+++ b/lib/tests/cli/test_cli_models.py
@@ -45,7 +45,7 @@ from blackfish.cli.__main__ import main
             False,
             None,
             500,
-            "Profile",  # error message mentions the profile in question
+            "Boom",  # error detail from mocked 500 response
         ),
         # With profile filter
         (

--- a/lib/tests/cli/test_cli_models.py
+++ b/lib/tests/cli/test_cli_models.py
@@ -5,31 +5,28 @@ from blackfish.cli.__main__ import main
 
 
 @pytest.mark.parametrize(
-    "profile, image, refresh, mock_response, expected_exit_code, expected_in_output",
+    "profile, image, refresh, mock_response_models, mock_response_status, expected_in_output",
     [
-        # Basic successful request with models
+        # Basic successful request with models, no filters
         (
             None,
             None,
             False,
-            {
-                "json": [
-                    {
-                        "repo": "openai/whisper-large-v3",
-                        "revision": "main",
-                        "profile": "default",
-                        "image": "speech-recognition",
-                    },
-                    {
-                        "repo": "microsoft/DialoGPT-medium",
-                        "revision": "main",
-                        "profile": "default",
-                        "image": "text-generation",
-                    },
-                ],
-                "status_code": 200,
-            },
-            0,
+            [
+                {
+                    "repo": "openai/whisper-large-v3",
+                    "revision": "main",
+                    "profile": "default",
+                    "image": "speech-recognition",
+                },
+                {
+                    "repo": "microsoft/DialoGPT-medium",
+                    "revision": "main",
+                    "profile": "default",
+                    "image": "text-generation",
+                },
+            ],
+            200,
             "openai/whisper-large-v3",
         ),
         # Empty response - no models found
@@ -37,8 +34,8 @@ from blackfish.cli.__main__ import main
             "default",
             None,
             False,
-            {"json": [], "status_code": 200},
-            0,
+            [],
+            200,
             "No models found",
         ),
         # Server error
@@ -46,56 +43,41 @@ from blackfish.cli.__main__ import main
             None,
             "text-generation",
             False,
-            {"json": {}, "status_code": 500},
-            0,
-            "Blackfish API encountered an error: 500",
+            None,
+            500,
+            "Profile",  # error message mentions the profile in question
         ),
         # With profile filter
         (
             "test-profile",
             None,
             False,
-            {
-                "json": [
-                    {
-                        "repo": "microsoft/DialoGPT-medium",
-                        "revision": "main",
-                        "profile": "test-profile",
-                        "image": "text-generation",
-                    }
-                ],
-                "status_code": 200,
-            },
-            0,
+            [
+                {
+                    "repo": "microsoft/DialoGPT-medium",
+                    "revision": "main",
+                    "profile": "test-profile",
+                    "image": "text-generation",
+                }
+            ],
+            200,
             "microsoft/DialoGPT-medium",
         ),
-        # With image filter and refresh
+        # With profile + image filter + refresh
         (
-            None,
+            "default",
             "speech-recognition",
             True,
-            {
-                "json": [
-                    {
-                        "repo": "openai/whisper-base",
-                        "revision": "main",
-                        "profile": "default",
-                        "image": "speech-recognition",
-                    }
-                ],
-                "status_code": 200,
-            },
-            0,
+            [
+                {
+                    "repo": "openai/whisper-base",
+                    "revision": "main",
+                    "profile": "default",
+                    "image": "speech-recognition",
+                }
+            ],
+            200,
             "openai/whisper-base",
-        ),
-        # Profile warning when no models found for specific profile
-        (
-            "admin",  # not in profile.cfg
-            None,
-            False,
-            {"json": [], "status_code": 200},
-            0,
-            "No models found.",
         ),
     ],
 )
@@ -105,13 +87,12 @@ def test_list_models(
     profile: str,
     image: str,
     refresh: bool,
-    mock_response: dict,
-    expected_exit_code: int,
+    mock_response_models,
+    mock_response_status: int,
     expected_in_output: str,
 ) -> None:
     """Test `blackfish model ls` command."""
 
-    # Prepare command
     cmd = ["model", "ls"]
     if profile:
         cmd.extend(["-p", profile])
@@ -122,15 +103,19 @@ def test_list_models(
 
     with patch("blackfish.cli.__main__.api.get") as mock_get:
         mock_response_obj = Mock()
-        mock_response_obj.ok = mock_response["status_code"] == 200
-        mock_response_obj.status_code = mock_response["status_code"]
-        mock_response_obj.json.return_value = mock_response["json"]
+        mock_response_obj.ok = mock_response_status == 200
+        mock_response_obj.status_code = mock_response_status
+        mock_response_obj.reason = "Internal Server Error"
+        mock_response_obj.json.return_value = (
+            mock_response_models
+            if mock_response_models is not None
+            else {"detail": "Boom"}
+        )
         mock_get.return_value = mock_response_obj
 
         result = cli_runner.invoke(main, cmd)
 
-    # Verify request was made with correct path and params
-    mock_get.assert_called_once()
+    mock_get.assert_called()
     call_path = mock_get.call_args[0][0]
     call_params = mock_get.call_args.kwargs.get("params", {})
     assert call_path == "/api/models"
@@ -140,7 +125,7 @@ def test_list_models(
     if image:
         assert call_params.get("image") == image
 
-    assert result.exit_code == expected_exit_code
+    assert result.exit_code == 0
     assert expected_in_output in result.output
 
 

--- a/lib/tests/unit/test_utils.py
+++ b/lib/tests/unit/test_utils.py
@@ -41,7 +41,10 @@ filesystem = {
 class MockSFTPClient:
     @staticmethod
     def listdir(key):
-        return filesystem[key]
+        try:
+            return filesystem[key]
+        except KeyError:
+            raise FileNotFoundError(key)
 
 
 def _mock_connection_class():
@@ -103,6 +106,42 @@ def test_get_model_dir_none(mock_conn):
         utils.get_model_dir("test/model-a", revision="test-commit-e", profile=profile)
         is None
     )
+
+
+@mock.patch(
+    "blackfish.server.remote.session.Connection", new_callable=_mock_connection_class
+)
+def test_get_models_missing_cache_dir_warns_and_returns_partial(mock_conn, capsys):
+    """If cache_dir is missing, return models from home_dir and warn the user."""
+    bad_profile = SlurmProfile(
+        name="test",
+        host="test",
+        user="test",
+        cache_dir="/missing/cache_dir/.blackfish",
+        home_dir="/test/home_dir/.blackfish",
+    )
+    assert set(utils.get_models(bad_profile)) == {"test/model-c", "test/model-d"}
+    captured = capsys.readouterr()
+    assert "/missing/cache_dir/.blackfish/models" in captured.out
+    assert "not found" in captured.out
+
+
+@mock.patch(
+    "blackfish.server.remote.session.Connection", new_callable=_mock_connection_class
+)
+def test_get_models_both_dirs_missing_warns_for_each(mock_conn, capsys):
+    """If both directories are missing, return [] and warn once per directory."""
+    bad_profile = SlurmProfile(
+        name="test",
+        host="test",
+        user="test",
+        cache_dir="/missing/cache_dir/.blackfish",
+        home_dir="/missing/home_dir/.blackfish",
+    )
+    assert utils.get_models(bad_profile) == []
+    captured = capsys.readouterr()
+    assert "/missing/cache_dir/.blackfish/models" in captured.out
+    assert "/missing/home_dir/.blackfish/models" in captured.out
 
 
 # TODO

--- a/lib/tests/unit/test_utils.py
+++ b/lib/tests/unit/test_utils.py
@@ -2,6 +2,8 @@ import os
 from unittest import mock
 import datetime
 
+import pytest
+
 from blackfish.server import utils
 from blackfish.server.models.profile import SlurmProfile
 
@@ -111,8 +113,8 @@ def test_get_model_dir_none(mock_conn):
 @mock.patch(
     "blackfish.server.remote.session.Connection", new_callable=_mock_connection_class
 )
-def test_get_models_missing_cache_dir_warns_and_returns_partial(mock_conn, capsys):
-    """If cache_dir is missing, return models from home_dir and warn the user."""
+def test_get_models_missing_cache_dir_raises(mock_conn):
+    """If cache_dir is missing, raise FileNotFoundError so callers can react."""
     bad_profile = SlurmProfile(
         name="test",
         host="test",
@@ -120,28 +122,8 @@ def test_get_models_missing_cache_dir_warns_and_returns_partial(mock_conn, capsy
         cache_dir="/missing/cache_dir/.blackfish",
         home_dir="/test/home_dir/.blackfish",
     )
-    assert set(utils.get_models(bad_profile)) == {"test/model-c", "test/model-d"}
-    captured = capsys.readouterr()
-    assert "/missing/cache_dir/.blackfish/models" in captured.out
-    assert "not found" in captured.out
-
-
-@mock.patch(
-    "blackfish.server.remote.session.Connection", new_callable=_mock_connection_class
-)
-def test_get_models_both_dirs_missing_warns_for_each(mock_conn, capsys):
-    """If both directories are missing, return [] and warn once per directory."""
-    bad_profile = SlurmProfile(
-        name="test",
-        host="test",
-        user="test",
-        cache_dir="/missing/cache_dir/.blackfish",
-        home_dir="/missing/home_dir/.blackfish",
-    )
-    assert utils.get_models(bad_profile) == []
-    captured = capsys.readouterr()
-    assert "/missing/cache_dir/.blackfish/models" in captured.out
-    assert "/missing/home_dir/.blackfish/models" in captured.out
+    with pytest.raises(FileNotFoundError):
+        utils.get_models(bad_profile)
 
 
 # TODO


### PR DESCRIPTION
## Summary
- `find_models` and the in-process `get_models` / `get_revisions` / `get_model_dir` propagate `FileNotFoundError` / `PermissionError` / `OSError` instead of swallowing them — a missing or unreadable cache_dir / home_dir is no longer silently ignored.
- `/api/models?refresh=true` requires a profile (the CLI fans out per profile when none is given) and returns 400 if either model directory can't be read.
- `RemoteSession.listdir` added so the SFTP path raises the same stdlib exceptions the local path already did.
- CLI surfaces a single `"Profile 'X': Model directories not accessible: <details>"` error in both the API and in-process paths, with a uniform `Found N models (M error(s)).` spinner line.

## Test plan
- [x] `uv run just lint` — passes
- [x] `uv run pytest --ignore=tests/dev` — 900 passed, 8 skipped
- [x] Manual: `blackfish model ls --profile default --refresh` against a profile with both dirs missing — clean error; against a profile with one dir missing — clean error; against a healthy profile — table

Closes #157