### PR TITLE
fix: batch job UI polish for v1.0

### DIFF
--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -1528,7 +1528,8 @@ async def get_job(
 
 @dataclass
 class JobFileResult:
-    file: str
+    file: str  # input file as tigerflow reports it (basename/relative)
+    input_file: str  # full path to the input file
     task: str
     output_file: str | None
     started_at: str
@@ -1569,6 +1570,14 @@ async def get_job_results(
         for file_metric in task_metrics.files:
             stem = PurePosixPath(file_metric.file).stem
             output_file = f"{job.output_dir}/{task_name}/{stem}{output_ext}"
+            # Full input path, symmetric with output_file. tigerflow reports the
+            # file relative to the input dir, so join unless it's already absolute.
+            input_path = PurePosixPath(file_metric.file)
+            input_file = (
+                str(input_path)
+                if input_path.is_absolute()
+                else f"{job.input_dir}/{file_metric.file}"
+            )
 
             key = (task_name, file_metric.file)
             prev = latest.get(key)
@@ -1577,6 +1586,7 @@ async def get_job_results(
             ) > datetime.fromisoformat(prev.finished_at):
                 latest[key] = JobFileResult(
                     file=file_metric.file,
+                    input_file=input_file,
                     task=task_name,
                     output_file=output_file
                     if file_metric.status == "success"

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -1541,8 +1541,14 @@ async def get_job(
 
 @dataclass
 class JobFileResult:
-    file: str  # input file as tigerflow reports it (basename/relative)
-    input_file: str  # full path to the input file
+    """A per-file batch result.
+
+    ``file`` is the raw name tigerflow reports (basename/relative) and is used
+    only for identity/dedup; use ``input_file`` (the full path) for display.
+    """
+
+    file: str  # raw name as tigerflow reports it — identity/dedup only
+    input_file: str  # full path to the input file (for display)
     task: str
     output_file: str | None
     started_at: str

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -543,7 +543,17 @@ async def get_files(
 
 
 IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp"]
-AUDIO_EXTENSIONS = [".wav", ".mp3"]
+# Kept in sync with the transcribe task's accepted inputs and the frontend
+# FILE_TYPE_CONFIG audio extensions (web/src/lib/fileApi.js).
+AUDIO_EXTENSIONS = [".wav", ".mp3", ".flac", ".m4a", ".ogg", ".webm"]
+AUDIO_CONTENT_TYPES = {
+    ".wav": "audio/wav",
+    ".mp3": "audio/mpeg",
+    ".flac": "audio/flac",
+    ".m4a": "audio/mp4",
+    ".ogg": "audio/ogg",
+    ".webm": "audio/webm",
+}
 
 # Mapping of task/image types to compatible pipeline tags
 # e.g., text-generation services can also run image-text-to-text models (VLMs)
@@ -932,10 +942,7 @@ async def get_audio(path: str, profile: Optional[str] = None) -> File | Response
 
         # Determine content type from extension
         ext = os.path.splitext(path)[1].lower()
-        content_type = {
-            ".wav": "audio/wav",
-            ".mp3": "audio/mpeg",
-        }.get(ext, "application/octet-stream")
+        content_type = AUDIO_CONTENT_TYPES.get(ext, "application/octet-stream")
 
         return Response(
             content=content,
@@ -952,7 +959,13 @@ async def get_audio(path: str, profile: Optional[str] = None) -> File | Response
     validate_file_exists(file_path)
     validate_file_extension(file_path, AUDIO_EXTENSIONS)
 
-    return try_read_file(file_path)
+    # Set an explicit audio media type: mimetypes guesses inconsistently for
+    # .flac/.m4a across platforms, which can leave the browser unable to play.
+    ext = file_path.suffix.lower()
+    return File(
+        path=file_path,
+        media_type=AUDIO_CONTENT_TYPES.get(ext, "application/octet-stream"),
+    )
 
 
 @put("/api/audio", guards=ENDPOINT_GUARDS)

--- a/lib/tests/api/test_audio.py
+++ b/lib/tests/api/test_audio.py
@@ -93,7 +93,7 @@ class TestUploadAudioAPI:
     async def test_upload_audio_valid_extensions(self, client: AsyncTestClient):
         """Test that all valid audio extensions are accepted."""
 
-        valid_extensions = [".wav", ".mp3"]
+        valid_extensions = [".wav", ".mp3", ".flac", ".m4a", ".ogg", ".webm"]
         audio_bytes = self._create_test_audio()
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -219,6 +219,19 @@ class TestGetAudioAPI:
             # Should return success with audio data
             assert response.status_code == 200
             assert response.content == original_data
+
+    async def test_get_audio_flac_content_type(self, client: AsyncTestClient):
+        """A .flac file serves with an explicit audio/flac content type so the
+        browser can play it (mimetypes guesses inconsistently for .flac)."""
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_path = os.path.join(temp_dir, "test.flac")
+            self._create_and_save_audio(file_path)
+
+            response = await client.get("/api/audio", params={"path": file_path})
+
+            assert response.status_code == 200
+            assert response.headers["content-type"].startswith("audio/flac")
 
     async def test_get_audio_not_found(self, client: AsyncTestClient):
         """Test retrieving a non-existent audio file."""

--- a/lib/tests/api/test_jobs.py
+++ b/lib/tests/api/test_jobs.py
@@ -582,6 +582,9 @@ class TestGetJobResultsAPI:
         success = next(r for r in results if r["file"] == "audio_001.wav")
         assert success["status"] == "success"
         assert success["task"] == "transcribe"
+        # input_file is the full path (input_dir + reported file), symmetric
+        # with output_file, so both preview rows can show full paths.
+        assert success["input_file"] == "/data/input/audio_001.wav"
         assert success["output_file"] == "/data/output/transcribe/audio_001.json"
         assert success["error"] is None
 

--- a/web/src/components/Pagination.jsx
+++ b/web/src/components/Pagination.jsx
@@ -14,17 +14,38 @@ import PropTypes from "prop-types";
  * @param {boolean} options.disabled - Disable pagination functionality.
  * @return {JSX.Element}
  */
-function Pagination({ filesPerPage, totalFiles, currentPage, setCurrentPage, disabled }) {
-  const pageNumbers = [];
-
-  for (let i = 1; i <= Math.ceil(totalFiles / filesPerPage); i++) {
-    pageNumbers.push(i);
+// Build the list of page items to render: always the first and last page, the
+// current page and its neighbours, and "…" placeholders for the gaps between.
+// Returns numbers for pages and the string "…" for a collapsed range.
+export function getPageItems(currentPage, totalPages, siblings = 1) {
+  if (totalPages <= 1) return [];
+  // Show every page when the full range is small enough that ellipsis wouldn't
+  // save space (first + last + current±siblings + two ellipses).
+  const maxPlain = siblings * 2 + 5;
+  if (totalPages <= maxPlain) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
   }
+
+  const left = Math.max(currentPage - siblings, 1);
+  const right = Math.min(currentPage + siblings, totalPages);
+  const items = [1];
+  if (left > 2) items.push("…");
+  for (let i = left; i <= right; i++) {
+    if (i !== 1 && i !== totalPages) items.push(i);
+  }
+  if (right < totalPages - 1) items.push("…");
+  items.push(totalPages);
+  return items;
+}
+
+function Pagination({ filesPerPage, totalFiles, currentPage, setCurrentPage, disabled }) {
+  const totalPages = Math.ceil(totalFiles / filesPerPage);
+  const pageItems = getPageItems(currentPage, totalPages);
 
   return (
     <div className="flex justify-center py-1">
       <button
-        disabled={currentPage === 1 || pageNumbers.length === 0 || disabled}
+        disabled={currentPage === 1 || totalPages === 0 || disabled}
         onClick={() => {
           if (!disabled) setCurrentPage((prevPage) => prevPage - 1);
         }}
@@ -33,7 +54,7 @@ function Pagination({ filesPerPage, totalFiles, currentPage, setCurrentPage, dis
         <ArrowLeftIcon className="w-4 h-4" />
       </button>
 
-      {pageNumbers.length === 0 && (
+      {totalPages === 0 && (
         <button
           key={1}
           disabled
@@ -43,24 +64,33 @@ function Pagination({ filesPerPage, totalFiles, currentPage, setCurrentPage, dis
         </button>
       )}
 
-      {pageNumbers.map((number) => (
-        <button
-          key={number}
-          disabled={number === currentPage || disabled}
-          onClick={() => {
-            if (!disabled) setCurrentPage(number);
-          }}
-          className={`h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 ${currentPage === number
-            ? "font-semibold"
-            : "font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-            }`}
-        >
-          {number}
-        </button>
-      ))}
+      {pageItems.map((item, index) =>
+        item === "…" ? (
+          <span
+            key={`ellipsis-${index}`}
+            className="h-8 w-8 px-1 py-1 mx-1 text-center sm:text-sm font-light text-gray-400 dark:text-gray-500 select-none"
+          >
+            …
+          </span>
+        ) : (
+          <button
+            key={item}
+            disabled={item === currentPage || disabled}
+            onClick={() => {
+              if (!disabled) setCurrentPage(item);
+            }}
+            className={`h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 ${currentPage === item
+              ? "font-semibold"
+              : "font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
+              }`}
+          >
+            {item}
+          </button>
+        )
+      )}
 
       <button
-        disabled={currentPage == pageNumbers.length || pageNumbers.length === 0}
+        disabled={currentPage === totalPages || totalPages === 0}
         className="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
         onClick={() => setCurrentPage((prevPage) => prevPage + 1)}
       >

--- a/web/src/components/Pagination.test.jsx
+++ b/web/src/components/Pagination.test.jsx
@@ -1,7 +1,41 @@
 import { render, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { test, expect, vi } from "vitest";
-import Pagination from "@/components/Pagination";
+import { test, expect, vi, describe } from "vitest";
+import Pagination, { getPageItems } from "@/components/Pagination";
+
+describe("getPageItems", () => {
+  test("returns every page when the range is small", () => {
+    expect(getPageItems(1, 5)).toEqual([1, 2, 3, 4, 5]);
+    expect(getPageItems(3, 7)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  test("elides with a trailing ellipsis near the start", () => {
+    // 20 pages, on page 2: 1 2 3 … 20
+    expect(getPageItems(2, 20)).toEqual([1, 2, 3, "…", 20]);
+  });
+
+  test("elides with a leading ellipsis near the end", () => {
+    // 20 pages, on page 19: 1 … 18 19 20
+    expect(getPageItems(19, 20)).toEqual([1, "…", 18, 19, 20]);
+  });
+
+  test("elides on both sides in the middle", () => {
+    // 20 pages, on page 10: 1 … 9 10 11 … 20
+    expect(getPageItems(10, 20)).toEqual([1, "…", 9, 10, 11, "…", 20]);
+  });
+
+  test("never duplicates the first/last page as a sibling", () => {
+    const items = getPageItems(3, 20);
+    expect(items).toEqual([1, 2, 3, 4, "…", 20]);
+    expect(items.filter((i) => i === 1)).toHaveLength(1);
+    expect(items.filter((i) => i === 20)).toHaveLength(1);
+  });
+
+  test("returns empty for a single page or none", () => {
+    expect(getPageItems(1, 1)).toEqual([]);
+    expect(getPageItems(1, 0)).toEqual([]);
+  });
+});
 
 test("Enabled Pagination", async () => {
   const user = userEvent.setup();

--- a/web/src/components/__snapshots__/AudioFileBrowser.test.jsx.snap
+++ b/web/src/components/__snapshots__/AudioFileBrowser.test.jsx.snap
@@ -295,12 +295,6 @@ exports[`AudioFileBrowser back navigation 1`] = `
             </svg>
           </button>
           <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
-          </button>
-          <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
             disabled=""
           >
@@ -562,12 +556,6 @@ exports[`AudioFileBrowser disabled interactions 1`] = `
                 stroke-linejoin="round"
               />
             </svg>
-          </button>
-          <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
           </button>
           <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
@@ -959,12 +947,6 @@ exports[`AudioFileBrowser folder navigation 1`] = `
             </svg>
           </button>
           <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
-          </button>
-          <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
             disabled=""
           >
@@ -1252,12 +1234,6 @@ exports[`AudioFileBrowser loading state with files 1`] = `
                 stroke-linejoin="round"
               />
             </svg>
-          </button>
-          <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
           </button>
           <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
@@ -1709,12 +1685,6 @@ exports[`AudioFileBrowser with directories and interactions 1`] = `
                 stroke-linejoin="round"
               />
             </svg>
-          </button>
-          <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
           </button>
           <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
@@ -2772,12 +2742,6 @@ exports[`Disabled AudioFileBrowser 1`] = `
             </svg>
           </button>
           <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
-          </button>
-          <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
             disabled=""
           >
@@ -3687,12 +3651,6 @@ exports[`Enabled AudioFileBrowser 1`] = `
             </svg>
           </button>
           <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
-          </button>
-          <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
             disabled=""
           >
@@ -3954,12 +3912,6 @@ exports[`Loading AudioFileBrowser 1`] = `
                 stroke-linejoin="round"
               />
             </svg>
-          </button>
-          <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
           </button>
           <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"

--- a/web/src/components/__snapshots__/Pagination.test.jsx.snap
+++ b/web/src/components/__snapshots__/Pagination.test.jsx.snap
@@ -45,42 +45,11 @@ exports[`Disabled Pagination 1`] = `
       >
         3
       </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-        disabled=""
+      <span
+        class="h-8 w-8 px-1 py-1 mx-1 text-center sm:text-sm font-light text-gray-400 dark:text-gray-500 select-none"
       >
-        4
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-        disabled=""
-      >
-        5
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-        disabled=""
-      >
-        6
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-        disabled=""
-      >
-        7
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-        disabled=""
-      >
-        8
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-        disabled=""
-      >
-        9
-      </button>
+        …
+      </span>
       <button
         class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
         disabled=""
@@ -157,42 +126,11 @@ exports[`Disabled Pagination 2`] = `
       >
         3
       </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-        disabled=""
+      <span
+        class="h-8 w-8 px-1 py-1 mx-1 text-center sm:text-sm font-light text-gray-400 dark:text-gray-500 select-none"
       >
-        4
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-        disabled=""
-      >
-        5
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-        disabled=""
-      >
-        6
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-        disabled=""
-      >
-        7
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-        disabled=""
-      >
-        8
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-        disabled=""
-      >
-        9
-      </button>
+        …
+      </span>
       <button
         class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
         disabled=""
@@ -266,36 +204,11 @@ exports[`Enabled Pagination 1`] = `
       >
         3
       </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
+      <span
+        class="h-8 w-8 px-1 py-1 mx-1 text-center sm:text-sm font-light text-gray-400 dark:text-gray-500 select-none"
       >
-        4
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-      >
-        5
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-      >
-        6
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-      >
-        7
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-      >
-        8
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-      >
-        9
-      </button>
+        …
+      </span>
       <button
         class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
       >
@@ -368,36 +281,11 @@ exports[`Enabled Pagination 2`] = `
       >
         3
       </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
+      <span
+        class="h-8 w-8 px-1 py-1 mx-1 text-center sm:text-sm font-light text-gray-400 dark:text-gray-500 select-none"
       >
-        4
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-      >
-        5
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-      >
-        6
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-      >
-        7
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-      >
-        8
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
-      >
-        9
-      </button>
+        …
+      </span>
       <button
         class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-light bg-white dark:bg-gray-800 hover:bg-slate-100 dark:hover:bg-gray-700"
       >

--- a/web/src/components/__snapshots__/RemoteFileBrowser.test.jsx.snap
+++ b/web/src/components/__snapshots__/RemoteFileBrowser.test.jsx.snap
@@ -236,12 +236,6 @@ exports[`Disabled RemoteFileBrowser 1`] = `
             </svg>
           </button>
           <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
-          </button>
-          <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
             disabled=""
           >
@@ -1151,12 +1145,6 @@ exports[`Enabled RemoteFileBrowser 1`] = `
             </svg>
           </button>
           <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
-          </button>
-          <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
             disabled=""
           >
@@ -1418,12 +1406,6 @@ exports[`Loading RemoteFileBrowser 1`] = `
                 stroke-linejoin="round"
               />
             </svg>
-          </button>
-          <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
           </button>
           <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
@@ -1748,12 +1730,6 @@ exports[`RemoteFileBrowser back navigation 1`] = `
             </svg>
           </button>
           <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
-          </button>
-          <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
             disabled=""
           >
@@ -2015,12 +1991,6 @@ exports[`RemoteFileBrowser disabled interactions 1`] = `
                 stroke-linejoin="round"
               />
             </svg>
-          </button>
-          <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
           </button>
           <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
@@ -2412,12 +2382,6 @@ exports[`RemoteFileBrowser folder navigation 1`] = `
             </svg>
           </button>
           <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
-          </button>
-          <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
             disabled=""
           >
@@ -2705,12 +2669,6 @@ exports[`RemoteFileBrowser loading state with files 1`] = `
                 stroke-linejoin="round"
               />
             </svg>
-          </button>
-          <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
           </button>
           <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
@@ -3162,12 +3120,6 @@ exports[`RemoteFileBrowser with directories and interactions 1`] = `
                 stroke-linejoin="round"
               />
             </svg>
-          </button>
-          <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm text-gray-900 dark:text-gray-100 font-semibold"
-            disabled=""
-          >
-            1
           </button>
           <button
             class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"

--- a/web/src/lib/fileApi.js
+++ b/web/src/lib/fileApi.js
@@ -33,7 +33,9 @@ export const FILE_TYPE_CONFIG = {
         endpoint: "/api/text",
     },
     audio: {
-        extensions: [".wav", ".mp3"],
+        // Matches the transcribe task's accepted input formats and the
+        // backend AUDIO_EXTENSIONS in asgi.py — keep the three in sync.
+        extensions: [".wav", ".mp3", ".flac", ".m4a", ".ogg", ".webm"],
         endpoint: "/api/audio",
     },
 };

--- a/web/src/lib/fileApi.test.js
+++ b/web/src/lib/fileApi.test.js
@@ -1,5 +1,23 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { uploadFile, replaceFile, deleteFile } from "@/lib/fileApi";
+import { uploadFile, replaceFile, deleteFile, getFileType } from "@/lib/fileApi";
+
+describe("getFileType", () => {
+  it("classifies audio formats the transcribe task accepts", () => {
+    for (const ext of [".wav", ".mp3", ".flac", ".m4a", ".ogg", ".webm"]) {
+      expect(getFileType(`recording${ext}`)).toBe("audio");
+    }
+  });
+
+  it("classifies from a full path, not just a bare name", () => {
+    expect(getFileType("/scratch/data/audio_001.flac")).toBe("audio");
+  });
+
+  it("classifies text and image, and returns null for unknown", () => {
+    expect(getFileType("out.txt")).toBe("text");
+    expect(getFileType("frame.png")).toBe("image");
+    expect(getFileType("archive.zip")).toBeNull();
+  });
+});
 
 const BASE_URL = "http://localhost:8000";
 

--- a/web/src/routes/jobs/components/JobDetailsPanel.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.jsx
@@ -10,6 +10,36 @@ import StatusBadge from "./StatusBadge";
 import { isBatchJobActive } from "@/lib/util";
 import PropTypes from "prop-types";
 
+// Friendly labels for known task params; falls back to a title-cased key.
+const PARAM_LABELS = {
+    batch_size: "Batch size",
+    sample_fps: "Sample FPS",
+    max_tokens: "Max tokens",
+    output_format: "Output format",
+    source_lang: "Source language",
+    target_lang: "Target language",
+    model_backend: "Model backend",
+    prompt_template: "Prompt template",
+    auto_lang_detect: "Auto-detect language",
+    use_fallback_prompt: "Fallback prompt",
+    overlap_s: "Window overlap (s)",
+    sampling_rate: "Sampling rate",
+};
+
+export function formatParamLabel(key) {
+    if (PARAM_LABELS[key]) return PARAM_LABELS[key];
+    // Title-case the first word of a snake_case key: "some_thing" -> "Some thing".
+    const spaced = key.replace(/_/g, " ");
+    return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+export function formatParamValue(key, value) {
+    if (typeof value === "boolean") return value ? "Yes" : "No";
+    // The transcribe language param uses "" to mean auto-detect.
+    if (key === "language" && value === "") return "Auto-detect";
+    return String(value);
+}
+
 function ProgressBar({ finished, staged, errored }) {
     const done = Number(finished) || 0;
     const pending = Number(staged) || 0;
@@ -167,10 +197,10 @@ function JobDetailsPanel({ job, onStopJob, onDeleteJob, jobActionInProgress }) {
                         </h4>
                     </div>
                     <div className="space-y-2 text-sm">
-                        {job.resources?.memory && (
+                        {job.resources?.mem != null && (
                             <div className="flex justify-between">
                                 <span className="text-gray-500 dark:text-gray-400">Memory:</span>
-                                <span className="text-gray-900 dark:text-gray-100">{job.resources.memory}</span>
+                                <span className="text-gray-900 dark:text-gray-100">{job.resources.mem} GB</span>
                             </div>
                         )}
                         {job.resources?.cpus != null && (
@@ -187,7 +217,9 @@ function JobDetailsPanel({ job, onStopJob, onDeleteJob, jobActionInProgress }) {
                         )}
                         {job.resources?.time && (
                             <div className="flex justify-between">
-                                <span className="text-gray-500 dark:text-gray-400">Time:</span>
+                                {/* Per-allocation walltime; batch jobs resubmit across
+                                    allocations, so this is not the total job runtime. */}
+                                <span className="text-gray-500 dark:text-gray-400">Walltime (per allocation):</span>
                                 <span className="text-gray-900 dark:text-gray-100">{job.resources.time}</span>
                             </div>
                         )}
@@ -244,9 +276,9 @@ function JobDetailsPanel({ job, onStopJob, onDeleteJob, jobActionInProgress }) {
                                             </div>
                                         </div>
                                     ) : (
-                                        <div key={key} className="flex justify-between">
-                                            <span className="text-gray-500 dark:text-gray-400 capitalize">{key.replace(/_/g, " ")}:</span>
-                                            <span className="text-gray-900 dark:text-gray-100">{String(value)}</span>
+                                        <div key={key} className="flex justify-between gap-2">
+                                            <span className="text-gray-500 dark:text-gray-400">{formatParamLabel(key)}:</span>
+                                            <span className="text-gray-900 dark:text-gray-100 text-right break-all">{formatParamValue(key, value)}</span>
                                         </div>
                                     )
                                 ))}
@@ -274,7 +306,7 @@ JobDetailsPanel.propTypes = {
         output_dir: PropTypes.string,
         max_workers: PropTypes.number,
         resources: PropTypes.shape({
-            memory: PropTypes.string,
+            mem: PropTypes.number,
             cpus: PropTypes.number,
             gpus: PropTypes.number,
             time: PropTypes.string,

--- a/web/src/routes/jobs/components/JobDetailsPanel.test.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.test.jsx
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "vitest";
+
+import { formatParamLabel, formatParamValue } from "./JobDetailsPanel";
+
+describe("formatParamLabel", () => {
+  test("uses friendly labels for known params", () => {
+    expect(formatParamLabel("overlap_s")).toBe("Window overlap (s)");
+    expect(formatParamLabel("batch_size")).toBe("Batch size");
+    expect(formatParamLabel("sample_fps")).toBe("Sample FPS");
+    expect(formatParamLabel("target_lang")).toBe("Target language");
+  });
+
+  test("title-cases unknown snake_case keys", () => {
+    expect(formatParamLabel("windowing")).toBe("Windowing");
+    expect(formatParamLabel("some_new_param")).toBe("Some new param");
+  });
+});
+
+describe("formatParamValue", () => {
+  test("renders booleans as Yes/No", () => {
+    expect(formatParamValue("raw", true)).toBe("Yes");
+    expect(formatParamValue("raw", false)).toBe("No");
+  });
+
+  test("renders an empty transcribe language as Auto-detect", () => {
+    expect(formatParamValue("language", "")).toBe("Auto-detect");
+  });
+
+  test("stringifies other values", () => {
+    expect(formatParamValue("batch_size", 16)).toBe("16");
+    expect(formatParamValue("windowing", "batched")).toBe("batched");
+  });
+});

--- a/web/src/routes/jobs/components/JobResultsTable.jsx
+++ b/web/src/routes/jobs/components/JobResultsTable.jsx
@@ -10,6 +10,12 @@ import { assetPath } from "@/config";
 import Pagination from "@/components/Pagination";
 import PropTypes from "prop-types";
 
+// The table shows file basenames (the full paths are in the result preview).
+function basename(path) {
+    if (!path) return "-";
+    return path.split("/").pop();
+}
+
 function formatElapsedTime(startedAt, finishedAt) {
     if (!startedAt || !finishedAt) return "-";
 
@@ -175,7 +181,7 @@ function JobResultsTable({
                                                 }`}
                                             >
                                                 <td className="whitespace-nowrap py-3 pl-4 pr-3 text-left text-xs font-mono text-gray-900 dark:text-gray-100 sm:pl-6">
-                                                    <div className="overflow-x-scroll">{result.input_file}</div>
+                                                    <div className="overflow-x-scroll">{basename(result.input_file)}</div>
                                                 </td>
                                                 <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-900 dark:text-gray-100">
                                                     {result.started_at ? lastModified(result.started_at) : "-"}
@@ -190,7 +196,7 @@ function JobResultsTable({
                                                 </td>
                                                 <td className="whitespace-nowrap py-3 px-3 text-left text-xs font-mono text-gray-900 dark:text-gray-100">
                                                     <div className="overflow-x-scroll">
-                                                        {result.output_file ? result.output_file.split("/").pop() : "-"}
+                                                        {basename(result.output_file)}
                                                     </div>
                                                 </td>
                                                 <td className="whitespace-nowrap py-3 px-3 text-right">

--- a/web/src/routes/jobs/components/JobsContainer.jsx
+++ b/web/src/routes/jobs/components/JobsContainer.jsx
@@ -255,7 +255,7 @@ function JobsContainer() {
         ? (selectedJob ? MOCK_RESULTS[selectedJob.id] || [] : [])
         : apiResults.map((r) => ({
             id: `${r.task}/${r.file}`,
-            input_file: r.file,
+            input_file: r.input_file,
             output_file: r.output_file,
             started_at: r.started_at,
             finished_at: r.finished_at,

--- a/web/src/routes/jobs/components/ResultPreview.jsx
+++ b/web/src/routes/jobs/components/ResultPreview.jsx
@@ -177,6 +177,70 @@ OutputFilePreview.propTypes = {
     profile: PropTypes.object,
 };
 
+// The initial toggle side: output when it exists (success), else input.
+export function defaultPreviewSide(hasOutput) {
+    return hasOutput ? "output" : "input";
+}
+
+// Resolve the side actually shown: fall back to input when output is chosen
+// but unavailable (e.g. a failed file with no output).
+export function resolvePreviewSide(side, hasOutput) {
+    return side === "output" && !hasOutput ? "input" : side;
+}
+
+// Preview pane with an input/output toggle. Output only exists on success, so
+// the toggle defaults to output when available and falls back to input.
+function FilePreviewPanel({ inputFile, outputFile, profile = null }) {
+    const hasOutput = Boolean(outputFile);
+    const [side, setSide] = useState(defaultPreviewSide(hasOutput));
+
+    const activeSide = resolvePreviewSide(side, hasOutput);
+    const file = activeSide === "output" ? outputFile : inputFile;
+
+    const tabClass = (isActive) =>
+        `px-2 py-1 text-xs rounded-md ${isActive
+            ? "bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm font-medium"
+            : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+        }`;
+
+    return (
+        <div className="border-t border-gray-200 dark:border-gray-700 pt-4 flex-1 min-h-0 flex flex-col">
+            <div className="flex items-center justify-between mb-2">
+                <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                    Preview
+                </h4>
+                <div className="inline-flex gap-1 rounded-lg bg-gray-100 dark:bg-gray-900 p-0.5">
+                    <button
+                        type="button"
+                        onClick={() => setSide("input")}
+                        className={tabClass(activeSide === "input")}
+                    >
+                        Input
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => setSide("output")}
+                        disabled={!hasOutput}
+                        title={hasOutput ? undefined : "No output for this file"}
+                        className={`${tabClass(activeSide === "output")} disabled:opacity-40 disabled:cursor-not-allowed`}
+                    >
+                        Output
+                    </button>
+                </div>
+            </div>
+            <div className="flex-1 min-h-0 overflow-y-auto">
+                <OutputFilePreview file={file} profile={profile} />
+            </div>
+        </div>
+    );
+}
+
+FilePreviewPanel.propTypes = {
+    inputFile: PropTypes.string,
+    outputFile: PropTypes.string,
+    profile: PropTypes.object,
+};
+
 function ResultPreview({ result, job, profile = null }) {
     if (!result) {
         return (
@@ -292,16 +356,15 @@ function ResultPreview({ result, job, profile = null }) {
                 </div>
             )}
 
-            {/* Output File Preview — at bottom, fills remaining space */}
-            {result.output_file && (
-                <div className="border-t border-gray-200 dark:border-gray-700 pt-4 flex-1 min-h-0 flex flex-col">
-                    <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
-                        Output Preview
-                    </h4>
-                    <div className="flex-1 min-h-0 overflow-y-auto">
-                        <OutputFilePreview file={result.output_file} profile={profile} />
-                    </div>
-                </div>
+            {/* File preview with input/output toggle — fills remaining space.
+                Keyed on the result so the toggle resets per selection. */}
+            {result.input_file && (
+                <FilePreviewPanel
+                    key={result.id}
+                    inputFile={result.input_file}
+                    outputFile={result.output_file}
+                    profile={profile}
+                />
             )}
         </div>
     );

--- a/web/src/routes/jobs/components/ResultPreview.jsx
+++ b/web/src/routes/jobs/components/ResultPreview.jsx
@@ -213,7 +213,7 @@ function ResultPreview({ result, job, profile = null }) {
                 <div className="flex justify-between">
                     <span className="text-gray-500 dark:text-gray-400">Input File:</span>
                     <span className="text-gray-900 dark:text-gray-100 ml-2">
-                        <TruncatedPath path={result.input_file} />
+                        <TruncatedPath path={result.input_file} maxWidth="max-w-[22rem]" />
                     </span>
                 </div>
                 <div className="flex justify-between">

--- a/web/src/routes/jobs/components/ResultPreview.test.jsx
+++ b/web/src/routes/jobs/components/ResultPreview.test.jsx
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "vitest";
+
+import { defaultPreviewSide, resolvePreviewSide } from "./ResultPreview";
+
+describe("defaultPreviewSide", () => {
+  test("defaults to output when output exists (success)", () => {
+    expect(defaultPreviewSide(true)).toBe("output");
+  });
+
+  test("defaults to input when there is no output (failure)", () => {
+    expect(defaultPreviewSide(false)).toBe("input");
+  });
+});
+
+describe("resolvePreviewSide", () => {
+  test("keeps the chosen side when it is available", () => {
+    expect(resolvePreviewSide("input", true)).toBe("input");
+    expect(resolvePreviewSide("output", true)).toBe("output");
+    expect(resolvePreviewSide("input", false)).toBe("input");
+  });
+
+  test("falls back to input when output is chosen but unavailable", () => {
+    expect(resolvePreviewSide("output", false)).toBe("input");
+  });
+});


### PR DESCRIPTION
## Summary

Pre-v1.0 fixes to the batch-job UI, surfaced while testing on real jobs:

- **Pagination** now windows page numbers with an ellipsis (first/last + current±1) instead of listing every page.
- **Job details** — resources reads the `mem` key (the launcher sends `mem`, not `memory`, so Memory never displayed) and renders "N GB"; "Time" relabeled to "Walltime (per allocation)" since batch jobs resubmit across allocations. Task-config params get friendlier labels and value formatting (booleans → Yes/No, empty transcribe language → Auto-detect).
- **Result files** — the backend now returns `input_file` as a full path (built from `input_dir`), symmetric with `output_file`. The preview panel shows both full paths at the same truncation width; the results table shows both as basenames.
- **Preview toggle** — the result preview pane now toggles between the Input and Output file (defaults to output on success, falls back to input when there's no output; Output tab disabled in that case).
- **Audio preview** — `getFileType` and the backend `AUDIO_EXTENSIONS` were stuck at `.wav`/`.mp3` while the transcribe task accepts `.flac`/`.m4a`/`.ogg`/`.webm` too, so those inputs showed "Preview not available" and the file endpoints rejected them. Extended both lists to match, with explicit audio content types on both serve paths.

## Test plan

- `cd lib && uv run just lint` — ruff + mypy (strict) clean
- `cd lib && uv run just test` — 879 passed, 7 skipped; coverage 70%. New/updated tests: results endpoint `input_file` full path; `/api/audio` serves `.flac` with `audio/flac`; all six audio extensions accepted on upload.
- `cd web && npm run lint && npm test` — 0 errors; 360 passed. New tests: `getPageItems` ellipsis windowing; job-details param formatters; preview-side defaulting/fallback; `getFileType` audio classification (incl. `.flac`/full paths). Pagination snapshots regenerated for the components that embed it.
- Note: `.webm` is now classified as audio for preview; it is also a detect video input, so a detect `.webm` input would render in an `<audio>` element (minor, accepted).