### PR TITLE
feat: add preliminary support for the chat batch task

### DIFF
--- a/lib/src/blackfish/server/jobs/tasks.py
+++ b/lib/src/blackfish/server/jobs/tasks.py
@@ -36,6 +36,7 @@ DEFAULT_INPUT_EXT: dict[str, str] = {
 DEFAULT_OUTPUT_EXT: dict[str, str] = {
     "detect": ".json",  # Object detection always outputs JSON
     "translate": ".txt",  # Translation outputs text files
+    "chat": ".txt",  # Chat writes the model response as text
 }
 
 

--- a/lib/src/blackfish/server/jobs/tasks.py
+++ b/lib/src/blackfish/server/jobs/tasks.py
@@ -19,6 +19,7 @@ SUPPORTED_TASKS: dict[str, str] = {
     "ocr": "tigerflow_ml.text.ocr.local",
     "transcribe": "tigerflow_ml.audio.transcribe.local",
     "translate": "tigerflow_ml.text.translate.local",
+    "chat": "tigerflow_ml.text.chat.local",
 }
 
 # Default input file extensions for each task
@@ -27,6 +28,7 @@ DEFAULT_INPUT_EXT: dict[str, str] = {
     "ocr": ".jpg",
     "transcribe": ".wav",
     "translate": ".txt",
+    "chat": ".txt",
 }
 
 # Default output file extensions for each task

--- a/lib/src/blackfish/server/templates/batch_local.sh
+++ b/lib/src/blackfish/server/templates/batch_local.sh
@@ -14,6 +14,7 @@ BLACKFISH_PIPELINE_EOF
 
 {%- if provider == "docker" %}
 docker run --rm {{ '--runtime nvidia --gpus all' if job_config.gres else '' }} \
+  -e VLLM_USE_FLASHINFER_SAMPLER=0 \
   -v {{ cache_dir }}:/cache \
   -v {{ input_dir }}:{{ input_dir }} \
   -v {{ output_dir }}:{{ output_dir }} \
@@ -25,6 +26,7 @@ docker run --rm {{ '--runtime nvidia --gpus all' if job_config.gres else '' }} \
 export SINGULARITY_NO_EVAL=1
 apptainer run {{ '--nv' if job_config.gres else '' }} \
   --env PYTHONNOUSERSITE=1 \
+  --env VLLM_USE_FLASHINFER_SAMPLER=0 \
   --bind {{ cache_dir }}:/cache \
   --bind {{ input_dir }} \
   --bind {{ output_dir }} \

--- a/lib/src/blackfish/server/templates/batch_slurm.sh
+++ b/lib/src/blackfish/server/templates/batch_slurm.sh
@@ -26,6 +26,7 @@ BLACKFISH_PIPELINE_EOF
 
 apptainer run {{ '--nv' if job_config.gres else '' }} \
   --env PYTHONNOUSERSITE=1 \
+  --env VLLM_USE_FLASHINFER_SAMPLER=0 \
   --bind {{ cache_dir }}:/cache \
   --bind {{ input_dir }} \
   --bind {{ output_dir }} \

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -28,6 +28,7 @@ from blackfish.server.jobs.tasks import (
     get_task_library,
     build_pipeline_config,
     get_default_input_ext,
+    get_default_output_ext,
 )
 
 
@@ -890,6 +891,14 @@ class TestTasks:
         """Chat defaults to text input (preliminary support is text-only)."""
         assert get_default_input_ext("chat") == ".txt"
 
+    def test_chat_default_output_ext_is_text(self) -> None:
+        """Chat writes text output. This default is load-bearing: both the
+        pipeline's output_ext (what tigerflow writes) and the results endpoint's
+        path (what Blackfish fetches) derive from it, so an unset value would
+        make tigerflow write ``.out`` while Blackfish looked for no extension.
+        """
+        assert get_default_output_ext("chat") == ".txt"
+
     def test_build_pipeline_config_builds_chat_task(self) -> None:
         """build_pipeline_config emits a local chat task with its prompt param."""
         config = build_pipeline_config(
@@ -907,3 +916,17 @@ class TestTasks:
         assert task["module"] == "tigerflow_ml.text.chat.local"
         assert task["input_ext"] == ".txt"
         assert task["params"]["prompt"] == "Summarize: {text}"
+
+    def test_chat_pipeline_yaml_sets_text_output_ext(self) -> None:
+        """A chat job with no explicit output_ext falls back to .txt in the
+        pipeline (otherwise tigerflow would write .out and the results endpoint,
+        which resolves the same default, would look for the wrong path).
+        """
+        job = create_test_batch_job(
+            task="chat",
+            input_ext=".txt",
+            output_ext=None,
+            params={"prompt": "Summarize: {text}"},
+        )
+        rendered = job._pipeline_yaml()
+        assert "output_ext: .txt" in rendered

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -27,6 +27,7 @@ from blackfish.server.jobs.tasks import (
     is_supported_task,
     get_task_library,
     build_pipeline_config,
+    get_default_input_ext,
 )
 
 
@@ -782,6 +783,7 @@ class TestTasks:
         assert is_supported_task("ocr") is True
         assert is_supported_task("transcribe") is True
         assert is_supported_task("translate") is True
+        assert is_supported_task("chat") is True
 
     def test_is_supported_task_returns_false_for_invalid_task(self) -> None:
         """is_supported_task should return False for unsupported tasks."""
@@ -878,3 +880,30 @@ class TestTasks:
         """No gpus/gres key -> the default gres applies (unchanged behavior)."""
         job = create_test_batch_job(resources={"cpus": 2, "mem": 4})
         assert job._job_config().gres == DEFAULT_JOB_RESOURCES["gres"]
+
+    def test_chat_task_is_supported(self) -> None:
+        """The chat task maps to the tigerflow-ml text.chat.local module."""
+        assert is_supported_task("chat") is True
+        assert get_task_library("chat") == "tigerflow_ml.text.chat.local"
+
+    def test_chat_default_input_ext_is_text(self) -> None:
+        """Chat defaults to text input (preliminary support is text-only)."""
+        assert get_default_input_ext("chat") == ".txt"
+
+    def test_build_pipeline_config_builds_chat_task(self) -> None:
+        """build_pipeline_config emits a local chat task with its prompt param."""
+        config = build_pipeline_config(
+            task="chat",
+            input_ext=".txt",
+            params={
+                "model": "meta-llama/Llama-3.1-8B-Instruct",
+                "prompt": "Summarize: {text}",
+            },
+        )
+
+        task = config["tasks"][0]
+        assert task["name"] == "chat"
+        assert task["kind"] == "local"
+        assert task["module"] == "tigerflow_ml.text.chat.local"
+        assert task["input_ext"] == ".txt"
+        assert task["params"]["prompt"] == "Summarize: {text}"

--- a/lib/tests/unit/test_templates.py
+++ b/lib/tests/unit/test_templates.py
@@ -110,6 +110,9 @@ def test_batch_slurm_renders_apptainer_run():
     # Container invocation
     assert "apptainer run" in rendered
     assert "--env PYTHONNOUSERSITE=1" in rendered
+    # Disable vLLM's flashinfer sampler, whose runtime kernel JIT needs a C
+    # compiler the tigerflow-ml image doesn't ship (breaks vLLM tasks on GPU).
+    assert "--env VLLM_USE_FLASHINFER_SAMPLER=0" in rendered
     assert f"--bind {CACHE_DIR}:/cache" in rendered
     assert f"/images/{sif}" in rendered
     # tigerflow pipeline run and resume behavior
@@ -128,6 +131,7 @@ def test_batch_local_renders_docker_run():
     docker_ref = DEFAULT_IMAGES["tigerflow_ml"].docker_ref
 
     assert "docker run --rm" in rendered
+    assert "-e VLLM_USE_FLASHINFER_SAMPLER=0" in rendered
     assert f"-v {CACHE_DIR}:/cache" in rendered
     assert docker_ref in rendered
     assert f"run {PIPELINE_PATH} {INPUT_DIR} {OUTPUT_DIR}" in rendered
@@ -140,5 +144,6 @@ def test_batch_local_renders_apptainer_run():
 
     assert "apptainer run" in rendered
     assert "--env PYTHONNOUSERSITE=1" in rendered
+    assert "--env VLLM_USE_FLASHINFER_SAMPLER=0" in rendered
     assert f"/images/{sif}" in rendered
     assert "docker run" not in rendered

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -34,7 +34,7 @@ import { selectTierByModelSize, isRemoteProfile } from "@/lib/util";
 import PropTypes from "prop-types";
 
 // Task definitions - each task maps to a TigerFlow task type
-// id must match backend SUPPORTED_TASKS keys (detect, ocr, transcribe, translate)
+// id must match backend SUPPORTED_TASKS keys (detect, ocr, transcribe, translate, chat)
 // service can be a string or array of strings for tasks that support multiple model types
 export const TASKS = [
   {
@@ -448,6 +448,35 @@ export const TASKS = [
         label: "Use fallback prompt",
         help: "When the source language can't be determined, use a fallback prompt that omits {source_lang}.",
         default: false,
+      },
+    ],
+  },
+  {
+    id: "chat",
+    name: "Chat",
+    description: "Apply a prompt to each text file",
+    service: "text-generation", // Uses LLM models
+    defaultInputExt: ".txt",
+    // Chat has no server-side default prompt, so it is required. Preliminary
+    // support is text-only; image inputs (and max_image_pixels) come later.
+    defaultPrompt: "Summarize the following text:\n\n{text}",
+    promptRequired: true,
+    promptHelp:
+      "Use {text} where each file's contents should go. Without {text}, the file contents follow the prompt.",
+    inputExtOptions: [
+      { value: ".txt", label: "Plain text (.txt)" },
+      { value: ".md", label: "Markdown (.md)" },
+      { value: ".log", label: "Log (.log)" },
+    ],
+    params: [
+      {
+        name: "temperature",
+        type: "text",
+        valueType: "number",
+        required: false,
+        label: "Temperature",
+        help: "Sampling temperature (0–2). Lower is more deterministic. Default: 0.0",
+        placeholder: "0.0",
       },
     ],
   },
@@ -1379,9 +1408,13 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
                   className="block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-500 sm:text-sm sm:leading-6 disabled:bg-gray-100 dark:disabled:bg-gray-800"
                 />
                 <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  {task.promptRequired
-                    ? "A prompt is required for this task."
-                    : "Leave empty to use the default prompt shown above."}
+                  {task.promptHelp ? (
+                    task.promptHelp
+                  ) : task.promptRequired ? (
+                    "A prompt is required for this task."
+                  ) : (
+                    "Leave empty to use the default prompt shown above."
+                  )}
                 </p>
               </fieldset>
             )}

--- a/web/src/routes/jobs/components/NewJobModal.test.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.test.jsx
@@ -76,6 +76,24 @@ describe("TASKS param definitions", () => {
     const targetLang = translate.params.find((p) => p.name === "target_lang");
     expect(targetLang.default).toBe("en");
   });
+
+  test("chat is registered, text-only, with a required prompt", () => {
+    const chat = TASKS.find((t) => t.id === "chat");
+    expect(chat).toBeDefined();
+    expect(chat.promptRequired).toBe(true);
+    expect(chat.defaultPrompt).toBeTruthy();
+    // Preliminary support is text-only (no image extensions yet).
+    const exts = chat.inputExtOptions.map((o) => o.value);
+    expect(exts).toContain(".txt");
+    expect(exts).not.toContain(".jpg");
+    // temperature is numeric so it coerces to a real number at submit.
+    const temp = chat.params.find((p) => p.name === "temperature");
+    expect(temp.valueType).toBe("number");
+    // max_image_pixels is deferred with image inputs.
+    expect(chat.params.map((p) => p.name)).not.toContain("max_image_pixels");
+    // The prompt help explains the {text} placeholder.
+    expect(chat.promptHelp).toMatch(/\{text\}/);
+  });
 });
 
 describe("isParamVisible — videoOnly", () => {


### PR DESCRIPTION
## Summary

- **Enable the tigerflow-ml `chat` batch task end-to-end.** Register `chat` → `tigerflow_ml.text.chat.local` in the backend `SUPPORTED_TASKS`/`DEFAULT_INPUT_EXT`, so the CLI (`--task` choice) and API (`is_supported_task`) accept it automatically — the registry is the single source of truth. Chat output is written as text (`DEFAULT_OUTPUT_EXT` = `.txt`), so result preview/download resolve the correct path.
- **Add a "Chat" entry to the job launcher** with text inputs (`.txt`/`.md`/`.log`), a required prompt (the image has no server-side default), and a `temperature` param. The prompt help explains the `{text}` placeholder — where each file's contents are injected — matching the image's own guidance.
- **Preliminary scope is text-only.** The chat task also accepts image inputs (with a `max_image_pixels` param) in tigerflow-ml; those are deferred and noted in the code so a follow-up can add them.

## Test plan

- `cd lib && uv run just lint` — ruff + mypy (strict) clean
- `cd lib && uv run just test` — 871 passed, 7 skipped; coverage 70%. New tests: chat is supported, maps to `text.chat.local`, defaults to `.txt` input, and builds a valid `local` pipeline config with its prompt param.
- `cd web && npm run lint && npm test` — 0 errors; 337 passed. New test asserts the chat task is text-only, has a required prompt, carries a numeric `temperature`, explains `{text}`, and omits `max_image_pixels` (deferred).
- Verified the chat task's params (`prompt` required, `temperature`, `max_image_pixels`) against the tigerflow-ml 0.1.1 `text/chat` `Params` class.

Closes #409
