### PR TITLE
test(lib): add migration replay and schema-drift tests

### DIFF
--- a/lib/src/blackfish/server/models/download.py
+++ b/lib/src/blackfish/server/models/download.py
@@ -5,6 +5,7 @@ from typing import Optional
 from uuid import UUID
 
 from advanced_alchemy.base import UUIDAuditBase
+from sqlalchemy import Index
 from sqlalchemy.orm import Mapped, mapped_column
 
 
@@ -21,6 +22,11 @@ class DownloadTask(UUIDAuditBase):
     """Track model download tasks for background processing."""
 
     __tablename__ = "download_task"
+    __table_args__ = (
+        Index("ix_download_task_status", "status"),
+        Index("ix_download_task_profile", "profile"),
+        Index("ix_download_task_profile_status", "profile", "status"),
+    )
 
     repo_id: Mapped[str]  # e.g., "meta-llama/Llama-2-7b-hf"
     profile: Mapped[str]  # Profile name

--- a/lib/tests/integration/test_migrations.py
+++ b/lib/tests/integration/test_migrations.py
@@ -1,0 +1,63 @@
+"""Verify migrations replay cleanly and that the schema they build
+matches the models' current view of the world.
+
+If `test_models_match_head_schema` fails with a non-empty diff, the
+two likely causes are:
+1. A model field was added without a corresponding migration.
+2. A new model module was added without a corresponding import below.
+"""
+
+from pathlib import Path
+
+from alembic.autogenerate import compare_metadata
+from alembic.migration import MigrationContext
+from sqlalchemy import create_engine
+from sqlalchemy.types import TypeDecorator, TypeEngine
+
+# Importing these registers each model's Table in orm_registry.metadata.
+import blackfish.server.models.download  # noqa: F401
+import blackfish.server.models.metadata  # noqa: F401
+import blackfish.server.models.model  # noqa: F401
+import blackfish.server.models.profile  # noqa: F401
+import blackfish.server.models.tiers  # noqa: F401
+from advanced_alchemy.base import orm_registry
+from blackfish.server.bootstrap import ensure_db
+
+
+def _compare_type(
+    ctx: object,  # noqa: ARG001
+    inspected_column: object,  # noqa: ARG001
+    metadata_column: object,  # noqa: ARG001
+    inspected_type: TypeEngine,  # noqa: ARG001
+    metadata_type: TypeEngine,
+) -> bool | None:
+    """Treat TypeDecorator columns as equivalent on round-trip.
+
+    advanced-alchemy ships custom types like GUID and DateTimeUTC that
+    are TypeDecorator subclasses. SQLite stores them under their impl
+    type's affinity, so reflection reads them back as NUMERIC, DATETIME,
+    etc. — never as the decorator. Defer to the model's declared type
+    in that case.
+    """
+    if isinstance(metadata_type, TypeDecorator):
+        return False
+    return None
+
+
+def test_migrations_replay_to_head(tmp_path: Path) -> None:
+    ensure_db(tmp_path)
+
+
+def test_models_match_head_schema(tmp_path: Path) -> None:
+    ensure_db(tmp_path)
+    engine = create_engine(f"sqlite:///{tmp_path / 'app.sqlite'}")
+    with engine.connect() as conn:
+        ctx = MigrationContext.configure(
+            conn,
+            opts={
+                "compare_type": _compare_type,
+                "version_table": "ddl_version",
+            },
+        )
+        diff = compare_metadata(ctx, orm_registry.metadata)
+    assert diff == [], f"Schema drift between models and migrations: {diff}"

--- a/lib/tests/integration/test_migrations.py
+++ b/lib/tests/integration/test_migrations.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from alembic.autogenerate import compare_metadata
 from alembic.migration import MigrationContext
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.types import TypeDecorator, TypeEngine
 
 # Importing these registers each model's Table in orm_registry.metadata.
@@ -46,18 +46,31 @@ def _compare_type(
 
 def test_migrations_replay_to_head(tmp_path: Path) -> None:
     ensure_db(tmp_path)
+    engine = create_engine(f"sqlite:///{tmp_path / 'app.sqlite'}")
+    try:
+        with engine.connect() as conn:
+            count = conn.execute(text("SELECT COUNT(*) FROM ddl_version")).scalar_one()
+        assert count > 0, "ensure_db returned without applying any migrations"
+    finally:
+        engine.dispose()
 
 
 def test_models_match_head_schema(tmp_path: Path) -> None:
     ensure_db(tmp_path)
     engine = create_engine(f"sqlite:///{tmp_path / 'app.sqlite'}")
-    with engine.connect() as conn:
-        ctx = MigrationContext.configure(
-            conn,
-            opts={
-                "compare_type": _compare_type,
-                "version_table": "ddl_version",
-            },
-        )
-        diff = compare_metadata(ctx, orm_registry.metadata)
+    try:
+        with engine.connect() as conn:
+            # version_table must match the name passed to AlembicAsyncConfig
+            # in bootstrap.ensure_db; otherwise MigrationContext wouldn't see
+            # the migrations as applied and the comparison would be wrong.
+            ctx = MigrationContext.configure(
+                conn,
+                opts={
+                    "compare_type": _compare_type,
+                    "version_table": "ddl_version",
+                },
+            )
+            diff = compare_metadata(ctx, orm_registry.metadata)
+    finally:
+        engine.dispose()
     assert diff == [], f"Schema drift between models and migrations: {diff}"


### PR DESCRIPTION
Adds two integration tests that catch a class of bug that's currently silent: migration files that break under a new alembic version, and \"added a model field but forgot the migration\" drift between models and migrations.

## Summary

- **\`test_migrations_replay_to_head\`** — applies every migration to a fresh SQLite DB via \`bootstrap.ensure_db()\`. Catches migrations that error under a new alembic version or that reference state from a sibling in an order-dependent way.
- **\`test_models_match_head_schema\`** — after replay, runs \`alembic.autogenerate.compare_metadata\` against the live ORM \`target_metadata\` and asserts an empty diff. Catches model-vs-migration drift before it reaches production. Needs a custom \`compare_type\` callback to ignore \`TypeDecorator\` round-tripping (\`GUID\`, \`DateTimeUTC\` reflect back as \`NUMERIC\` / \`DATETIME\` on SQLite — spurious otherwise).
- **Surfaced + fixed a pre-existing model bug.** \`DownloadTask\` had three indexes (on \`status\`, \`profile\`, and \`(profile, status)\`) created by the migration in #215 but never declared on the model class. The fix is a one-block \`__table_args__\` addition; no migration needed since the DB already has them.

Lands the test scaffolding before the alembic + advanced-alchemy bumps in #238, so those bumps' CI runs will exercise these checks automatically. The tests have independent value beyond that.

Closes #383
Refs #238

## Test plan

- [x] \`uv run pytest tests/integration/test_migrations.py\` — both new tests pass
- [x] \`uv run pytest\` — 902 passed, 8 skipped (no regressions; +2 new tests)
- [x] \`uv run pre-commit run --all-files\` — clean
- [x] Manually verified the schema-drift test catches a known drift by inspecting the failure pre-fix (5 GUID type round-trips + 3 missing indexes)
- [ ] CI green on a clean machine