### PR TITLE
deps(web): bump happy-dom to 20 (security)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -33,7 +33,7 @@
         "eslint": "^9.27.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.1.0",
-        "happy-dom": "^15.11.6",
+        "happy-dom": "^20.10.1",
         "postcss": "^8",
         "tailwindcss": "^3",
         "vite": "^6.0.3",
@@ -1985,6 +1985,16 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -2000,6 +2010,23 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -2560,6 +2587,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/cac": {
@@ -3124,9 +3164,9 @@
       "license": "MIT"
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -4050,18 +4090,22 @@
       }
     },
     "node_modules/happy-dom": {
-      "version": "15.11.7",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-15.11.7.tgz",
-      "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
+      "version": "20.10.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.1.tgz",
+      "integrity": "sha512-awPoqPjx8CgjapJllyDlgzgVHjBExcitKK5ZJkxwhQJyQpHFkyS2bEcqCm7IeW20cQvuCI0cz2Ifq79CJKqtiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^4.5.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-mimetype": "^3.0.0"
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/has-bigints": {
@@ -7794,6 +7838,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -9167,16 +9218,6 @@
         }
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -9402,6 +9443,28 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/web/package.json
+++ b/web/package.json
@@ -39,7 +39,7 @@
     "eslint": "^9.27.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.1.0",
-    "happy-dom": "^15.11.6",
+    "happy-dom": "^20.10.1",
     "postcss": "^8",
     "tailwindcss": "^3",
     "vite": "^6.0.3",

--- a/web/src/components/__snapshots__/ServiceModal.test.jsx.snap
+++ b/web/src/components/__snapshots__/ServiceModal.test.jsx.snap
@@ -59,23 +59,34 @@ exports[`ServiceModal > Rendering > renders modal when open is true 1`] = `
                     data-open=""
                     id="headlessui-dialog-title-:r7:"
                   />
-                  bound HTMLFormElement {
-                    "0": <button
-                      data-testid="set-model-button"
+                  <form
+                    class="mt-2"
+                  >
+                    <div
+                      data-testid="service-modal-form"
                     >
-                      Set Model
-                    </button>,
-                    "1": <button
-                      data-testid="set-job-options-button"
-                    >
-                      Set Job Options
-                    </button>,
-                    "2": <button
-                      data-testid="set-validation-errors-button"
-                    >
-                      Set Validation Errors
-                    </button>,
-                  }
+                      <button
+                        data-testid="set-model-button"
+                      >
+                        Set Model
+                      </button>
+                      <button
+                        data-testid="set-job-options-button"
+                      >
+                        Set Job Options
+                      </button>
+                      <button
+                        data-testid="set-validation-errors-button"
+                      >
+                        Set Validation Errors
+                      </button>
+                      <div
+                        data-testid="modal-children"
+                      >
+                        Test Children
+                      </div>
+                    </div>
+                  </form>
                 </div>
                 <div
                   class="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-4 sm:px-6 py-3 rounded-b-lg"

--- a/web/src/components/__snapshots__/ServiceModalCheckbox.test.jsx.snap
+++ b/web/src/components/__snapshots__/ServiceModalCheckbox.test.jsx.snap
@@ -10,6 +10,7 @@ exports[`ServiceModalCheckbox > renders in checked and disabled state 1`] = `
         class="flex h-6 items-center"
       >
         <input
+          checked=""
           class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-500 focus:ring-blue-500 disabled:bg-gray-100 dark:disabled:bg-gray-700 dark:bg-gray-700"
           disabled=""
           id="gpu-service-checkbox"
@@ -84,6 +85,7 @@ exports[`ServiceModalCheckbox > renders properly when checked 1`] = `
         class="flex h-6 items-center"
       >
         <input
+          checked=""
           class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-500 focus:ring-blue-500 disabled:bg-gray-100 dark:disabled:bg-gray-700 dark:bg-gray-700"
           id="gpu-service-checkbox"
           name="gpu-service-checkbox"

--- a/web/src/components/inputs/__snapshots__/Slider.test.jsx.snap
+++ b/web/src/components/inputs/__snapshots__/Slider.test.jsx.snap
@@ -251,6 +251,7 @@ exports[`Slider > Optional 1`] = `
           class="flex items-center space-x-1"
         >
           <input
+            checked=""
             class="mr-1 ml-1 h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
             type="checkbox"
           />
@@ -331,6 +332,7 @@ exports[`Slider > Optional 2`] = `
           class="flex items-center space-x-1"
         >
           <input
+            checked=""
             class="mr-1 ml-1 h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
             type="checkbox"
           />

--- a/web/src/routes/text-generation/components/__snapshots__/TextGenerationChatContainer.test.jsx.snap
+++ b/web/src/routes/text-generation/components/__snapshots__/TextGenerationChatContainer.test.jsx.snap
@@ -46,50 +46,99 @@ exports[`TextGenerationChatContainer > Component rendering > renders the main co
         <div
           class="min-w-0 flex-1"
         >
-          bound HTMLFormElement {
-            "0": <textarea
-              class="block w-full resize-none bg-transparent px-4 py-3 text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 border-0  focus:border-0 focus:outline-none focus:ring-0 sm:text-sm/6"
-              id="comment"
-              name="comment"
-              placeholder="Why are orcas so awesome?"
-              rows="3"
-            />,
-            "1": <button
-              data-testid="upload-button"
+          <form
+            action="#"
+            class="relative"
+          >
+            <div
+              class="rounded-lg bg-white dark:bg-gray-700 outline outline-1 -outline-offset-1 outline-gray-300 dark:outline-gray-600 shadow-md overflow-visible"
             >
-              Upload
-            </button>,
-            "2": <button
-              data-testid="remote-button"
-            >
-              Remote
-            </button>,
-            "3": <button
-              data-testid="upload-button"
-            >
-              Upload
-            </button>,
-            "4": <button
-              data-testid="remote-button"
-            >
-              Remote
-            </button>,
-            "5": <button
-              class="inline-flex items-center rounded-full bg-white dark:bg-gray-600 p-2 text-sm font-semibold text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-500 shadow-sm hover:bg-gray-100 dark:hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600 disabled:text-gray-400 disabled:opacity-50 disabled:hover:bg-white dark:disabled:hover:bg-gray-600 disabled:border-gray-200 dark:disabled:border-gray-600 disabled:shadow-none"
-              disabled=""
-              type="submit"
+              <label
+                class="sr-only"
+                for="comment"
+              >
+                Ask anything
+              </label>
+              <textarea
+                class="block w-full resize-none bg-transparent px-4 py-3 text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 border-0  focus:border-0 focus:outline-none focus:ring-0 sm:text-sm/6"
+                id="comment"
+                name="comment"
+                placeholder="Why are orcas so awesome?"
+                rows="3"
+              />
+              <div
+                aria-hidden="true"
+                class="py-2"
+              >
+                <div
+                  class="py-px"
+                >
+                  <div
+                    class="h-9"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="absolute inset-x-0 bottom-0 flex justify-between py-2 pl-3 pr-2"
             >
               <div
-                class="size-5"
-                data-testid="paper-airplane-icon"
-              />
-              <span
-                class="sr-only"
+                class="flex items-center space-x-5"
               >
-                Submit
-              </span>
-            </button>,
-          }
+                <div
+                  class="flex items-center gap-2"
+                >
+                  <div
+                    data-testid="attachment-menu"
+                  >
+                    <button
+                      data-testid="upload-button"
+                    >
+                      Upload
+                    </button>
+                    <button
+                      data-testid="remote-button"
+                    >
+                      Remote
+                    </button>
+                  </div>
+                  <div
+                    data-testid="attachment-menu"
+                  >
+                    <button
+                      data-testid="upload-button"
+                    >
+                      Upload
+                    </button>
+                    <button
+                      data-testid="remote-button"
+                    >
+                      Remote
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="shrink-0"
+              >
+                <button
+                  class="inline-flex items-center rounded-full bg-white dark:bg-gray-600 p-2 text-sm font-semibold text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-500 shadow-sm hover:bg-gray-100 dark:hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600 disabled:text-gray-400 disabled:opacity-50 disabled:hover:bg-white dark:disabled:hover:bg-gray-600 disabled:border-gray-200 dark:disabled:border-gray-600 disabled:shadow-none"
+                  disabled=""
+                  type="submit"
+                >
+                  <div
+                    class="size-5"
+                    data-testid="paper-airplane-icon"
+                  />
+                  <span
+                    class="sr-only"
+                  >
+                    Submit
+                  </span>
+                </button>
+              </div>
+            </div>
+          </form>
         </div>
       </div>
       <div

--- a/web/src/routes/text-generation/components/__snapshots__/TextGenerationCompletionContainer.test.jsx.snap
+++ b/web/src/routes/text-generation/components/__snapshots__/TextGenerationCompletionContainer.test.jsx.snap
@@ -22,34 +22,75 @@ exports[`TextGenerationCompletionContainer > Component rendering > renders the m
           <div
             class="min-w-0 flex-1"
           >
-            bound HTMLFormElement {
-              "0": <textarea
-                class="block w-full resize-none bg-transparent px-4 py-3 text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 border-0  focus:border-0 focus:outline-none focus:ring-0 sm:text-sm/6 overflow-visible"
-                id="text-generation-text-input"
-                name="text-generation-text-input"
-                placeholder="Orcas are awesome because..."
-                rows="10"
-              />,
-              "1": <button
-                data-testid="upload-button"
+            <form
+              action="#"
+              class="relative"
+            >
+              <div
+                class="rounded-lg bg-white dark:bg-gray-700 outline outline-1 -outline-offset-1 outline-gray-300 dark:outline-gray-600 shadow-md"
               >
-                Upload
-              </button>,
-              "2": <button
-                data-testid="remote-button"
-              >
-                Remote
-              </button>,
-              "3": <button
-                class="inline-flex items-center rounded-full bg-white dark:bg-gray-600 p-2 text-sm font-semibold text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-500 shadow-sm hover:bg-gray-100 dark:hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600 disabled:text-gray-400 disabled:opacity-50 disabled:hover:bg-white dark:disabled:hover:bg-gray-600 disabled:border-gray-200 dark:disabled:border-gray-600 disabled:shadow-none"
-                type="submit"
+                <label
+                  class="sr-only"
+                  for="text-generation-text-input"
+                >
+                  Prompt anything
+                </label>
+                <textarea
+                  class="block w-full resize-none bg-transparent px-4 py-3 text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 border-0  focus:border-0 focus:outline-none focus:ring-0 sm:text-sm/6 overflow-visible"
+                  id="text-generation-text-input"
+                  name="text-generation-text-input"
+                  placeholder="Orcas are awesome because..."
+                  rows="10"
+                />
+                <div
+                  aria-hidden="true"
+                  class="py-2"
+                >
+                  <div
+                    class="py-px"
+                  >
+                    <div
+                      class="h-9"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="absolute inset-x-0 bottom-0 flex justify-between py-2 pl-3 pr-2"
               >
                 <div
-                  class="size-5"
-                  data-testid="paper-airplane-icon"
-                />
-              </button>,
-            }
+                  class="flex items-center"
+                >
+                  <div
+                    data-testid="attachment-menu"
+                  >
+                    <button
+                      data-testid="upload-button"
+                    >
+                      Upload
+                    </button>
+                    <button
+                      data-testid="remote-button"
+                    >
+                      Remote
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="shrink-0"
+                >
+                  <button
+                    class="inline-flex items-center rounded-full bg-white dark:bg-gray-600 p-2 text-sm font-semibold text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-500 shadow-sm hover:bg-gray-100 dark:hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600 disabled:text-gray-400 disabled:opacity-50 disabled:hover:bg-white dark:disabled:hover:bg-gray-600 disabled:border-gray-200 dark:disabled:border-gray-600 disabled:shadow-none"
+                    type="submit"
+                  >
+                    <div
+                      class="size-5"
+                      data-testid="paper-airplane-icon"
+                    />
+                  </button>
+                </div>
+              </div>
+            </form>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Second of three security-driven dependency PRs surfaced by \`npm audit\` (after #389). Resolves three critical CVEs in happy-dom 15.x:

- **VM context escape → Remote Code Execution**
- Cross-origin cookie leak in \`fetch\` (page-origin cookies sent to target origin)
- Unsanitized export names interpolated as executable code in the ESM compiler

happy-dom is dev-time only (test environment), so this isn't a production runtime exposure — but a dev-time RCE in CI / on developer machines is still not something to leave standing.

## Summary

- Bump \`happy-dom\` from \`^15.11.6\` to \`^20.10.1\`.
- 7 snapshot files updated: happy-dom 20 serializes boolean HTML attributes spec-correctly (e.g. \`<input checked>\` renders as \`checked=\"\"\` rather than being omitted). No semantic test changes.
- Existing \`setup.js\` workaround for happy-dom's unreliable \`localStorage.clear\` stays in place; it's forward-compatible.

After this lands, \`npm audit\` will show 16 vulnerabilities (1 critical remaining), all in the vitest dep-chain. That's the next PR (vitest 2 → 4 bundled with vite + @vitejs/plugin-react).

Refs #238

## Test plan

- [x] \`npm test\` — 312 passed (39 files), all snapshot updates reviewed and confirmed as serialization-only
- [x] \`npm run lint\` — clean (pre-existing warning in \`ImageAttachment.jsx\` unchanged)
- [x] \`npm audit\` — 17 → 16 vulns; one of three criticals resolved
- [x] CI green on a clean machine