### PR TITLE
fix(web): coerce batch job params to typed values and refine task options

### DIFF
--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -474,10 +474,16 @@ const VIDEO_INPUT_EXTS = new Set([
 ]);
 
 // Whether a param applies given the current form state. Hides params the task
-// would ignore: `videoOnly` params for image inputs (e.g. detect's batch_size),
-// and params gated on another param's value via `showWhenParam` (e.g.
-// transcribe's batch_size only applies when windowing is "batched").
-export function isParamVisible(param, { inputExt, taskParams } = {}) {
+// would ignore: `showWhen.modelType` params for a mismatched model (e.g.
+// detect's labels, zero-shot only), `videoOnly` params for image inputs (e.g.
+// detect's batch_size), and params gated on another param's value via
+// `showWhenParam` (e.g. transcribe's batch_size only applies when windowing is
+// "batched"). All three call sites (render, validation, submit) go through this
+// one predicate so a hidden param's stale value is never sent.
+export function isParamVisible(param, { inputExt, taskParams, modelType } = {}) {
+  if (param.showWhen?.modelType && modelType !== param.showWhen.modelType) {
+    return false;
+  }
   if (param.videoOnly && !VIDEO_INPUT_EXTS.has(inputExt)) {
     return false;
   }
@@ -979,16 +985,24 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
       // strings, but tigerflow tasks consume params by their real type (e.g.
       // `batch_size > 1`), so a string would crash the task. Numbers/booleans
       // are converted; empty optional fields are dropped rather than sent blank.
-      // Params hidden for the selected input (e.g. video-only params on an image
-      // input) are also dropped, so a stale value from switching format isn't sent.
+      // A param hidden for the current form state (mismatched model type,
+      // video-only on an image input, or value-gated) is dropped, so a stale
+      // value left over from switching model/format/strategy isn't sent.
       const resolvedInputExt = inputExt || task.defaultInputExt;
       const pipelineParams = {};
       for (const [key, value] of Object.entries(rawParams)) {
-        if (value === "" || value === undefined || value === null) continue;
+        // Drop empty / whitespace-only values so an untouched optional field
+        // isn't submitted (a bare " " must not coerce to 0 for a number param).
+        if (value === undefined || value === null) continue;
+        if (typeof value === "string" && value.trim() === "") continue;
         const spec = task.params.find((p) => p.name === key);
         if (
           spec &&
-          !isParamVisible(spec, { inputExt: resolvedInputExt, taskParams })
+          !isParamVisible(spec, {
+            inputExt: resolvedInputExt,
+            taskParams,
+            modelType,
+          })
         ) {
           continue;
         }
@@ -1059,15 +1073,13 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
           return false;
         }
         for (const param of task.params) {
-          // Skip params that don't apply to current model type
-          if (param.showWhen?.modelType && modelType !== param.showWhen.modelType) {
-            continue;
-          }
-          // Skip params hidden for the current form state (video-only, gated)
+          // Skip params hidden for the current form state (mismatched model
+          // type, video-only, or value-gated).
           if (
             !isParamVisible(param, {
               inputExt: inputExt || task.defaultInputExt,
               taskParams,
+              modelType,
             })
           ) {
             continue;
@@ -1228,18 +1240,15 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
             )}
 
             {task.params
-              .filter((param) => {
-                // Filter out params with showWhen conditions that don't match
-                if (param.showWhen?.modelType) {
-                  return modelType === param.showWhen.modelType;
-                }
-                // Hide params the task would ignore (video-only for images,
-                // or gated on another param's value).
-                return isParamVisible(param, {
+              .filter((param) =>
+                // Hide params the task would ignore (mismatched model type,
+                // video-only for images, or gated on another param's value).
+                isParamVisible(param, {
                   inputExt: inputExt || task.defaultInputExt,
                   taskParams,
-                });
-              })
+                  modelType,
+                })
+              )
               .map((param) => {
                 // Params with showWhen are required when shown
                 const paramRequired = param.showWhen ? true : param.required;

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -23,6 +23,7 @@ import RevisionSelect from "@/components/RevisionSelect";
 import PartitionSelect from "@/components/PartitionSelect";
 import TierSelect from "@/components/TierSelect";
 import ServiceModalValidatedInput from "@/components/ServiceModalValidatedInput";
+import ServiceModalCheckBox from "@/components/ServiceModalCheckbox";
 import Alert from "@/components/Alert";
 import Stepper from "@/components/Stepper";
 import DirectoryBrowser from "@/components/DirectoryBrowser";
@@ -67,6 +68,7 @@ export const TASKS = [
       {
         name: "threshold",
         type: "text",
+        valueType: "number",
         required: false,
         label: "Confidence Threshold",
         help: "Minimum confidence score (0-1). Default: 0.3",
@@ -75,18 +77,46 @@ export const TASKS = [
       {
         name: "batch_size",
         type: "text",
+        valueType: "number",
+        videoOnly: true,
         required: false,
         label: "Batch Size",
-        help: "Parallel frame processing count. Default: 4",
+        help: "Frames processed in parallel on the GPU. Default: 4",
         placeholder: "4",
       },
       {
         name: "sample_fps",
         type: "text",
+        valueType: "number",
+        videoOnly: true,
         required: false,
         label: "Sample FPS",
-        help: "Video sampling rate. Use 0 for all frames. Default: 1.0",
+        help: "Frames per second to sample. Use 0 for all frames. Default: 1.0",
         placeholder: "1.0",
+      },
+      {
+        name: "dtype",
+        type: "select",
+        required: false,
+        label: "Model Precision",
+        help: "Model dtype. 'auto' uses float16 on GPU, float32 on CPU.",
+        default: "auto",
+        options: [
+          { value: "auto", label: "Auto" },
+          { value: "float32", label: "float32" },
+          { value: "float16", label: "float16" },
+          { value: "bfloat16", label: "bfloat16" },
+        ],
+      },
+      {
+        name: "compile",
+        type: "checkbox",
+        valueType: "boolean",
+        videoOnly: true,
+        required: false,
+        label: "Compile model (torch.compile)",
+        help: "Adds 30-60s first-call overhead; worthwhile for long videos.",
+        default: false,
       },
     ],
   },
@@ -96,7 +126,11 @@ export const TASKS = [
     description: "Extract text from images",
     service: "image-text-to-text", // Vision models only
     defaultInputExt: ".png",
+    // The image-text-to-text task has no server-side default prompt, so the
+    // prompt is required. `defaultPrompt` seeds the field as an editable value
+    // (not just a placeholder the user can leave blank).
     defaultPrompt: "Extract all text from this image.",
+    promptRequired: true,
     inputExtOptions: [
       { value: ".png", label: "PNG (.png)" },
       { value: ".jpg", label: "JPEG (.jpg)" },
@@ -116,6 +150,15 @@ export const TASKS = [
           { value: "json", label: "JSON (.json)" },
         ],
         default: "text",
+      },
+      {
+        name: "max_tokens",
+        type: "text",
+        valueType: "number",
+        required: false,
+        label: "Max Tokens",
+        help: "Maximum tokens generated per image. Default: 4096",
+        placeholder: "4096",
       },
     ],
   },
@@ -140,7 +183,7 @@ export const TASKS = [
         type: "select",
         required: false,
         label: "Language",
-        help: "Language spoken in the audio. Leave empty to auto-detect.",
+        help: "Language spoken in the audio.",
         options: [
           { value: "", label: "Auto-detect" },
           { value: "en", label: "English" },
@@ -170,6 +213,48 @@ export const TASKS = [
         ],
         default: "text",
       },
+      {
+        name: "windowing",
+        type: "select",
+        required: false,
+        label: "Decode Strategy",
+        help: "Batching cuts audio into parallel 30s windows (faster, less accurate); native decoding uses Whisper's sequential algorithm (slower, more accurate).",
+        default: "batched",
+        options: [
+          { value: "batched", label: "Batched (fastest)" },
+          { value: "native", label: "Native (most accurate)" },
+        ],
+      },
+      {
+        name: "batch_size",
+        type: "text",
+        valueType: "number",
+        required: false,
+        showWhenParam: { name: "windowing", value: "batched", default: "batched" },
+        label: "Batch Size",
+        help: "30s windows decoded per batch. Higher uses more GPU memory. Default: 16",
+        placeholder: "16",
+      },
+      {
+        name: "overlap_s",
+        type: "text",
+        valueType: "number",
+        required: false,
+        showWhenParam: { name: "windowing", value: "batched", default: "batched" },
+        label: "Window Overlap (s)",
+        help: "Overlap between 30s windows, de-duplicated when stitching. Default: 5.0",
+        placeholder: "5.0",
+      },
+      {
+        name: "raw",
+        type: "checkbox",
+        valueType: "boolean",
+        required: false,
+        showWhenParam: { name: "output_format", value: "json", default: "text" },
+        label: "Raw segments",
+        help: "Emit un-merged per-window segments instead of the merged transcript.",
+        default: false,
+      },
     ],
   },
   {
@@ -178,15 +263,18 @@ export const TASKS = [
     description: "Translate text between languages",
     service: "text-generation", // Uses LLM models
     defaultInputExt: ".txt",
-    defaultPrompt: "Translate the following text to {target_language}. Preserve the original formatting.",
+    // No generic prompt field: the translate task takes a `prompt_template`
+    // (below), not a `prompt`. A defaultPrompt here would render a spurious
+    // "Prompt" field whose value the task ignores.
+    defaultPrompt: null,
     params: [
       {
         name: "source_lang",
         type: "select",
-        required: true,
+        required: false,
         label: "Source Language",
         default: "auto",
-        help: "Language of the input text.",
+        help: "Language of the input text, or auto-detect per file.",
         options: [
           { value: "auto", label: "Auto-detect" },
           { value: "af", label: "Afrikaans" },
@@ -249,8 +337,9 @@ export const TASKS = [
       {
         name: "target_lang",
         type: "select",
-        required: true,
+        required: false,
         label: "Target Language",
+        default: "en",
         help: "Language to translate into.",
         options: [
           { value: "af", label: "Afrikaans" },
@@ -310,6 +399,56 @@ export const TASKS = [
           { value: "zh-tw", label: "Chinese (Traditional)" },
         ],
       },
+      {
+        name: "model_backend",
+        type: "select",
+        required: false,
+        label: "Model Backend",
+        help: "Translation backend. 'auto' picks from the model name.",
+        default: "auto",
+        options: [
+          { value: "auto", label: "Auto" },
+          { value: "chat", label: "Chat" },
+          { value: "tgemma", label: "TranslateGemma" },
+        ],
+      },
+      {
+        name: "chunk_size",
+        type: "text",
+        valueType: "number",
+        required: false,
+        label: "Chunk Size",
+        help: "Maximum tokens per batch (250–8182). Default: 900.",
+        placeholder: "900",
+      },
+      {
+        name: "prompt_template",
+        type: "textarea",
+        required: false,
+        showWhenParam: {
+          name: "model_backend",
+          values: ["auto", "chat"],
+          default: "auto",
+        },
+        label: "Prompt Template",
+        help: "Overrides the default prompt for chat models. Use {source_lang}, {target_lang}, and {text} placeholders.",
+        placeholder:
+          "Translate the following text from {source_lang} to {target_lang}. Output only the translated text, nothing else. Text: {text}",
+      },
+      {
+        name: "use_fallback_prompt",
+        type: "checkbox",
+        valueType: "boolean",
+        required: false,
+        showWhenParam: {
+          name: "model_backend",
+          values: ["auto", "chat"],
+          default: "auto",
+        },
+        label: "Use fallback prompt",
+        help: "When the source language can't be determined, use a fallback prompt that omits {source_lang}.",
+        default: false,
+      },
     ],
   },
 ];
@@ -321,6 +460,67 @@ const OUTPUT_FORMAT_EXT = {
   json: ".json",
   srt: ".srt",
 };
+
+// Input extensions the detect task treats as video (matches tigerflow-ml's
+// _VIDEO_EXTENSIONS). Params flagged `videoOnly` only apply to these.
+const VIDEO_INPUT_EXTS = new Set([
+  ".mp4",
+  ".avi",
+  ".mov",
+  ".mkv",
+  ".webm",
+  ".flv",
+  ".wmv",
+]);
+
+// Whether a param applies given the current form state. Hides params the task
+// would ignore: `videoOnly` params for image inputs (e.g. detect's batch_size),
+// and params gated on another param's value via `showWhenParam` (e.g.
+// transcribe's batch_size only applies when windowing is "batched").
+export function isParamVisible(param, { inputExt, taskParams } = {}) {
+  if (param.videoOnly && !VIDEO_INPUT_EXTS.has(inputExt)) {
+    return false;
+  }
+  if (param.showWhenParam) {
+    const { name, value, values, default: fallback } = param.showWhenParam;
+    const current = taskParams?.[name] ?? fallback;
+    const allowed = values ?? [value];
+    if (!allowed.includes(current)) return false;
+  }
+  return true;
+}
+
+// Coerce a form value (always a string) to the JSON type its param declares,
+// so tigerflow tasks receive a real number/boolean rather than a string. Falls
+// back to the raw value for string params or an unparseable number.
+export function coerceParamValue(task, paramName, value) {
+  const spec = task?.params?.find((p) => p.name === paramName);
+  if (!spec || spec.valueType === undefined || spec.valueType === "string") {
+    return value;
+  }
+  if (spec.valueType === "boolean") {
+    return value === true || value === "true";
+  }
+  if (spec.valueType === "number") {
+    const n = Number(value);
+    return Number.isNaN(n) ? value : n;
+  }
+  return value;
+}
+
+// Translate exposes a single "Source Language" dropdown, but the image has two
+// params: an optional explicit source_lang and an auto_lang_detect boolean.
+// "auto" (not a valid language code) means "detect per file"; a real code is
+// explicit. Mutates the params object in place.
+export function applyTranslateSourceLang(params) {
+  if (params.source_lang === "auto") {
+    delete params.source_lang;
+    params.auto_lang_detect = true;
+  } else if (params.source_lang) {
+    params.auto_lang_detect = false;
+  }
+  return params;
+}
 
 // ISO language codes supported by langdetect
 const ISO_LANGUAGE_CODES = new Set([
@@ -606,6 +806,12 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
         defaults[param.name] = param.default;
       }
     });
+    // A required prompt has no server-side default, so seed the field with the
+    // task's default prompt rather than leaving it blank (which would submit an
+    // empty required param).
+    if (task.promptRequired && task.defaultPrompt) {
+      defaults.prompt = task.defaultPrompt;
+    }
     setTaskParams(defaults);
   }, [task]);
 
@@ -766,8 +972,34 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
       // output_format is a UI-only field: it selects the output *extension*
       // (the tigerflow tasks derive their format from output_ext), so map it to
       // output_ext and strip it from the params sent to tigerflow.
-      const { output_format: outputFormat, ...pipelineParams } = taskParams;
+      const { output_format: outputFormat, ...rawParams } = taskParams;
       const outputExt = outputFormat ? OUTPUT_FORMAT_EXT[outputFormat] : null;
+
+      // Coerce params to their declared JSON types. Form inputs are always
+      // strings, but tigerflow tasks consume params by their real type (e.g.
+      // `batch_size > 1`), so a string would crash the task. Numbers/booleans
+      // are converted; empty optional fields are dropped rather than sent blank.
+      // Params hidden for the selected input (e.g. video-only params on an image
+      // input) are also dropped, so a stale value from switching format isn't sent.
+      const resolvedInputExt = inputExt || task.defaultInputExt;
+      const pipelineParams = {};
+      for (const [key, value] of Object.entries(rawParams)) {
+        if (value === "" || value === undefined || value === null) continue;
+        const spec = task.params.find((p) => p.name === key);
+        if (
+          spec &&
+          !isParamVisible(spec, { inputExt: resolvedInputExt, taskParams })
+        ) {
+          continue;
+        }
+        pipelineParams[key] = coerceParamValue(task, key, value);
+      }
+
+      // The translate "Source Language" dropdown drives the image's two
+      // separate params (see applyTranslateSourceLang).
+      if (task.id === "translate") {
+        applyTranslateSourceLang(pipelineParams);
+      }
 
       // Default job name: a compact, Slurm-friendly token like
       // "detect-detr-resnet-50" (task id + model basename), not the display
@@ -822,9 +1054,22 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
       case "options":
         // Check required params (including dynamically required ones based on model type)
         if (!task) return false;
+        // A required prompt (task has no server-side default) must be non-empty.
+        if (task.promptRequired && !String(taskParams.prompt || "").trim()) {
+          return false;
+        }
         for (const param of task.params) {
           // Skip params that don't apply to current model type
           if (param.showWhen?.modelType && modelType !== param.showWhen.modelType) {
+            continue;
+          }
+          // Skip params hidden for the current form state (video-only, gated)
+          if (
+            !isParamVisible(param, {
+              inputExt: inputExt || task.defaultInputExt,
+              taskParams,
+            })
+          ) {
             continue;
           }
           // Params with showWhen are required when shown
@@ -988,16 +1233,45 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
                 if (param.showWhen?.modelType) {
                   return modelType === param.showWhen.modelType;
                 }
-                return true;
+                // Hide params the task would ignore (video-only for images,
+                // or gated on another param's value).
+                return isParamVisible(param, {
+                  inputExt: inputExt || task.defaultInputExt,
+                  taskParams,
+                });
               })
               .map((param) => {
                 // Params with showWhen are required when shown
-                const isRequired = param.showWhen ? true : param.required;
+                const paramRequired = param.showWhen ? true : param.required;
+                // A select always resolves to a value (default / first option),
+                // so a "required" marker on it is misleading — only show it for
+                // free-entry fields the user could actually leave blank.
+                const showRequiredMark =
+                  paramRequired && param.type !== "select";
+                // Booleans use the shared checkbox component (label + help built in).
+                if (param.type === "checkbox") {
+                  const checked =
+                    taskParams[param.name] === true ||
+                    taskParams[param.name] === "true";
+                  return (
+                    <ServiceModalCheckBox
+                      key={param.name}
+                      id={`param-${param.name}`}
+                      checked={checked}
+                      onChange={(e) =>
+                        handleTaskParamChange(param.name, e.target.checked)
+                      }
+                      disabled={isSubmitting}
+                      label={param.label}
+                      help={param.help}
+                    />
+                  );
+                }
                 return (
               <fieldset key={param.name}>
                 <label className="block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100 mb-1">
                   {param.label}
-                  {isRequired && <span className="text-red-500 ml-1">*</span>}
+                  {showRequiredMark && <span className="text-red-500 ml-1">*</span>}
                 </label>
                 {param.type === "select" ? (
                   <Listbox
@@ -1045,6 +1319,15 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
                       </ListboxOptions>
                     </div>
                   </Listbox>
+                ) : param.type === "textarea" ? (
+                  <textarea
+                    value={taskParams[param.name] || ""}
+                    onChange={(e) => handleTaskParamChange(param.name, e.target.value)}
+                    placeholder={param.placeholder}
+                    disabled={isSubmitting}
+                    rows={3}
+                    className="block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-500 sm:text-sm sm:leading-6 disabled:bg-gray-100 dark:disabled:bg-gray-800"
+                  />
                 ) : (
                   <input
                     type="text"
@@ -1067,6 +1350,7 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
               <fieldset>
                 <label className="block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100 mb-1">
                   Prompt
+                  {task.promptRequired && <span className="text-red-500 ml-1">*</span>}
                 </label>
                 <textarea
                   value={taskParams.prompt || ""}
@@ -1077,7 +1361,9 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
                   className="block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-500 sm:text-sm sm:leading-6 disabled:bg-gray-100 dark:disabled:bg-gray-800"
                 />
                 <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  Leave empty to use the default prompt shown above.
+                  {task.promptRequired
+                    ? "A prompt is required for this task."
+                    : "Leave empty to use the default prompt shown above."}
                 </p>
               </fieldset>
             )}

--- a/web/src/routes/jobs/components/NewJobModal.test.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.test.jsx
@@ -1,0 +1,176 @@
+import { describe, test, expect } from "vitest";
+
+import {
+  TASKS,
+  coerceParamValue,
+  isParamVisible,
+  applyTranslateSourceLang,
+} from "./NewJobModal";
+
+const detect = TASKS.find((t) => t.id === "detect");
+const translate = TASKS.find((t) => t.id === "translate");
+const transcribe = TASKS.find((t) => t.id === "transcribe");
+
+describe("coerceParamValue", () => {
+  test("coerces number-typed params to real numbers", () => {
+    // Form inputs are strings; tigerflow consumes these raw (e.g. batch_size > 1),
+    // so a string would crash the task. They must arrive as JSON numbers.
+    expect(coerceParamValue(detect, "batch_size", "4")).toBe(4);
+    expect(coerceParamValue(detect, "threshold", "0.3")).toBe(0.3);
+    expect(typeof coerceParamValue(detect, "batch_size", "4")).toBe("number");
+  });
+
+  test("coerces boolean-typed params to real booleans", () => {
+    // Checkboxes store real booleans; legacy string values still coerce.
+    expect(coerceParamValue(detect, "compile", true)).toBe(true);
+    expect(coerceParamValue(detect, "compile", false)).toBe(false);
+    expect(coerceParamValue(detect, "compile", "true")).toBe(true);
+    expect(coerceParamValue(transcribe, "raw", "false")).toBe(false);
+  });
+
+  test("passes string params through unchanged", () => {
+    expect(coerceParamValue(detect, "dtype", "float16")).toBe("float16");
+    expect(coerceParamValue(detect, "labels", "cat,dog")).toBe("cat,dog");
+  });
+
+  test("returns an unparseable number value unchanged", () => {
+    expect(coerceParamValue(detect, "batch_size", "abc")).toBe("abc");
+  });
+
+  test("returns the raw value for an unknown param", () => {
+    expect(coerceParamValue(detect, "not_a_param", "x")).toBe("x");
+  });
+});
+
+describe("TASKS param definitions", () => {
+  test("every task exposes a params array", () => {
+    for (const task of TASKS) {
+      expect(Array.isArray(task.params)).toBe(true);
+    }
+  });
+
+  test("boolean params are checkboxes with a boolean valueType", () => {
+    // Guard against re-introducing the string-typed bug: any conceptual boolean
+    // must be a checkbox carrying valueType "boolean" so it is coerced.
+    const booleans = new Set(["compile", "raw", "use_fallback_prompt"]);
+    for (const task of TASKS) {
+      for (const param of task.params) {
+        if (booleans.has(param.name)) {
+          expect(param.type).toBe("checkbox");
+          expect(param.valueType).toBe("boolean");
+        }
+      }
+    }
+  });
+
+  test("ocr marks its prompt as required (no server-side default)", () => {
+    const ocr = TASKS.find((t) => t.id === "ocr");
+    expect(ocr.promptRequired).toBe(true);
+    expect(ocr.defaultPrompt).toBeTruthy();
+  });
+
+  test("translate target language defaults to English", () => {
+    // Without an explicit default the renderer falls back to options[0]
+    // (Afrikaans), which is a poor default; the image default is "en".
+    const targetLang = translate.params.find((p) => p.name === "target_lang");
+    expect(targetLang.default).toBe("en");
+  });
+});
+
+describe("isParamVisible — videoOnly", () => {
+  const videoParam = detect.params.find((p) => p.name === "batch_size");
+  const imageParam = detect.params.find((p) => p.name === "threshold");
+
+  test("video-only params are hidden for image inputs", () => {
+    expect(isParamVisible(videoParam, { inputExt: ".jpg" })).toBe(false);
+    expect(isParamVisible(videoParam, { inputExt: ".png" })).toBe(false);
+  });
+
+  test("video-only params are shown for video inputs", () => {
+    expect(isParamVisible(videoParam, { inputExt: ".mp4" })).toBe(true);
+    expect(isParamVisible(videoParam, { inputExt: ".mov" })).toBe(true);
+  });
+
+  test("non-video params are always visible", () => {
+    expect(isParamVisible(imageParam, { inputExt: ".jpg" })).toBe(true);
+    expect(isParamVisible(imageParam, { inputExt: ".mp4" })).toBe(true);
+  });
+
+  test("detect's video-only params are flagged", () => {
+    for (const name of ["batch_size", "sample_fps", "compile"]) {
+      const p = detect.params.find((x) => x.name === name);
+      expect(p.videoOnly).toBe(true);
+    }
+  });
+});
+
+describe("isParamVisible — showWhenParam", () => {
+  const batchSize = transcribe.params.find((p) => p.name === "batch_size");
+  const raw = transcribe.params.find((p) => p.name === "raw");
+
+  test("transcribe batch_size shows only for the batched strategy", () => {
+    // Default (windowing unset) falls back to the gate's default "batched".
+    expect(isParamVisible(batchSize, { taskParams: {} })).toBe(true);
+    expect(
+      isParamVisible(batchSize, { taskParams: { windowing: "batched" } })
+    ).toBe(true);
+    expect(
+      isParamVisible(batchSize, { taskParams: { windowing: "native" } })
+    ).toBe(false);
+  });
+
+  test("transcribe raw shows only for JSON output", () => {
+    expect(isParamVisible(raw, { taskParams: { output_format: "json" } })).toBe(
+      true
+    );
+    // Default output_format is "text", so raw is hidden by default.
+    expect(isParamVisible(raw, { taskParams: {} })).toBe(false);
+    expect(isParamVisible(raw, { taskParams: { output_format: "text" } })).toBe(
+      false
+    );
+  });
+
+  test("prompt params show for chat/auto backends, not tgemma", () => {
+    // Both prompt_template and use_fallback_prompt are unused for tgemma models.
+    for (const name of ["prompt_template", "use_fallback_prompt"]) {
+      const p = translate.params.find((x) => x.name === name);
+      expect(isParamVisible(p, { taskParams: {} })).toBe(true); // default "auto"
+      expect(
+        isParamVisible(p, { taskParams: { model_backend: "chat" } })
+      ).toBe(true);
+      expect(
+        isParamVisible(p, { taskParams: { model_backend: "tgemma" } })
+      ).toBe(false);
+    }
+  });
+});
+
+describe("applyTranslateSourceLang", () => {
+  test("'auto' becomes auto_lang_detect=true with no source_lang", () => {
+    const params = { source_lang: "auto", target_lang: "de" };
+    applyTranslateSourceLang(params);
+    expect(params.source_lang).toBeUndefined();
+    expect(params.auto_lang_detect).toBe(true);
+  });
+
+  test("an explicit language sets auto_lang_detect=false and keeps source_lang", () => {
+    const params = { source_lang: "fr", target_lang: "en" };
+    applyTranslateSourceLang(params);
+    expect(params.source_lang).toBe("fr");
+    expect(params.auto_lang_detect).toBe(false);
+  });
+
+  test("the source_lang dropdown is the only auto-detect control", () => {
+    // The redundant auto_lang_detect checkbox was removed; the dropdown drives it.
+    const names = translate.params.map((p) => p.name);
+    expect(names).toContain("source_lang");
+    expect(names).not.toContain("auto_lang_detect");
+  });
+
+  test("translate uses prompt_template, not a generic prompt field", () => {
+    // The translate task has no `prompt` param; a defaultPrompt would render a
+    // spurious "Prompt" field. prompt_template is the real control.
+    expect(translate.defaultPrompt).toBeNull();
+    expect(translate.params.map((p) => p.name)).toContain("prompt_template");
+  });
+});

--- a/web/src/routes/jobs/components/NewJobModal.test.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.test.jsx
@@ -102,6 +102,30 @@ describe("isParamVisible — videoOnly", () => {
       expect(p.videoOnly).toBe(true);
     }
   });
+
+  test("dtype applies to both image and video (not video-only)", () => {
+    const dtype = detect.params.find((p) => p.name === "dtype");
+    expect(dtype.videoOnly).toBeUndefined();
+    expect(isParamVisible(dtype, { inputExt: ".jpg" })).toBe(true);
+    expect(isParamVisible(dtype, { inputExt: ".mp4" })).toBe(true);
+  });
+});
+
+describe("isParamVisible — showWhen.modelType", () => {
+  // detect's `labels` is zero-shot only. A stale value must not leak through
+  // any call site when the model type no longer matches.
+  const labels = detect.params.find((p) => p.name === "labels");
+
+  test("model-type-gated params show only for the matching model type", () => {
+    expect(
+      isParamVisible(labels, { modelType: "zero-shot-object-detection" })
+    ).toBe(true);
+    expect(isParamVisible(labels, { modelType: "object-detection" })).toBe(
+      false
+    );
+    // No model type known yet -> hidden (can't confirm the match).
+    expect(isParamVisible(labels, {})).toBe(false);
+  });
 });
 
 describe("isParamVisible — showWhenParam", () => {


### PR DESCRIPTION
## Summary

- **Fix a latent crash in the job launcher.** Form inputs are strings, but the tigerflow-ml tasks consume params by their real type (e.g. `batch_size > 1`), so setting any numeric param from the UI would crash the job with a `str`-vs-`int` error. Params now carry a `valueType` and are coerced to real JSON numbers/booleans at submit; empty and context-hidden optionals are dropped rather than sent blank. (The CLI path was already correct via `json.loads`.)
- **Complete and correct the per-task options** against the tigerflow-ml 0.1.1 schema: surface the previously-missing optional params for detect/ocr/transcribe/translate, render booleans with the shared `ServiceModalCheckBox`, and gate params on context so only applicable options show — detect's video-only params hide for image inputs; transcribe's `batch_size`/`overlap_s`/`raw` hide unless their strategy/output applies; translate's prompt params hide for the tgemma backend.
- **Fix translate UX bugs:** collapse the redundant auto-detect controls (a "Source Language" dropdown *and* a checkbox that could contradict) into the dropdown, mapping "Auto-detect" to the image's `auto_lang_detect`/`source_lang` pair (the dropdown previously sent the invalid value `"auto"`); default the target language to English (was Afrikaans, the first option); and drop a spurious "Prompt" field the translate task doesn't accept.
- **Make the OCR prompt required** (the image has no server-side default), and tidy labels, help text, and required-field markers (a `*` on an always-defaulted `select` is misleading).

## Test plan

- `cd web && npm run lint` — 0 errors (1 pre-existing warning in an untouched file)
- `cd web && npm test` — 334 passed (40 files); adds `NewJobModal.test.jsx` covering param coercion, context-gated visibility (`videoOnly` / value-gated), the translate source-language transform, required-prompt handling, and the target-language default
- Verified each param name, type, default, and required/optional status against the tigerflow-ml 0.1.1 task `Params` classes (detect/ocr/transcribe/translate).
- Frontend-only change; no backend or API changes.
