### PR TITLE
feat(web): namespace browser storage keys with bf: prefix

### DIFF
--- a/web/src/components/ProfileSelect.jsx
+++ b/web/src/components/ProfileSelect.jsx
@@ -7,6 +7,7 @@ import {
 } from "@headlessui/react";
 import { CheckIcon, ChevronDownIcon } from "@heroicons/react/20/solid";
 import { useProfiles } from "@/lib/loaders";
+import { STORAGE_KEYS } from "@/lib/storage";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
 import PropTypes from "prop-types";
 
@@ -21,7 +22,7 @@ const ProfileContext = createContext();
 const ProfileProvider = ({ children }) => {
   const { profiles } = useProfiles();
   const [profileName, setProfileName] = useState(() =>
-    typeof window !== "undefined" ? localStorage.getItem("profileName") : null
+    typeof window !== "undefined" ? localStorage.getItem(STORAGE_KEYS.PROFILE) : null
   );
 
   // Discard the legacy full-object payload so stale shapes from older
@@ -45,9 +46,9 @@ const ProfileProvider = ({ children }) => {
   const setProfile = useCallback((nextProfile) => {
     const name = nextProfile?.name ?? null;
     if (name) {
-      localStorage.setItem("profileName", name);
+      localStorage.setItem(STORAGE_KEYS.PROFILE, name);
     } else {
-      localStorage.removeItem("profileName");
+      localStorage.removeItem(STORAGE_KEYS.PROFILE);
     }
     setProfileName(name);
   }, []);

--- a/web/src/components/ProfileSelect.test.jsx
+++ b/web/src/components/ProfileSelect.test.jsx
@@ -6,6 +6,7 @@ import ProfileSelect, {
   ProfileProvider
 } from "@/components/ProfileSelect";
 import { useProfiles } from "@/lib/loaders";
+import { STORAGE_KEYS } from "@/lib/storage";
 
 const defaultProfiles = [
   {name: "test-profile", host: "example.com"},
@@ -52,7 +53,7 @@ describe("ProfileProvider", () => {
   });
 
   it("resolves profile from storage by name", () => {
-    localStorage.setItem("profileName", "test-profile");
+    localStorage.setItem(STORAGE_KEYS.PROFILE, "test-profile");
 
     let contextValue = null;
     const TestComponent = () => {
@@ -79,7 +80,7 @@ describe("ProfileProvider", () => {
   });
 
   it("resolves to null when the stored name is not in /api/profiles", () => {
-    localStorage.setItem("profileName", "unknown-profile");
+    localStorage.setItem(STORAGE_KEYS.PROFILE, "unknown-profile");
 
     let contextValue = null;
     const TestComponent = () => {
@@ -131,7 +132,7 @@ describe("ProfileProvider", () => {
   });
 
   it("falls back to the default-flagged profile when the stored name is stale", () => {
-    localStorage.setItem("profileName", "deleted-profile");
+    localStorage.setItem(STORAGE_KEYS.PROFILE, "deleted-profile");
     const profilesWithDefault = [
       {name: "test-profile", host: "example.com"},
       {name: "default-profile", host: "defaulthost.com", default: true},
@@ -160,7 +161,7 @@ describe("ProfileProvider", () => {
   });
 
   it("prefers an explicit stored selection over the default-flagged profile", () => {
-    localStorage.setItem("profileName", "test-profile");
+    localStorage.setItem(STORAGE_KEYS.PROFILE, "test-profile");
     const profilesWithDefault = [
       {name: "test-profile", host: "example.com"},
       {name: "default-profile", host: "defaulthost.com", default: true},
@@ -225,14 +226,14 @@ describe("ProfileProvider", () => {
       contextValue.setProfile({name: "new-profile", type: "slurm", host: "stale"});
     });
 
-    expect(localStorage.getItem("profileName")).toEqual("new-profile");
+    expect(localStorage.getItem(STORAGE_KEYS.PROFILE)).toEqual("new-profile");
     expect(contextValue.profile).toEqual(
       defaultProfiles.find((p) => p.name === "new-profile")
     );
   });
 
   it("setProfile with null clears the stored name", () => {
-    localStorage.setItem("profileName", "test-profile");
+    localStorage.setItem(STORAGE_KEYS.PROFILE, "test-profile");
 
     let contextValue = null;
     const TestComponent = () => {
@@ -256,7 +257,7 @@ describe("ProfileProvider", () => {
       contextValue.setProfile(null);
     });
 
-    expect(localStorage.getItem("profileName")).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEYS.PROFILE)).toBeNull();
     expect(contextValue.profile).toBeNull();
   });
 });

--- a/web/src/lib/storage.js
+++ b/web/src/lib/storage.js
@@ -1,0 +1,59 @@
+/**
+ * Centralized browser storage keys for the Blackfish frontend.
+ *
+ * All keys use a `bf:` prefix with topic sub-namespaces (e.g.
+ * `bf:tg:chat:messages`) so they don't collide with other apps sharing the
+ * origin during development and are self-documenting in devtools. New
+ * persisted state should add a key here rather than inlining a string.
+ */
+export const STORAGE_KEYS = {
+  // localStorage
+  PROFILE: "bf:profile",
+  THEME: "bf:theme",
+
+  // sessionStorage (text-generation)
+  TG_CHAT_SYSTEM_MESSAGE: "bf:tg:chat:systemMessage",
+  TG_CHAT_USER_MESSAGE: "bf:tg:chat:userMessage",
+  TG_CHAT_MESSAGES: "bf:tg:chat:messages",
+  TG_COMPLETION_INPUT: "bf:tg:completion:input",
+  TG_COMPLETION_OUTPUT: "bf:tg:completion:output",
+};
+
+/**
+ * One-time mapping from the legacy (un-prefixed) keys to their `bf:`-prefixed
+ * replacements. Used by {@link migrateStorageKeys} on app boot.
+ */
+const LEGACY_KEY_MIGRATIONS = [
+  { area: "local", from: "profileName", to: STORAGE_KEYS.PROFILE },
+  { area: "local", from: "theme", to: STORAGE_KEYS.THEME },
+  { area: "session", from: "tgcc-sm", to: STORAGE_KEYS.TG_CHAT_SYSTEM_MESSAGE },
+  { area: "session", from: "tgcc-um", to: STORAGE_KEYS.TG_CHAT_USER_MESSAGE },
+  { area: "session", from: "tgcc-ml", to: STORAGE_KEYS.TG_CHAT_MESSAGES },
+  { area: "session", from: "tgci", to: STORAGE_KEYS.TG_COMPLETION_INPUT },
+  { area: "session", from: "tgco", to: STORAGE_KEYS.TG_COMPLETION_OUTPUT },
+];
+
+/**
+ * Migrate any legacy storage keys to their `bf:`-prefixed equivalents.
+ *
+ * For each legacy key, the value is copied to the new key (only if the new key
+ * isn't already set, so a re-run never clobbers fresh data) and the legacy key
+ * is removed. Safe to call multiple times and a no-op once migration is done.
+ */
+export function migrateStorageKeys() {
+  if (typeof window === "undefined") return;
+
+  for (const { area, from, to } of LEGACY_KEY_MIGRATIONS) {
+    const store = area === "local" ? window.localStorage : window.sessionStorage;
+    try {
+      const oldValue = store.getItem(from);
+      if (oldValue === null) continue;
+      if (store.getItem(to) === null) {
+        store.setItem(to, oldValue);
+      }
+      store.removeItem(from);
+    } catch (error) {
+      console.error(`Failed to migrate storage key "${from}" -> "${to}"`, error);
+    }
+  }
+}

--- a/web/src/lib/storage.test.js
+++ b/web/src/lib/storage.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { STORAGE_KEYS, migrateStorageKeys } from "@/lib/storage";
+
+// Map-backed storage so get/set/remove round-trip in tests (the global
+// sessionStorage mock from setup.js is a no-op).
+const createStorageMock = () => {
+  const store = new Map();
+  return {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => store.set(key, String(value)),
+    removeItem: (key) => store.delete(key),
+    clear: () => store.clear(),
+  };
+};
+
+describe("migrateStorageKeys", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      value: createStorageMock(),
+      writable: true,
+    });
+    Object.defineProperty(window, "sessionStorage", {
+      value: createStorageMock(),
+      writable: true,
+    });
+  });
+
+  it("moves legacy localStorage keys to the bf: scheme", () => {
+    localStorage.setItem("profileName", "my-profile");
+    localStorage.setItem("theme", "dark");
+
+    migrateStorageKeys();
+
+    expect(localStorage.getItem(STORAGE_KEYS.PROFILE)).toBe("my-profile");
+    expect(localStorage.getItem(STORAGE_KEYS.THEME)).toBe("dark");
+    expect(localStorage.getItem("profileName")).toBeNull();
+    expect(localStorage.getItem("theme")).toBeNull();
+  });
+
+  it("moves legacy sessionStorage keys to the bf: scheme", () => {
+    sessionStorage.setItem("tgcc-sm", "system");
+    sessionStorage.setItem("tgcc-um", "user");
+    sessionStorage.setItem("tgcc-ml", "[]");
+    sessionStorage.setItem("tgci", "in");
+    sessionStorage.setItem("tgco", "out");
+
+    migrateStorageKeys();
+
+    expect(sessionStorage.getItem(STORAGE_KEYS.TG_CHAT_SYSTEM_MESSAGE)).toBe("system");
+    expect(sessionStorage.getItem(STORAGE_KEYS.TG_CHAT_USER_MESSAGE)).toBe("user");
+    expect(sessionStorage.getItem(STORAGE_KEYS.TG_CHAT_MESSAGES)).toBe("[]");
+    expect(sessionStorage.getItem(STORAGE_KEYS.TG_COMPLETION_INPUT)).toBe("in");
+    expect(sessionStorage.getItem(STORAGE_KEYS.TG_COMPLETION_OUTPUT)).toBe("out");
+
+    expect(sessionStorage.getItem("tgcc-sm")).toBeNull();
+    expect(sessionStorage.getItem("tgci")).toBeNull();
+  });
+
+  it("does not clobber an existing new-scheme value", () => {
+    localStorage.setItem("theme", "light");
+    localStorage.setItem(STORAGE_KEYS.THEME, "dark");
+
+    migrateStorageKeys();
+
+    // The already-migrated value wins; the legacy key is still cleaned up.
+    expect(localStorage.getItem(STORAGE_KEYS.THEME)).toBe("dark");
+    expect(localStorage.getItem("theme")).toBeNull();
+  });
+
+  it("is a no-op when there is nothing to migrate", () => {
+    migrateStorageKeys();
+
+    expect(localStorage.getItem(STORAGE_KEYS.PROFILE)).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEYS.TG_CHAT_MESSAGES)).toBeNull();
+  });
+});

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -2,7 +2,12 @@
   import ReactDOM from 'react-dom/client';
   import { RouterProvider } from 'react-router-dom';
   import { router } from './router';
+  import { migrateStorageKeys } from './lib/storage';
   import './index.css';
+
+  // Move any legacy (un-prefixed) browser storage keys to the `bf:` scheme
+  // before the app reads them.
+  migrateStorageKeys();
 
   ReactDOM.createRoot(document.getElementById('root')).render(
     <React.StrictMode>

--- a/web/src/providers/ThemeProvider.jsx
+++ b/web/src/providers/ThemeProvider.jsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState } from "react";
+import { STORAGE_KEYS } from "@/lib/storage";
 import PropTypes from "prop-types";
 
 const ThemeContext = createContext();
@@ -14,7 +15,7 @@ function ThemeProvider({ children }) {
   // theme can be "light", "dark", or "system"
   const [theme, setThemeState] = useState(() => {
     if (typeof window !== "undefined") {
-      const stored = localStorage.getItem("theme");
+      const stored = localStorage.getItem(STORAGE_KEYS.THEME);
       if (stored === "light" || stored === "dark" || stored === "system") {
         return stored;
       }
@@ -43,7 +44,7 @@ function ThemeProvider({ children }) {
     } else {
       document.documentElement.classList.remove("dark");
     }
-    localStorage.setItem("theme", theme);
+    localStorage.setItem(STORAGE_KEYS.THEME, theme);
   }, [isDark, theme]);
 
   const setTheme = (newTheme) => {

--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
@@ -14,6 +14,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { ServiceContext } from "@/providers/ServiceProvider";
 import { ProfileContext } from "@/components/ProfileSelect";
+import { STORAGE_KEYS } from "@/lib/storage";
 import { streamChatCompletionInference } from "../lib/requests";
 import {
   fileToBase64,
@@ -584,7 +585,7 @@ Message.propTypes = {
  */
 function MessageList({ messages, setMessages, handleResubmit, elementRef, isWaitingForResponse, canRegenerate }) {
   try {
-    sessionStorage.setItem("tgcc-ml", JSON.stringify(messages));
+    sessionStorage.setItem(STORAGE_KEYS.TG_CHAT_MESSAGES, JSON.stringify(messages));
   } catch (error) {
     console.error(error);
   };
@@ -676,13 +677,13 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
   const { selectedService } = useContext(ServiceContext);
   const { profile } = useContext(ProfileContext);
   const isServiceHealthy = selectedService?.status === ServiceStatus.HEALTHY;
-  const storedMessages = sessionStorage.getItem("tgcc-ml");
+  const storedMessages = sessionStorage.getItem(STORAGE_KEYS.TG_CHAT_MESSAGES);
   const [messages, setMessages] = useState(
     storedMessages ? JSON.parse(storedMessages) : []
   );
   const [userMessage, setUserMessage] = useState({
     role: Role.USER,
-    content: sessionStorage.getItem("tgcc-um") || "",
+    content: sessionStorage.getItem(STORAGE_KEYS.TG_CHAT_USER_MESSAGE) || "",
   });
   const [attachedImages, setAttachedImages] = useState([]);
   const [imageBrowserOpen, setImageBrowserOpen] = useState(false);
@@ -810,7 +811,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
 
     // Clear input and attached items after sending
     setUserMessage({ role: Role.USER, content: "" });
-    sessionStorage.removeItem("tgcc-um");
+    sessionStorage.removeItem(STORAGE_KEYS.TG_CHAT_USER_MESSAGE);
     setAttachedImages([]);
     clearFiles();
 
@@ -872,7 +873,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
         return prev;
       });
       setUserMessage({ role: Role.USER, content: savedInput });
-      sessionStorage.setItem("tgcc-um", savedInput);
+      sessionStorage.setItem(STORAGE_KEYS.TG_CHAT_USER_MESSAGE, savedInput);
       setApiError(classifyApiError(error));
     } finally {
       setIsWaitingForResponse(false);
@@ -963,7 +964,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
       ...userMessage,
       content: value
     });
-    sessionStorage.setItem("tgcc-um", value);
+    sessionStorage.setItem(STORAGE_KEYS.TG_CHAT_USER_MESSAGE, value);
   }
 
   function handleClearConversation() {
@@ -975,8 +976,8 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
     setIsWaitingForResponse(false);
     setIsStreaming(false);
     setApiError(null);
-    sessionStorage.removeItem("tgcc-ml");
-    sessionStorage.removeItem("tgcc-um");
+    sessionStorage.removeItem(STORAGE_KEYS.TG_CHAT_MESSAGES);
+    sessionStorage.removeItem(STORAGE_KEYS.TG_CHAT_USER_MESSAGE);
   }
 
   /**
@@ -1023,7 +1024,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
       <UserMessageInput
         message={userMessage.content ? userMessage : {
           ...userMessage,
-          content: sessionStorage.getItem("tgcc-um")
+          content: sessionStorage.getItem(STORAGE_KEYS.TG_CHAT_USER_MESSAGE)
         }}
         onChange={(event) => handleUserMessageChange(event.target.value)}
         onSubmit={handleSubmit}

--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.test.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.test.jsx
@@ -8,6 +8,7 @@ import { ServiceContext } from "@/providers/ServiceProvider";
 import { ProfileContext } from "@/components/ProfileSelect";
 import { streamChatCompletionInference } from "../lib/requests";
 import { ServiceStatus } from "@/lib/util";
+import { STORAGE_KEYS } from "@/lib/storage";
 
 vi.mock("../lib/requests", () => ({
   streamChatCompletionInference: vi.fn(),
@@ -612,7 +613,7 @@ describe("TextGenerationChatContainer", () => {
         { role: "assistant", content: "Original response" },
       ]);
       sessionStorage.getItem.mockImplementation((key) => {
-        if (key === "tgcc-ml") return storedMessages;
+        if (key === STORAGE_KEYS.TG_CHAT_MESSAGES) return storedMessages;
         return null;
       });
       const {getByRole, getByText} = render(

--- a/web/src/routes/text-generation/components/TextGenerationCompletionContainer.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationCompletionContainer.jsx
@@ -21,6 +21,7 @@ import FileAttachmentList from "./FileAttachmentList";
 import FileSelectModal from "@/components/FileSelectModal";
 import Notification from "@/components/Notification";
 import { ServiceStatus } from "@/lib/util";
+import { STORAGE_KEYS } from "@/lib/storage";
 import PropTypes from "prop-types";
 
 
@@ -59,7 +60,7 @@ function TextGenerationPromptInput({
    */
   function handleChange(value) {
     setPrompt(value || "");
-    sessionStorage.setItem("tgci", value || "");
+    sessionStorage.setItem(STORAGE_KEYS.TG_COMPLETION_INPUT, value || "");
   }
 
   return (
@@ -179,7 +180,7 @@ function TextGenerationResponseOutput({
 }) {
   if (content && content.length > 0) {
     try {
-      sessionStorage.setItem("tgco", content);
+      sessionStorage.setItem(STORAGE_KEYS.TG_COMPLETION_OUTPUT, content);
     } catch(error) {
       console.error(error);
     };
@@ -233,10 +234,10 @@ function TextGenerationCompletionContainer({ parameters, toolbar }) {
   const { selectedService } = useContext(ServiceContext);
   const { profile } = useContext(ProfileContext);
   const [prompt, setPrompt] = useState(
-    sessionStorage.getItem("tgci") || ""
+    sessionStorage.getItem(STORAGE_KEYS.TG_COMPLETION_INPUT) || ""
   );
   const [response, setResponse] = useState(
-    sessionStorage.getItem("tgco") || ""
+    sessionStorage.getItem(STORAGE_KEYS.TG_COMPLETION_OUTPUT) || ""
   );
   const [isLoading, setIsLoading] = useState(false);
 
@@ -262,7 +263,7 @@ function TextGenerationCompletionContainer({ parameters, toolbar }) {
 
     setIsLoading(true);
     setResponse("");
-    sessionStorage.setItem("tgco", "");
+    sessionStorage.setItem(STORAGE_KEYS.TG_COMPLETION_OUTPUT, "");
 
     const stream = streamCompletionInference(
       selectedService,

--- a/web/src/routes/text-generation/text-generation.jsx
+++ b/web/src/routes/text-generation/text-generation.jsx
@@ -13,6 +13,7 @@ import {
   CodeBracketIcon,
 } from "@heroicons/react/24/outline";
 
+import { STORAGE_KEYS } from "@/lib/storage";
 import { Page } from "@/components/Page";
 import { TaskContainer } from "@/components/TaskContainer";
 import { SidebarContainer } from "@/components/SidebarContainer";
@@ -207,12 +208,12 @@ export default function TextGenerationPage() {
   // System message state (for Chat mode)
   const [systemMessage, setSystemMessage] = useState({
     role: "system",
-    content: sessionStorage.getItem("tgcc-sm") || "",
+    content: sessionStorage.getItem(STORAGE_KEYS.TG_CHAT_SYSTEM_MESSAGE) || "",
   });
 
   const handleSystemMessageChange = (value) => {
     setSystemMessage((prev) => ({ ...prev, content: value }));
-    sessionStorage.setItem("tgcc-sm", value);
+    sessionStorage.setItem(STORAGE_KEYS.TG_CHAT_SYSTEM_MESSAGE, value);
   };
 
   const [isReady, setIsReady] = useState(false);


### PR DESCRIPTION
## Summary

- Adopt a consistent `bf:` prefix with topic sub-namespaces for all `localStorage`/`sessionStorage` keys, centralized in a new `web/src/lib/storage.js` module (`STORAGE_KEYS`). This avoids dev-time collisions on the same origin and makes devtools inspection self-documenting.
- Add a one-time read-old-write-new migration (`migrateStorageKeys`) run on app boot in `main.jsx`, so existing theme/profile/text-generation state carries over without users losing selections. The migration won't clobber an already-migrated value and is safe to re-run.
- Update all call sites (profile, theme, text-generation chat/completion) to reference `STORAGE_KEYS` instead of inline strings.

Key renames:

| Legacy key | New key |
|---|---|
| `profileName` (localStorage) | `bf:profile` |
| `theme` | `bf:theme` |
| `tgcc-sm` | `bf:tg:chat:systemMessage` |
| `tgcc-um` | `bf:tg:chat:userMessage` |
| `tgcc-ml` | `bf:tg:chat:messages` |
| `tgci` | `bf:tg:completion:input` |
| `tgco` | `bf:tg:completion:output` |

Out of scope (per the issue): extracting a `useLocalStorage`/`useSessionStorage` hook and adding a schema version to the chat message blob — both better as separate follow-ups.

## Test plan
- [x] With legacy keys present in storage, load the app and confirm theme/profile/text-generation state persists under the new `bf:`-prefixed keys and the old keys are removed.

Closes #284