### PR TITLE
fix(lib,web): enable file uploads for all profile types

### DIFF
--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -264,7 +264,7 @@ def _get_validated_remote_profile(profile_name: str) -> SlurmProfile:
 
     Raises:
         NotFoundException: If profile doesn't exist
-        ValidationException: If profile is not a remote SlurmProfile
+        ValidationException: If profile is not a remote profile
     """
     try:
         profile = deserialize_profile(blackfish_config.HOME_DIR, profile_name)

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -253,7 +253,7 @@ async def get_batch_job(job_id: str, session: AsyncSession) -> BatchJob | None:
         return None
 
 
-def _get_validated_slurm_profile(profile_name: str) -> SlurmProfile:
+def _get_validated_remote_profile(profile_name: str) -> SlurmProfile:
     """Get and validate a profile for remote SFTP operations.
 
     Args:
@@ -605,7 +605,7 @@ async def upload_image(
         raise ValidationException(f"Pillow detected invalid image data: {e}")
 
     if profile is not None:
-        remote_profile = _get_validated_slurm_profile(profile)
+        remote_profile = _get_validated_remote_profile(profile)
         logger.debug(f"Uploading image to remote profile {profile}: {data.path}")
         response = sftp.write_file(remote_profile, data.path, content, update=False)
         return FileUploadResponse(
@@ -629,7 +629,7 @@ async def get_image(path: str, profile: Optional[str] = None) -> File | Stream:
 
     if profile is not None:
         validate_file_extension(Path(path), IMAGE_EXTENSIONS)
-        remote_profile = _get_validated_slurm_profile(profile)
+        remote_profile = _get_validated_remote_profile(profile)
         logger.debug(f"Streaming image from remote profile {profile}: {path}")
 
         # Get file size and streaming generator
@@ -698,7 +698,7 @@ async def update_image(
         raise ValidationException(f"Pillow detected invalid image data: {e}")
 
     if profile is not None:
-        remote_profile = _get_validated_slurm_profile(profile)
+        remote_profile = _get_validated_remote_profile(profile)
         logger.debug(f"Updating image on remote profile {profile}: {data.path}")
         response = sftp.write_file(remote_profile, data.path, content, update=True)
         return FileUploadResponse(
@@ -722,7 +722,7 @@ async def delete_image(path: str, profile: Optional[str] = None) -> Path | str:
     # Remote delete
     if profile is not None:
         validate_file_extension(Path(path), IMAGE_EXTENSIONS)
-        remote_profile = _get_validated_slurm_profile(profile)
+        remote_profile = _get_validated_remote_profile(profile)
         logger.debug(f"Deleting image on remote profile {profile}: {path}")
         return sftp.delete_file(remote_profile, path)
 
@@ -763,7 +763,7 @@ async def upload_text(
         raise ValidationException(f"File contains invalid UTF-8 text data: {e}")
 
     if profile is not None:
-        remote_profile = _get_validated_slurm_profile(profile)
+        remote_profile = _get_validated_remote_profile(profile)
         logger.debug(f"Uploading text file to remote profile {profile}: {data.path}")
         response = sftp.write_file(remote_profile, data.path, content, update=False)
         return FileUploadResponse(
@@ -786,7 +786,7 @@ async def get_text(path: str, profile: Optional[str] = None) -> File | Response[
     """Retrieve a text file from the specified path."""
 
     if profile is not None:
-        remote_profile = _get_validated_slurm_profile(profile)
+        remote_profile = _get_validated_remote_profile(profile)
         logger.debug(f"Downloading text file from remote profile {profile}: {path}")
         content = sftp.read_file(remote_profile, path)
 
@@ -849,7 +849,7 @@ async def update_text(
         raise ValidationException(f"File contains invalid UTF-8 text data: {e}")
 
     if profile is not None:
-        remote_profile = _get_validated_slurm_profile(profile)
+        remote_profile = _get_validated_remote_profile(profile)
         logger.debug(f"Updating text file on remote profile {profile}: {data.path}")
         response = sftp.write_file(remote_profile, data.path, content, update=True)
         return FileUploadResponse(
@@ -871,7 +871,7 @@ async def delete_text(path: str, profile: Optional[str] = None) -> Path | str:
     """Delete a text file at the specified path."""
 
     if profile is not None:
-        remote_profile = _get_validated_slurm_profile(profile)
+        remote_profile = _get_validated_remote_profile(profile)
         logger.debug(f"Deleting text file on remote profile {profile}: {path}")
         return sftp.delete_file(remote_profile, path)
 
@@ -906,7 +906,7 @@ async def upload_audio(
     validate_file_size(content, state.MAX_FILE_SIZE)
 
     if profile is not None:
-        remote_profile = _get_validated_slurm_profile(profile)
+        remote_profile = _get_validated_remote_profile(profile)
         logger.debug(f"Uploading audio file to remote profile {profile}: {data.path}")
         response = sftp.write_file(remote_profile, data.path, content, update=False)
         return FileUploadResponse(
@@ -930,7 +930,7 @@ async def get_audio(path: str, profile: Optional[str] = None) -> File | Response
 
     if profile is not None:
         validate_file_extension(Path(path), AUDIO_EXTENSIONS)
-        remote_profile = _get_validated_slurm_profile(profile)
+        remote_profile = _get_validated_remote_profile(profile)
         logger.debug(f"Downloading audio file from remote profile {profile}: {path}")
         content = sftp.read_file(remote_profile, path)
 
@@ -974,7 +974,7 @@ async def update_audio(
     validate_file_size(content, state.MAX_FILE_SIZE)
 
     if profile is not None:
-        remote_profile = _get_validated_slurm_profile(profile)
+        remote_profile = _get_validated_remote_profile(profile)
         logger.debug(f"Updating audio file on remote profile {profile}: {data.path}")
         response = sftp.write_file(remote_profile, data.path, content, update=True)
         return FileUploadResponse(
@@ -997,7 +997,7 @@ async def delete_audio(path: str, profile: Optional[str] = None) -> Path | str:
 
     if profile is not None:
         validate_file_extension(Path(path), AUDIO_EXTENSIONS)
-        remote_profile = _get_validated_slurm_profile(profile)
+        remote_profile = _get_validated_remote_profile(profile)
         logger.debug(f"Deleting audio file on remote profile {profile}: {path}")
         return sftp.delete_file(remote_profile, path)
 

--- a/lib/tests/api/test_sftp_api.py
+++ b/lib/tests/api/test_sftp_api.py
@@ -50,7 +50,7 @@ class TestRemoteImageUpload:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ) as mock_get_profile,
             mock.patch(
@@ -80,7 +80,7 @@ class TestRemoteImageUpload:
         invalid_data = b"This is not an image"
 
         with mock.patch(
-            "blackfish.server.asgi._get_validated_slurm_profile"
+            "blackfish.server.asgi._get_validated_remote_profile"
         ) as mock_get_profile:
             response = await client.post(
                 "/api/image",
@@ -109,7 +109,7 @@ class TestRemoteImageDownload:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ) as mock_get_profile,
             mock.patch(
@@ -147,7 +147,7 @@ class TestRemoteImageUpdate:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ) as mock_get_profile,
             mock.patch(
@@ -181,7 +181,7 @@ class TestRemoteImageDelete:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ) as mock_get_profile,
             mock.patch(
@@ -217,7 +217,7 @@ class TestRemoteTextUpload:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ) as mock_get_profile,
             mock.patch(
@@ -252,7 +252,7 @@ class TestRemoteTextDownload:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ) as mock_get_profile,
             mock.patch(
@@ -279,7 +279,7 @@ class TestRemoteTextDownload:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ),
             mock.patch(
@@ -313,7 +313,7 @@ class TestRemoteTextUpdate:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ) as mock_get_profile,
             mock.patch(
@@ -345,7 +345,7 @@ class TestRemoteTextDelete:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ) as mock_get_profile,
             mock.patch(
@@ -382,7 +382,7 @@ class TestRemoteAudioUpload:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ) as mock_get_profile,
             mock.patch(
@@ -417,7 +417,7 @@ class TestRemoteAudioDownload:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ) as mock_get_profile,
             mock.patch(
@@ -444,7 +444,7 @@ class TestRemoteAudioDownload:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ),
             mock.patch(
@@ -478,7 +478,7 @@ class TestRemoteAudioUpdate:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ) as mock_get_profile,
             mock.patch(
@@ -510,7 +510,7 @@ class TestRemoteAudioDelete:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ) as mock_get_profile,
             mock.patch(
@@ -539,7 +539,7 @@ class TestRemoteFileErrorHandling:
         png_bytes = create_test_png()
 
         with mock.patch(
-            "blackfish.server.asgi._get_validated_slurm_profile",
+            "blackfish.server.asgi._get_validated_remote_profile",
             side_effect=NotFoundException("Profile 'nonexistent' not found"),
         ):
             response = await client.post(
@@ -561,7 +561,7 @@ class TestRemoteFileErrorHandling:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ),
             mock.patch(
@@ -589,7 +589,7 @@ class TestRemoteFileErrorHandling:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ),
             mock.patch(
@@ -614,7 +614,7 @@ class TestRemoteFileErrorHandling:
 
         with (
             mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile",
+                "blackfish.server.asgi._get_validated_remote_profile",
                 return_value=remote_profile,
             ),
             mock.patch(
@@ -644,7 +644,7 @@ class TestLocalFallback:
             file_path = os.path.join(temp_dir, "test.png")
 
             with mock.patch(
-                "blackfish.server.asgi._get_validated_slurm_profile"
+                "blackfish.server.asgi._get_validated_remote_profile"
             ) as mock_get_profile:
                 response = await client.post(
                     "/api/image",

--- a/web/src/components/FileManager.jsx
+++ b/web/src/components/FileManager.jsx
@@ -156,7 +156,7 @@ function FileManager({
                             </div>
                         )}
                     </div>
-                    {enableUpload && isRemote ? (
+                    {enableUpload ? (
                         <button
                             onClick={() => setUploadDialogOpen(true)}
                             disabled={status.disabled || operationInProgress}


### PR DESCRIPTION
## Summary
- Drop the `isRemoteProfile` gate on the FileManager upload button. The frontend upload helper already routes the request through the local-FS branch of the file endpoints (it only appends `?profile=` for actually-remote profiles), so the gate was both wrong and unnecessary.
- Rename `_get_validated_slurm_profile` → `_get_validated_remote_profile` for clarity. Behavior unchanged.

## Test plan
- [x] `uv run just lint` — passes
- [x] `uv run pytest --ignore=tests/dev` — 899 passed, 8 skipped
- [x] `npm test` — 303 passed
- [x] Manual: upload a file from the dashboard against a local profile

Closes #315