### PR TITLE
fix: correct batch job resource field mapping for Slurm

### DIFF
--- a/lib/src/blackfish/server/jobs/base.py
+++ b/lib/src/blackfish/server/jobs/base.py
@@ -306,15 +306,23 @@ class BatchJob(UUIDAuditBase):
         return yaml.dump(config, default_flow_style=False)
 
     def _job_config(self) -> SlurmJobConfig:
-        """Build the sbatch resource config from ``self.resources``."""
-        res = {**DEFAULT_JOB_RESOURCES, **(self.resources or {})}
+        """Build the sbatch resource config from ``self.resources``.
+
+        GPU count accepts either ``gpus`` (what the launcher/services send) or
+        ``gres``. This is resolved against the *raw* request resources, not a
+        dict pre-merged with ``DEFAULT_JOB_RESOURCES`` — otherwise the default
+        ``gres`` would always shadow an explicit ``gpus``.
+        """
+        req = self.resources or {}
+        gpu_count = req.get("gres", req.get("gpus", DEFAULT_JOB_RESOURCES["gres"]))
+        res = {**DEFAULT_JOB_RESOURCES, **req}
         return SlurmJobConfig(
             name=self.name,
             time=str(res.get("time", DEFAULT_JOB_RESOURCES["time"])),
             nodes=int(res.get("nodes", 1)),
             ntasks_per_node=int(res.get("cpus", DEFAULT_JOB_RESOURCES["cpus"])),
             mem=int(res.get("mem", DEFAULT_JOB_RESOURCES["mem"])),
-            gres=int(res.get("gres", res.get("gpus", DEFAULT_JOB_RESOURCES["gres"]))),
+            gres=int(gpu_count),
             partition=res.get("partition"),
             constraint=res.get("constraint"),
             account=res.get("account"),

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -829,3 +829,37 @@ class TestTasks:
         assert task["output_ext"] == ".json"
         assert task["params"]["model"] == "openai/whisper-large-v3"
         assert task["params"]["language"] == "en"
+
+    def test_job_config_maps_account_from_resources(self) -> None:
+        """A Slurm account passed in resources reaches SlurmJobConfig.account.
+
+        The launcher sends the account as a top-level resources field (not a
+        free-form sbatch option), and clusters that require --account reject
+        jobs without it.
+        """
+        job = create_test_batch_job(resources={"account": "cses"})
+        assert job._job_config().account == "cses"
+
+    def test_job_config_account_is_none_when_absent(self) -> None:
+        """No account in resources -> None (no --account directive rendered)."""
+        job = create_test_batch_job(resources={})
+        assert job._job_config().account is None
+
+    def test_job_config_maps_resources_to_sbatch_fields(self) -> None:
+        """Tier resources map to the sbatch config the launcher must send:
+        cpus->ntasks_per_node, mem (GB int), gpus->gres, time, partition."""
+        job = create_test_batch_job(
+            resources={
+                "cpus": 8,
+                "mem": 64,
+                "gpus": 2,
+                "time": "02:00:00",
+                "partition": "gpu",
+            }
+        )
+        cfg = job._job_config()
+        assert cfg.ntasks_per_node == 8
+        assert cfg.mem == 64
+        assert cfg.gres == 2
+        assert cfg.time == "02:00:00"
+        assert cfg.partition == "gpu"

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -8,6 +8,7 @@ from blackfish.server.config import ContainerProvider
 from blackfish.server.images import DEFAULT_IMAGES
 from blackfish.server.job import JobState
 from blackfish.server.jobs.base import (
+    DEFAULT_JOB_RESOURCES,
     BatchJob,
     BatchJobStatus,
     create_tigerflow_client,
@@ -863,3 +864,17 @@ class TestTasks:
         assert cfg.gres == 2
         assert cfg.time == "02:00:00"
         assert cfg.partition == "gpu"
+
+    def test_job_config_honors_explicit_zero_gpus(self) -> None:
+        """An explicit gpus: 0 (CPU-only tier) yields gres 0, not the default 1.
+
+        The launcher must send gpus: 0 rather than omit it; omitting lets the
+        default (1) apply and a CPU job would still request a GPU.
+        """
+        job = create_test_batch_job(resources={"cpus": 2, "mem": 4, "gpus": 0})
+        assert job._job_config().gres == 0
+
+    def test_job_config_defaults_gpus_when_unspecified(self) -> None:
+        """No gpus/gres key -> the default gres applies (unchanged behavior)."""
+        job = create_test_batch_job(resources={"cpus": 2, "mem": 4})
+        assert job._job_config().gres == DEFAULT_JOB_RESOURCES["gres"]

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -961,16 +961,19 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
       const selectedTierObj = tiers.find(t => t.name === selectedTier);
       const jobResources = {};
 
-      // Map tier fields to backend format
+      // Map tier fields to the backend resource keys read by _job_config
+      // (cpus, mem in GB, gpus). Note the key is `mem` (an integer number of
+      // GB), not `memory` — the backend renders `--mem={mem}G`.
       if (selectedTierObj?.cpu_cores) jobResources.cpus = selectedTierObj.cpu_cores;
-      if (selectedTierObj?.memory_gb) jobResources.memory = `${selectedTierObj.memory_gb}GB`;
+      if (selectedTierObj?.memory_gb) jobResources.mem = selectedTierObj.memory_gb;
       if (selectedTierObj?.gpu_count) jobResources.gpus = selectedTierObj.gpu_count;
 
-      // Add optional advanced options as sbatch_options
-      const sbatchOptions = [];
-      if (account) sbatchOptions.push(`--account=${account}`);
+      // Slurm account: the batch job's sbatch script renders --account from
+      // job_config.account (a top-level resources field), so send it there —
+      // not as a free-form sbatch_options entry, which the batch templates
+      // don't render (matching how services pass the account).
+      if (account) jobResources.account = account;
       if (workerTimeout) jobResources.time = `${workerTimeout}:00`;
-      if (sbatchOptions.length > 0) jobResources.sbatch_options = sbatchOptions;
 
       // Derive cache_dir from model's model_dir (parent directory)
       const cacheDir = model?.model_dir ? dirname(model.model_dir) : null;

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -528,6 +528,21 @@ export function applyTranslateSourceLang(params) {
   return params;
 }
 
+// Build the job `resources` payload from the selected tier plus optional
+// account/time. Maps to the keys _job_config reads (cpus, mem in GB, gpus).
+// GPU count uses an explicit null check, not truthiness, so the CPU-only tier
+// (gpu_count 0) sends `gpus: 0` — otherwise the backend's default (1 GPU)
+// would apply and a CPU job would still request a GPU.
+export function buildJobResources(tier, { account, workerTimeout } = {}) {
+  const resources = {};
+  if (tier?.cpu_cores != null) resources.cpus = tier.cpu_cores;
+  if (tier?.memory_gb != null) resources.mem = tier.memory_gb;
+  if (tier?.gpu_count != null) resources.gpus = tier.gpu_count;
+  if (account) resources.account = account;
+  if (workerTimeout) resources.time = `${workerTimeout}:00`;
+  return resources;
+}
+
 // ISO language codes supported by langdetect
 const ISO_LANGUAGE_CODES = new Set([
   "af", "ar", "bg", "bn", "ca", "cs", "cy", "da", "de", "el", "en", "es", "et",
@@ -957,23 +972,14 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
     setSubmitError(null);
 
     try {
-      // Build resources object from selected tier
+      // Build the resources payload from the selected tier. See
+      // buildJobResources for the tier -> backend key mapping, the account
+      // handling, and why the CPU-only tier must send an explicit gpus: 0.
       const selectedTierObj = tiers.find(t => t.name === selectedTier);
-      const jobResources = {};
-
-      // Map tier fields to the backend resource keys read by _job_config
-      // (cpus, mem in GB, gpus). Note the key is `mem` (an integer number of
-      // GB), not `memory` — the backend renders `--mem={mem}G`.
-      if (selectedTierObj?.cpu_cores) jobResources.cpus = selectedTierObj.cpu_cores;
-      if (selectedTierObj?.memory_gb) jobResources.mem = selectedTierObj.memory_gb;
-      if (selectedTierObj?.gpu_count) jobResources.gpus = selectedTierObj.gpu_count;
-
-      // Slurm account: the batch job's sbatch script renders --account from
-      // job_config.account (a top-level resources field), so send it there —
-      // not as a free-form sbatch_options entry, which the batch templates
-      // don't render (matching how services pass the account).
-      if (account) jobResources.account = account;
-      if (workerTimeout) jobResources.time = `${workerTimeout}:00`;
+      const jobResources = buildJobResources(selectedTierObj, {
+        account,
+        workerTimeout,
+      });
 
       // Derive cache_dir from model's model_dir (parent directory)
       const cacheDir = model?.model_dir ? dirname(model.model_dir) : null;

--- a/web/src/routes/jobs/components/NewJobModal.test.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.test.jsx
@@ -5,6 +5,7 @@ import {
   coerceParamValue,
   isParamVisible,
   applyTranslateSourceLang,
+  buildJobResources,
 } from "./NewJobModal";
 
 const detect = TASKS.find((t) => t.id === "detect");
@@ -196,5 +197,45 @@ describe("applyTranslateSourceLang", () => {
     // spurious "Prompt" field. prompt_template is the real control.
     expect(translate.defaultPrompt).toBeNull();
     expect(translate.params.map((p) => p.name)).toContain("prompt_template");
+  });
+});
+
+describe("buildJobResources", () => {
+  const cpuTier = { name: "CPU Only", gpu_count: 0, cpu_cores: 2, memory_gb: 4 };
+  const gpuTier = { name: "GPU", gpu_count: 2, cpu_cores: 6, memory_gb: 32 };
+
+  test("CPU-only tier sends an explicit gpus: 0 (not omitted)", () => {
+    // Omitting gpus lets the backend default (1 GPU) apply, so a CPU job would
+    // still request a GPU. gpu_count 0 must be sent through.
+    const res = buildJobResources(cpuTier);
+    expect(res.gpus).toBe(0);
+    expect(res.cpus).toBe(2);
+    expect(res.mem).toBe(4);
+  });
+
+  test("GPU tier maps gpu_count to gpus and memory_gb to mem (int GB)", () => {
+    const res = buildJobResources(gpuTier);
+    expect(res.gpus).toBe(2);
+    expect(res.mem).toBe(32); // key is `mem`, an int, not `memory: \"32GB\"`
+    expect(res).not.toHaveProperty("memory");
+  });
+
+  test("account and worker timeout are included when provided", () => {
+    const res = buildJobResources(gpuTier, {
+      account: "cses",
+      workerTimeout: "02:00",
+    });
+    expect(res.account).toBe("cses");
+    expect(res.time).toBe("02:00:00");
+  });
+
+  test("account and time are omitted when absent", () => {
+    const res = buildJobResources(gpuTier);
+    expect(res).not.toHaveProperty("account");
+    expect(res).not.toHaveProperty("time");
+  });
+
+  test("an undefined tier yields an empty resources object", () => {
+    expect(buildJobResources(undefined)).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary

The job launcher and the backend's `_job_config` disagreed on three resource keys, so **every Slurm batch job** got the wrong allocation. Surfaced while submitting a job on an account-required cluster (Della), which rejected it outright.

- **account** — the launcher sent it as a free-form `sbatch_options` entry (`--account=…`), but the batch sbatch templates only render `--account` from `job_config.account` and don't render `sbatch_options` at all. Result: no `--account` directive → `sbatch: error: You have to specify an account…`. Now sent as a top-level `account` resource, matching how services pass it.
- **memory** — the launcher sent `memory: "32GB"`, but the backend reads an integer `mem` (GB) and renders `--mem={mem}G`. The `memory` key was ignored, so every job silently fell back to the default 32G. Now sends `mem` (int GB).
- **gpus** — `DEFAULT_JOB_RESOURCES["gres"]` shadowed the request's `gpus` in the `{**defaults, **resources}` merge, so `res.get("gres", res.get("gpus"))` always found the default `gres=1`. Every job got 1 GPU regardless of tier. Now resolves `gpus`/`gres` from the raw request before the default merge.

These are pre-existing bugs affecting all batch jobs, independent of any task.

## Test plan

- `cd lib && uv run just lint` — ruff + mypy (strict) clean
- `cd lib && uv run pytest tests/unit/test_jobs.py` — 48 passed; new tests assert `resources` → `SlurmJobConfig` mapping for account (present/absent) and cpus/mem/gpus/time/partition.
- `cd web && npm run lint && npm test` — 0 errors; 336 passed.
- Verified against the batch sbatch templates (`base_slurm.sh` renders `--account` only from `job_config.account`; no `sbatch_options` rendering) and `_job_config` in `jobs/base.py`.