### PR TITLE
fix(lib): require litestar>=2.16 for advanced-alchemy compat (v1.0.0a6)

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "blackfish-ai"
-version = "1.0.0a5"
+version = "1.0.0a6"
 description = "An open-source AI-as-a-Service platform."
 readme = "README.md"
 license = "MIT"
@@ -28,7 +28,7 @@ dependencies = [
   "httpx>=0.28,<1",
   "huggingface-hub>=1.4.1,<2",
   "jinja2>=3.1.5,<4",
-  "litestar>=2.14,<3",
+  "litestar>=2.16,<3",
   "log-symbols>=0.0.14,<0.1",
   "pillow>=12,<13",
   "prettytable>=3.12,<4",

--- a/lib/uv.lock
+++ b/lib/uv.lock
@@ -239,7 +239,7 @@ wheels = [
 
 [[package]]
 name = "blackfish-ai"
-version = "1.0.0a5"
+version = "1.0.0a6"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },
@@ -307,7 +307,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28,<1" },
     { name = "huggingface-hub", specifier = ">=1.4.1,<2" },
     { name = "jinja2", specifier = ">=3.1.5,<4" },
-    { name = "litestar", specifier = ">=2.14,<3" },
+    { name = "litestar", specifier = ">=2.16,<3" },
     { name = "log-symbols", specifier = ">=0.0.14,<0.1" },
     { name = "pillow", specifier = ">=12,<13" },
     { name = "prettytable", specifier = ">=3.12,<4" },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blackfish-ui",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blackfish-ui",
-      "version": "1.0.0-alpha.5",
+      "version": "1.0.0-alpha.6",
       "dependencies": {
         "@headlessui/react": "^2.1",
         "@heroicons/react": "^2.0.18",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blackfish-ui",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "private": true,
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Raise the `litestar` lower bound from `>=2.14` to `>=2.16,<3`. advanced-alchemy 1.11 imports `NamedDependency` from `litestar.di` (added in litestar 2.16), so the old floor permitted a metadata-valid but runtime-broken resolution. This crashed `blackfish start` on pip-installed environments where an older litestar satisfied `>=2.14`; `uv` avoided it only by pinning the newest litestar (2.23.0).
- Bump versions to `v1.0.0a6` (lib `pyproject.toml`, web `package.json` + lockfiles).

## Why CI missed it
Our tests only ever run against the lockfile, which pins the *newest* litestar — never the lower bound. The floor was an unverified claim that silently rotted. Follow-up worth tracking: add a `uv sync --resolution lowest-direct` smoke job so lower bounds are actually exercised.

## Test plan
- [x] `cd lib && uv run pre-commit run --all-files` (ruff, mypy, format)
- [x] `cd lib && uv run pytest` (passed)
- [x] `cd web && npm test` (312 passed)
- [x] Lockfile still resolves litestar 2.23.0; floor now enforced by metadata