### PR TITLE
feat(web): add cancel button for in-flight chat completions

### DIFF
--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
@@ -88,7 +88,7 @@ function classifyApiError(error) {
  * @param {Function} options.onImageRemoteSelect
  * @param {Function} options.onFileBrowserUpload
  * @param {Function} options.onFileRemoteSelect
- * @param {boolean} options.isServiceHealthy
+ * @param {boolean} options.canSubmit
  * @param {boolean} options.isStreaming
  * @param {Function} options.onStop
  * @return {JSX.Element}
@@ -109,16 +109,10 @@ function UserMessageInput({
   onImageRemoteSelect,
   onFileBrowserUpload,
   onFileRemoteSelect,
-  isServiceHealthy,
+  canSubmit,
   isStreaming,
   onStop,
 }) {
-  const hasMessageContent = Boolean(
-    (message && message.content && message.content.length > 0) ||
-    attachedImages.length > 0 ||
-    attachedFiles.length > 0
-  );
-  const canSubmit = isServiceHealthy && hasMessageContent;
 
   return (
     <div className="flex items-start space-x-4 mt-auto pt-4">
@@ -163,7 +157,7 @@ function UserMessageInput({
                   return;
                 } else if (event.key === "Enter") {
                   event.preventDefault();
-                  if (canSubmit && !isStreaming) {
+                  if (canSubmit) {
                     onSubmit(event);
                   }
                 }
@@ -251,7 +245,7 @@ UserMessageInput.propTypes = {
   onImageRemoteSelect: PropTypes.func,
   onFileBrowserUpload: PropTypes.func,
   onFileRemoteSelect: PropTypes.func,
-  isServiceHealthy: PropTypes.bool,
+  canSubmit: PropTypes.bool,
   isStreaming: PropTypes.bool,
   onStop: PropTypes.func,
 };
@@ -754,14 +748,15 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
   }, []);
 
   
+  const hasUserInput =
+    userMessage.content.length > 0 ||
+    attachedImages.length > 0 ||
+    attachedFiles.length > 0;
+  const canSubmit = isServiceHealthy && hasUserInput && !isStreaming;
+
   const handleSubmit = async (event) => {
     event.preventDefault();
-    const hasUserInput = Boolean(
-      userMessage.content.length > 0 ||
-      attachedImages.length > 0 ||
-      attachedFiles.length > 0
-    );
-    if (!isServiceHealthy || !hasUserInput || isStreaming) return;
+    if (!canSubmit) return;
 
     console.debug("user message submitted");
 
@@ -1044,7 +1039,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
         onImageRemoteSelect={() => setImageBrowserOpen(true)}
         onFileBrowserUpload={handleFileBrowserUpload}
         onFileRemoteSelect={() => setFileBrowserOpen(true)}
-        isServiceHealthy={isServiceHealthy}
+        canSubmit={canSubmit}
         isStreaming={isStreaming}
         onStop={handleStop}
       />

--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
@@ -7,6 +7,7 @@ import {
   DocumentTextIcon,
   PaperAirplaneIcon,
   PencilIcon,
+  StopIcon,
   TrashIcon,
   XMarkIcon,
   PhotoIcon,
@@ -88,6 +89,8 @@ function classifyApiError(error) {
  * @param {Function} options.onFileBrowserUpload
  * @param {Function} options.onFileRemoteSelect
  * @param {boolean} options.isServiceHealthy
+ * @param {boolean} options.isStreaming
+ * @param {Function} options.onStop
  * @return {JSX.Element}
  */
 function UserMessageInput({
@@ -107,6 +110,8 @@ function UserMessageInput({
   onFileBrowserUpload,
   onFileRemoteSelect,
   isServiceHealthy,
+  isStreaming,
+  onStop,
 }) {
   const hasMessageContent = Boolean(
     (message && message.content && message.content.length > 0) ||
@@ -158,7 +163,7 @@ function UserMessageInput({
                   return;
                 } else if (event.key === "Enter") {
                   event.preventDefault();
-                  if (canSubmit) {
+                  if (canSubmit && !isStreaming) {
                     onSubmit(event);
                   }
                 }
@@ -203,14 +208,26 @@ function UserMessageInput({
               </div>
             </div>
             <div className="shrink-0">
-              <button
-                type="submit"
-                disabled={!canSubmit}
-                className="inline-flex items-center rounded-full bg-white dark:bg-gray-600 p-2 text-sm font-semibold text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-500 shadow-sm hover:bg-gray-100 dark:hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600 disabled:text-gray-400 disabled:opacity-50 disabled:hover:bg-white dark:disabled:hover:bg-gray-600 disabled:border-gray-200 dark:disabled:border-gray-600 disabled:shadow-none"
-              >
-                <PaperAirplaneIcon className="size-5" />
-                <span className="sr-only">Submit</span>
-              </button>
+              {isStreaming ? (
+                <button
+                  type="button"
+                  onClick={onStop}
+                  className="inline-flex items-center rounded-full bg-white dark:bg-gray-600 p-2 text-sm font-semibold text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-500 shadow-sm hover:bg-gray-100 dark:hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600"
+                  aria-label="Stop generating"
+                >
+                  <StopIcon className="size-5" />
+                  <span className="sr-only">Stop</span>
+                </button>
+              ) : (
+                <button
+                  type="submit"
+                  disabled={!canSubmit}
+                  className="inline-flex items-center rounded-full bg-white dark:bg-gray-600 p-2 text-sm font-semibold text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-500 shadow-sm hover:bg-gray-100 dark:hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600 disabled:text-gray-400 disabled:opacity-50 disabled:hover:bg-white dark:disabled:hover:bg-gray-600 disabled:border-gray-200 dark:disabled:border-gray-600 disabled:shadow-none"
+                >
+                  <PaperAirplaneIcon className="size-5" />
+                  <span className="sr-only">Submit</span>
+                </button>
+              )}
             </div>
           </div>
         </form>
@@ -236,6 +253,8 @@ UserMessageInput.propTypes = {
   onFileBrowserUpload: PropTypes.func,
   onFileRemoteSelect: PropTypes.func,
   isServiceHealthy: PropTypes.bool,
+  isStreaming: PropTypes.bool,
+  onStop: PropTypes.func,
 };
 
 /**
@@ -677,6 +696,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
   const [imageError, setImageError] = useState(null);
   const [apiError, setApiError] = useState(null);
   const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
+  const [isStreaming, setIsStreaming] = useState(false);
   const abortRef = useRef(null);
 
   // File attachment state and handlers
@@ -742,7 +762,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
       attachedImages.length > 0 ||
       attachedFiles.length > 0
     );
-    if (!isServiceHealthy || !hasUserInput) return;
+    if (!isServiceHealthy || !hasUserInput || isStreaming) return;
 
     console.debug("user message submitted");
 
@@ -802,6 +822,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
 
     // Show loading state while waiting for first response chunk
     setIsWaitingForResponse(true);
+    setIsStreaming(true);
 
     try {
       abortRef.current = new AbortController();
@@ -845,10 +866,10 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
         ]);
       }
     } catch (error) {
-      // handleClearConversation already reset state; skip rollback
+      // Aborts (cancel button or conversation clear) leave the partial
+      // assistant turn in place; skip rollback and error reporting.
       if (error.name === "AbortError") return;
       console.error("Chat submission error:", error);
-      setIsWaitingForResponse(false);
       // Roll back the optimistically-added user message if no assistant response was started
       setMessages((prev) => {
         if (prev.length > 0 && prev[prev.length - 1].role === Role.USER) {
@@ -859,6 +880,9 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
       setUserMessage({ role: Role.USER, content: savedInput });
       sessionStorage.setItem("tgcc-um", savedInput);
       setApiError(classifyApiError(error));
+    } finally {
+      setIsWaitingForResponse(false);
+      setIsStreaming(false);
     }
   };
 
@@ -880,6 +904,7 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
 
     // Show loading state while waiting for first response chunk
     setIsWaitingForResponse(true);
+    setIsStreaming(true);
 
     try {
       abortRef.current = new AbortController();
@@ -923,12 +948,15 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
         ]);
       }
     } catch (error) {
-      // handleClearConversation already reset state; skip rollback
+      // Aborts (cancel button or conversation clear) leave the partial
+      // assistant turn in place; skip rollback and error reporting.
       if (error.name === "AbortError") return;
       console.error("Chat resubmit error:", error);
-      setIsWaitingForResponse(false);
       setMessages(savedMessages.slice(0, index + 1));
       setApiError(classifyApiError(error));
+    } finally {
+      setIsWaitingForResponse(false);
+      setIsStreaming(false);
     }
   };
 
@@ -951,9 +979,20 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
     setUserMessage({ role: Role.USER, content: "" });
     setAttachedImages([]);
     setIsWaitingForResponse(false);
+    setIsStreaming(false);
     setApiError(null);
     sessionStorage.removeItem("tgcc-ml");
     sessionStorage.removeItem("tgcc-um");
+  }
+
+  /**
+   * Cancel an in-flight chat completion mid-stream. Aborts the active request
+   * and leaves the partial assistant message in place as a finalized turn.
+   */
+  function handleStop() {
+    abortRef.current?.abort();
+    setIsWaitingForResponse(false);
+    setIsStreaming(false);
   }
 
   return (
@@ -1005,6 +1044,8 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
         onFileBrowserUpload={handleFileBrowserUpload}
         onFileRemoteSelect={() => setFileBrowserOpen(true)}
         isServiceHealthy={isServiceHealthy}
+        isStreaming={isStreaming}
+        onStop={handleStop}
       />
 
       {/* Image file browser modal */}

--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.jsx
@@ -213,10 +213,9 @@ function UserMessageInput({
                   type="button"
                   onClick={onStop}
                   className="inline-flex items-center rounded-full bg-white dark:bg-gray-600 p-2 text-sm font-semibold text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-500 shadow-sm hover:bg-gray-100 dark:hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600"
-                  aria-label="Stop generating"
                 >
                   <StopIcon className="size-5" />
-                  <span className="sr-only">Stop</span>
+                  <span className="sr-only">Stop generating</span>
                 </button>
               ) : (
                 <button
@@ -991,6 +990,8 @@ export default function TextGenerationChatContainer({ parameters, systemMessage,
    */
   function handleStop() {
     abortRef.current?.abort();
+    // Reset eagerly so the UI responds immediately; the finally block in the
+    // submit/resubmit handlers mirrors this once the abort propagates.
     setIsWaitingForResponse(false);
     setIsStreaming(false);
   }

--- a/web/src/routes/text-generation/components/TextGenerationChatContainer.test.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationChatContainer.test.jsx
@@ -44,6 +44,9 @@ vi.mock("@heroicons/react/24/outline", () => ({
   PencilIcon: ({ className, ...props }) => {
     return <div data-testid="pencil-icon" className={className} {...props} />;
   },
+  StopIcon: ({ className, ...props }) => {
+    return <div data-testid="stop-icon" className={className} {...props} />;
+  },
   XCircleIcon: ({ className, ...props }) => {
     return <div data-testid="x-circle-icon" className={className} {...props} />;
   },
@@ -510,6 +513,50 @@ describe("TextGenerationChatContainer", () => {
         expect(queryByText("Partial response")).not.toBeInTheDocument();
         expect(queryByText("Test message")).not.toBeInTheDocument();
       });
+    });
+
+    it("shows a Stop control while streaming and cancels the in-flight response", async () => {
+      const user = userEvent.setup();
+      const abortError = new DOMException("The operation was aborted.", "AbortError");
+      let abortSignal;
+      const mockStream = {
+        next: vi.fn().mockResolvedValue({
+          value: [{ choices: [{ delta: { content: "Partial response" } }] }]
+        }),
+        [Symbol.asyncIterator]: vi.fn().mockReturnValue({
+          // Mimic fetch: the next chunk never arrives until the request is aborted.
+          next: () =>
+            new Promise((_, reject) => {
+              abortSignal?.addEventListener("abort", () => reject(abortError));
+            })
+        })
+      };
+      streamChatCompletionInference.mockImplementation(
+        (service, messages, params, useProxy, signal) => {
+          abortSignal = signal;
+          return mockStream;
+        }
+      );
+      const { getByPlaceholderText, getByRole, queryByText } = render(
+        <MockProviders>
+          <TextGenerationChatContainer parameters={{}} systemMessage={{ role: "system", content: "" }} />
+        </MockProviders>
+      );
+      const textarea = getByPlaceholderText("Why are orcas so awesome?");
+      await user.type(textarea, "Test message");
+      await user.click(getByRole("button", { name: "Submit" }));
+      // Partial response streams in and the Stop control replaces Submit.
+      await waitFor(() => {
+        expect(queryByText("Partial response")).toBeInTheDocument();
+      });
+      const stopButton = getByRole("button", { name: "Stop generating" });
+      await user.click(stopButton);
+      // Control reverts to Submit and the partial turn is preserved.
+      await waitFor(() => {
+        expect(getByRole("button", { name: "Submit" })).toBeInTheDocument();
+      });
+      expect(queryByText("Partial response")).toBeInTheDocument();
+      expect(queryByText("Test message")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

- Surface a **Stop** control in the chat input while a response is streaming; clicking it aborts the in-flight request via the existing `AbortController` plumbing (from #227) and resets the streaming state.
- The partial assistant message is left in place as a finalized turn — no ghost messages and no rollback on cancel.
- Track an `isStreaming` flag for the full request lifecycle (distinct from the first-chunk spinner), swap Submit ↔ Stop accordingly, block Enter-to-submit while streaming, and move streaming-state cleanup into `finally` blocks so cancel/clear/error/success all reset consistently.

## Test plan

- [x] Manually start a chat completion, click Stop mid-stream, confirm the partial response remains and the input is ready for the next message.

Closes #311