### PR TITLE
docs: update batch-job docs for the tigerflow-ml image migration

### DIFF
--- a/lib/docs/setup/management.md
+++ b/lib/docs/setup/management.md
@@ -31,13 +31,13 @@ Let's consider what happens when a user launches a service from their laptop tar
 
 ## Images
 
-Blackfish does **not** ship with the container images required to run services. These images should be downloaded before running services[^1]. To see the images required by your installed version of Blackfish, run:
+Blackfish does **not** ship with the container images required to run services and batch jobs. These images should be downloaded before use[^1]. To see the images required by your installed version of Blackfish, run:
 
 ```shell
 blackfish image ls
 ```
 
-This lists each service's pinned image and whether it is available in the configured cache. Pinned versions change over time as Blackfish releases bump the underlying runtimes.
+This lists each pinned image — one per service, plus the tigerflow-ml image used for batch jobs — and whether it is available in the configured cache. Pinned versions change over time as Blackfish releases bump the underlying runtimes.
 
 ### Obtaining Images
 
@@ -47,7 +47,13 @@ Services deployed on HPC systems require Apptainer, which uses Single Image Form
 apptainer pull docker://ghcr.io/princeton-ddss/speech-recognition-inference:0.1.2
 ```
 
-This command generates a file `speech-recognition-inference_0.1.2.sif` in the directory where it is run. Blackfish looks for images in the `cache_dir/images` directory specified by your profile. If you are an HPC admin setting up a shared environment, move images to the shared cache directory (e.g., `/shared/.blackfish/images`). If you are an individual user and your cache directory is read-only, ask your admin to add the required images or set your profile's `cache_dir` to a directory you can write to.
+This command generates a file `speech-recognition-inference_0.1.2.sif` in the directory where it is run. The tigerflow-ml image used for batch jobs is staged the same way — pull the version reported by `blackfish image ls`, e.g.
+
+```shell
+apptainer pull docker://ghcr.io/princeton-ddss/tigerflow-ml:0.1.1
+```
+
+Blackfish looks for images in the `cache_dir/images` directory specified by your profile. If you are an HPC admin setting up a shared environment, move images to the shared cache directory (e.g., `/shared/.blackfish/images`). If you are an individual user and your cache directory is read-only, ask your admin to add the required images or set your profile's `cache_dir` to a directory you can write to.
 
 ## Models
 
@@ -99,7 +105,7 @@ The `snapshot_download` method stores model files to `~/.cache/huggingface/hub/`
 
 ## Batch Jobs
 
-Blackfish delegates batch job execution to [TigerFlow](https://github.com/princeton-ddss/tigerflow), a companion project for running task-based pipelines on Slurm clusters. TigerFlow is installed automatically the first time you create a Slurm profile, so users typically don't need to manage it directly. If the install fails, users can re-run it via `blackfish profile repair`, and upgrade an existing install via `blackfish profile upgrade`.
+Blackfish runs batch jobs inside the [tigerflow-ml](https://github.com/princeton-ddss/tigerflow-ml) container image, a companion project for running task-based pipelines on Slurm clusters. Like service images, the tigerflow-ml image must be available in the profile's cache — see [Images](#images) for how to stage it. Once the image is present, any Slurm profile can run batch jobs; `blackfish profile repair` verifies the image is in place.
 
 ## Resource Tiers
 

--- a/lib/docs/usage/cli.md
+++ b/lib/docs/usage/cli.md
@@ -62,7 +62,6 @@ A *Slurm profile* specifies how to schedule services *on* a (possibly) remote se
 - `user`: a user name used to connect to server.
 - `home`: a location on the server to store application model, image and job data, e.g., `/home/<user>/.blackfish`. User should have read-write access to this directory.
 - `cache`: a location on the server to source additional shared model and images files from. Blackfish does *not* attempt to create this directory for you, but it does require that it can be found. User should *at least* have read access to this directory.
-- `python_path` (optional): path to Python on the cluster, e.g., `python3` (default) or `/usr/local/bin/python3.11`. This may also include module load commands like `module load python && python3`. Used for setting up the TigerFlow environment for batch jobs.
 
 #### Local
 
@@ -156,33 +155,17 @@ This marks `<profile>` as the default and clears the flag from every other profi
 profile is the default at a time. The default profile is shown with a `(default)` marker in
 `blackfish profile ls`.
 
-#### upgrade - Upgrade TigerFlow
-
-Slurm profiles use [TigerFlow](https://github.com/princeton-ddss/tigerflow) for batch job processing.
-To upgrade TigerFlow to the latest version on a profile, use:
-
-```shell
-blackfish profile upgrade --name <profile>
-```
-
-You can also install from a specific git branch:
-
-```shell
-blackfish profile upgrade --name <profile> \
-    --tigerflow-spec "git+https://github.com/princeton-ddss/tigerflow@main"
-    --tigerflow-ml-spec "git+https://github.com/princeton-ddss/tigerflow-ml@main"
-```
-
 #### repair - Repair a profile
 
-If a Slurm profile is in a broken state (missing directories, corrupted TigerFlow installation),
-you can repair it by re-running the setup process:
+If a Slurm profile is in a broken state (e.g. missing directories), you can repair it by
+re-running the setup process:
 
 ```shell
 blackfish profile repair --name <profile>
 ```
 
-This recreates the profile's directories and reinstalls TigerFlow.
+This recreates the profile's directories and checks that the tigerflow-ml image used for batch
+jobs is available in the profile's cache (see [Images](../setup/management.md#images)).
 
 #### rm - Delete a profile
 
@@ -436,11 +419,11 @@ blackfish rm --filters id=fed36739-70b4-4dc4-8017-a4277563aef9
 
 ## Batch Jobs
 
-Services are great for interactive work, but sometimes you need to run an ML task across a whole directory of files — a corpus of audio to transcribe, a document set to translate, or a photo library to run object detection on. Batch jobs are the right tool for this. Under the hood, Blackfish delegates batch execution to [TigerFlow](https://github.com/princeton-ddss/tigerflow), a companion project that manages Slurm job submission, worker parallelism, and per-file progress tracking.
+Services are great for interactive work, but sometimes you need to run an ML task across a whole directory of files — a corpus of audio to transcribe, a document set to translate, or a photo library to run object detection on. Batch jobs are the right tool for this. Under the hood, Blackfish runs each batch job inside the [tigerflow-ml](https://github.com/princeton-ddss/tigerflow-ml) container image as a Slurm allocation, resuming across allocations until every file in the input directory is processed.
 
 !!! note
 
-    Batch jobs require a Slurm profile. TigerFlow is installed automatically the first time you create a Slurm profile, so in practice any Slurm profile will work. See the [Management Guide](../setup/management.md#batch-jobs) for more on the install process.
+    Batch jobs require a Slurm profile with the tigerflow-ml image staged in its cache. See the [Management Guide](../setup/management.md#batch-jobs) for details.
 
 ### Supported tasks
 

--- a/lib/docs/usage/cli.md
+++ b/lib/docs/usage/cli.md
@@ -445,7 +445,7 @@ blackfish batch run \
   --model openai/whisper-large-v3 \
   --input-dir /scratch/shamu/audio \
   --output-dir /scratch/shamu/transcripts \
-  --max-workers 4
+  --resources '{"gpus": 1, "time": "02:00:00"}'
 ```
 
 The `--name`, `--task`, `--model`, `--input-dir`, and `--output-dir` flags are required. Other useful flags:
@@ -454,12 +454,26 @@ The `--name`, `--task`, `--model`, `--input-dir`, and `--output-dir` flags are r
 - `--revision`: specific model commit (defaults to the latest downloaded revision).
 - `--input-ext`: input file extension filter. Defaults to the task's typical extension.
 - `--params`: task-specific parameters as a JSON string, e.g. `'{"language": "en"}'` for transcribe.
-- `--resources`: per-worker Slurm resources as a JSON string, e.g. `'{"gpus": 1, "cpus": 4, "memory": "32GB", "time": "02:00:00"}'`.
-- `--max-workers`: maximum number of concurrent Slurm workers.
+- `--resources`: Slurm resources for the job's allocation as a JSON string, e.g. `'{"gpus": 1, "cpus": 4, "memory": "32GB", "time": "02:00:00"}'`.
 
 !!! tip
 
-    Add `--dry-run` to print the generated TigerFlow pipeline config without submitting the job. Useful for validating settings before a long-running batch.
+    Add `--dry-run` to print the generated pipeline config without submitting the job. Useful for validating settings before a long-running batch.
+
+#### Walltime and restarts
+
+A batch job runs as a Slurm allocation sized by `--resources`. If that allocation is killed at its
+walltime with files still unprocessed, Blackfish can resubmit it and resume where it left off —
+already-finished files are skipped — so the `time` you request need not cover the entire input
+directory.
+
+The resubmit is not automatic in the background: it happens when the job's status is
+refreshed by listing jobs. The Blackfish UI lists jobs on an interval, so under the UI restarts
+happen on their own. From the CLI, run `blackfish batch ls` to refresh — that check is what
+resubmits a walltime-killed job that still has work to do.
+
+A job that stops making progress across restarts (e.g. an input that always fails to process) is
+halted and reported as `STALLED`; one that exhausts its restart budget is reported as `EXHAUSTED`.
 
 ### `ls` - List batch jobs
 
@@ -467,7 +481,9 @@ The `--name`, `--task`, `--model`, `--input-dir`, and `--output-dir` flags are r
 blackfish batch ls
 ```
 
-Lists all batch jobs with their current status, task, model, and per-file progress.
+Lists all batch jobs with their current status, task, model, and per-file progress. Listing also
+refreshes each job's status, which is what resubmits a walltime-killed job that still has work
+remaining (see [Walltime and restarts](#walltime-and-restarts)).
 
 ### `stop` - Stop a batch job
 
@@ -475,7 +491,14 @@ Lists all batch jobs with their current status, task, model, and per-file progre
 blackfish batch stop <job-id>
 ```
 
-Stops a running batch job. Partial results already written to the output directory are preserved.
+Stops a running batch job and cancels its Slurm allocation. Partial results already written to the
+output directory are preserved.
+
+!!! warning
+
+    Stopping a job is final. A stopped job is never resubmitted, even if files remain unprocessed —
+    there is no resume-after-stop. To finish the remaining files, submit a new job pointed at the
+    same output directory; already-finished files are skipped.
 
 ### `rm` - Delete a batch job
 


### PR DESCRIPTION
## Summary

- Update the batch-job documentation for the tigerflow-ml container migration (#404): batch jobs run inside the `tigerflow-ml` image, not a managed remote venv. Removes the `python_path` profile field and the deleted `blackfish profile upgrade` command (and its `--tigerflow-spec`/`--tigerflow-ml-spec` flags), and rewrites `profile repair` and both Batch Jobs intros accordingly.
- Correct the `batch run` reference: drop the now no-op `--max-workers` from the example (the `local` variant runs a single allocation — no concurrent workers), and relabel `--resources` as the resources for the job's *allocation* rather than "per-worker".
- Document restart behavior accurately: a new "Walltime and restarts" section explains that a walltime-killed job resumes on a **status refresh** (poll-driven, not a background daemon) — automatic under the UI's interval polling, triggered by `blackfish batch ls` from the CLI — plus the `STALLED`/`EXHAUSTED` terminal states and a warning that `batch stop` is final.
- Extend the Images section to cover staging the tigerflow-ml image (`apptainer pull`), since the batch-job docs now point there.

## Test plan

- `cd lib && uv run just lint` — pre-commit (mypy strict, ruff, codespell, whitespace/EOF) passes
- `cd lib && uv run just test` — 868 passed, 7 skipped; coverage 70% (no code changed; run as a gate)
- Docs-only change — no frontend or Python source touched.
- Claims verified against the code: `--max-workers` is stored but consumed nowhere; `--resources` feeds the sbatch allocation; the restart resubmit is reachable only via the job-list refresh (`GET /api/jobs` → `poll()`); the output dir is `mkdir -p`'d and never cleared, so resubmitting at the same output dir resumes via `.finished/` markers.