### PR TITLE
fix(lib): normalize model_dir to repo root in add_model

### DIFF
--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -990,7 +990,7 @@ def models_add(
                     "profile": model.profile,
                     "revision": model.revision,
                     "image": model.image,
-                    "model_dir": path,
+                    "model_dir": model.model_dir,
                     "metadata_": model.metadata_,
                 },
             )

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -2385,7 +2385,9 @@ async def update_model(
         # 8. Update database record with new revision and path
         old_revision = model.revision
         model.revision = latest_revision
-        model.model_dir = path
+        # add_model normalizes model_dir to the repo root; persist it directly
+        # so updated models mount the same path as freshly downloaded ones.
+        model.model_dir = new_model.model_dir
         session.add(model)
 
         return ModelUpdateResponse(
@@ -2482,14 +2484,12 @@ async def _run_download_task(
         # Update status to DOWNLOADING
         await update_task_status(DownloadStatus.DOWNLOADING)
 
-        # Run the blocking download in a thread pool
+        # Run the blocking download in a thread pool. add_model sets model_dir
+        # to the repo root on the returned Model, so no further normalization
+        # is needed here.
         new_model, snapshot_path = await asyncio.to_thread(
             add_model, repo_id, profile, revision, use_cache
         )
-
-        # model_dir is the parent of snapshots directory (2 levels up from snapshot path)
-        model_dir = str(Path(snapshot_path).parent.parent)
-        new_model.model_dir = model_dir
 
         # Add model to database
         async with async_session_factory() as session:

--- a/lib/src/blackfish/server/db/migrations/versions/2026-07-23_normalize_model_dir_to_repo_root_565bd6201d2a.py
+++ b/lib/src/blackfish/server/db/migrations/versions/2026-07-23_normalize_model_dir_to_repo_root_565bd6201d2a.py
@@ -1,0 +1,112 @@
+# type: ignore
+"""normalize model_dir to repo root
+
+The model *update* path historically persisted the raw Hugging Face snapshot
+path (``.../models--<ns>--<model>/snapshots/<revision>``) in ``model.model_dir``,
+while the *download* path stored the repo root (``.../models--<ns>--<model>``).
+Services render their bind mounts from ``model_dir``, so any updated model
+launched with a mount one directory level too deep and the inference server
+could not find the model.
+
+The code paths are now fixed to always store the repo root, but existing rows do
+not self-heal. This data migration rewrites any ``model_dir`` that still points
+inside a ``snapshots`` directory back to its repo root.
+
+Revision ID: 565bd6201d2a
+Revises: c3d4e5f6a7b8
+Create Date: 2026-07-23 15:46:07.550963+00:00
+
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import sqlalchemy as sa
+from alembic import op
+from advanced_alchemy.types import (
+    EncryptedString,
+    EncryptedText,
+    GUID,
+    ORA_JSONB,
+    DateTimeUTC,
+)
+from sqlalchemy import Text  # noqa: F401
+
+__all__ = [
+    "downgrade",
+    "upgrade",
+    "schema_upgrades",
+    "schema_downgrades",
+    "data_upgrades",
+    "data_downgrades",
+]
+
+sa.GUID = GUID
+sa.DateTimeUTC = DateTimeUTC
+sa.ORA_JSONB = ORA_JSONB
+sa.EncryptedString = EncryptedString
+sa.EncryptedText = EncryptedText
+
+# revision identifiers, used by Alembic.
+revision = "565bd6201d2a"
+down_revision = "c3d4e5f6a7b8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        with op.get_context().autocommit_block():
+            schema_upgrades()
+            data_upgrades()
+
+
+def downgrade() -> None:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        with op.get_context().autocommit_block():
+            data_downgrades()
+            schema_downgrades()
+
+
+def schema_upgrades() -> None:
+    """schema upgrade migrations go here."""
+    pass
+
+
+def schema_downgrades() -> None:
+    """schema downgrade migrations go here."""
+    pass
+
+
+def data_upgrades() -> None:
+    """Rewrite any snapshot-path ``model_dir`` values to their repo root.
+
+    A corrupt value looks like ``.../models--<ns>--<model>/snapshots/<revision>``;
+    the repo root is everything before ``/snapshots``. Correct rows (already at
+    the repo root) contain no ``/snapshots`` segment and are left untouched.
+    """
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text("SELECT id, model_dir FROM model WHERE model_dir LIKE :pattern"),
+        {"pattern": "%/snapshots%"},
+    ).fetchall()
+
+    for row_id, model_dir in rows:
+        repo_root = model_dir.partition("/snapshots")[0]
+        if repo_root and repo_root != model_dir:
+            bind.execute(
+                sa.text("UPDATE model SET model_dir = :model_dir WHERE id = :id"),
+                {"model_dir": repo_root, "id": row_id},
+            )
+
+
+def data_downgrades() -> None:
+    """No-op: the normalized ``model_dir`` is the correct value.
+
+    Reversing would mean re-introducing the snapshot-path bug, and the original
+    (correct) download rows never had a snapshot suffix to restore, so there is
+    nothing meaningful to downgrade.
+    """

--- a/lib/src/blackfish/server/models/model.py
+++ b/lib/src/blackfish/server/models/model.py
@@ -201,7 +201,10 @@ def add_model(
             stored to the profile's home directory. Default: False.
 
     Returns:
-        A tuple of (Model object with metadata, snapshot path)
+        A tuple of (Model object with metadata, snapshot path). The Model's
+        ``model_dir`` is set to the repo root (the grandparent of the snapshot
+        path, e.g. ``.../models--<namespace>--<model>``) so callers can persist
+        it directly without further normalization.
 
     Raises:
         RepositoryNotFoundError
@@ -250,12 +253,19 @@ def add_model(
             f"(source: {metadata.size_source})"
         )
 
+    # model_dir is the repo root, i.e. the grandparent of the snapshot path
+    # (`.../models--<namespace>--<model>/snapshots/<revision>`). Services render
+    # their bind mounts from model_dir, so normalize here to ensure every caller
+    # persists the same value regardless of download vs. update path.
+    model_dir = str(Path(path).parent.parent)
+
     return (
         Model(
             repo=repo_id,
             revision=revision,
             profile=profile.name,
             image=image,
+            model_dir=model_dir,
             metadata_=metadata.to_dict() if metadata else None,
         ),
         path,

--- a/lib/tests/api/test_models.py
+++ b/lib/tests/api/test_models.py
@@ -1177,11 +1177,14 @@ class TestUpdateModelAPI:
         mock_info.sha = "newrev789"
         mock_model_info.return_value = mock_info
 
-        # Mock successful download
-        mock_add_model.return_value = (
-            AsyncMock(),
-            "/path/to/new/model",
-        )
+        # Mock successful download. add_model normalizes model_dir to the repo
+        # root and sets it on the returned Model; the update path must persist
+        # that value, not the raw snapshot path (regression test for #406).
+        repo_root = "/home/test/.blackfish/models/models--openai--whisper-tiny"
+        snapshot_path = f"{repo_root}/snapshots/newrev789"
+        returned_model = MagicMock()
+        returned_model.model_dir = repo_root
+        mock_add_model.return_value = (returned_model, snapshot_path)
 
         response = await client.put(f"/api/models/{model_id}")
 
@@ -1190,6 +1193,12 @@ class TestUpdateModelAPI:
         assert result["status"] == "updated"
         assert result["old_revision"] == "1"
         assert result["new_revision"] == "newrev789"
+
+        # The persisted model_dir is the repo root, so services mount the
+        # correct directory after an update.
+        get_response = await client.get(f"/api/models/{model_id}")
+        assert get_response.status_code == 200
+        assert get_response.json()["model_dir"] == repo_root
 
     @patch("blackfish.server.models.model.add_model")
     @patch("huggingface_hub.model_info")

--- a/lib/tests/unit/test_migrations.py
+++ b/lib/tests/unit/test_migrations.py
@@ -322,3 +322,89 @@ class TestTigerFlowBatchJobsMigration:
                 assert before[name]["notnull"] == after[name]["notnull"], (
                     f"nullability mismatch on {name!r} after round-trip"
                 )
+
+
+def _create_model_table(conn: sa.Connection) -> None:
+    """Create a minimal `model` table for exercising the data migration."""
+    conn.execute(
+        text(
+            """
+            CREATE TABLE model (
+                id VARCHAR NOT NULL,
+                model_dir VARCHAR NOT NULL,
+                CONSTRAINT pk_model PRIMARY KEY (id)
+            )
+            """
+        )
+    )
+
+
+class TestNormalizeModelDirMigration:
+    """Tests for 2026-07-23_normalize_model_dir_to_repo_root (revision 565bd6201d2a).
+
+    The data migration rewrites any `model_dir` that points inside a snapshots
+    directory (the historical output of the model update path) back to its repo
+    root, while leaving already-correct rows untouched.
+    """
+
+    FILENAME = "2026-07-23_normalize_model_dir_to_repo_root_565bd6201d2a.py"
+
+    def test_data_upgrade_rewrites_snapshot_paths(self, engine: Engine) -> None:
+        """Snapshot-path rows are fixed; repo-root rows are left as-is."""
+        base = "/home/test/.blackfish/models"
+        corrupt = f"{base}/models--openai--whisper-tiny/snapshots/169d4a43deadbeef"
+        fixed = f"{base}/models--openai--whisper-tiny"
+        correct = f"{base}/models--google--gemma-3-1b-it"
+
+        with engine.connect() as conn:
+            _create_model_table(conn)
+            conn.execute(
+                text("INSERT INTO model (id, model_dir) VALUES (:id, :d)"),
+                [
+                    {"id": "corrupt", "d": corrupt},
+                    {"id": "correct", "d": correct},
+                ],
+            )
+            conn.commit()
+
+            migration = load_migration(self.FILENAME)
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.data_upgrades()
+            conn.commit()
+
+            rows = dict(
+                conn.execute(text("SELECT id, model_dir FROM model")).fetchall()
+            )
+
+        # The updated row now points at the repo root, matching download rows.
+        assert rows["corrupt"] == fixed
+        # The already-correct row is untouched.
+        assert rows["correct"] == correct
+
+    def test_data_upgrade_is_idempotent(self, engine: Engine) -> None:
+        """Running the data upgrade twice leaves correct rows unchanged."""
+        base = "/home/test/.blackfish/models"
+        corrupt = f"{base}/models--openai--whisper-tiny/snapshots/169d4a43deadbeef"
+        fixed = f"{base}/models--openai--whisper-tiny"
+
+        with engine.connect() as conn:
+            _create_model_table(conn)
+            conn.execute(
+                text("INSERT INTO model (id, model_dir) VALUES (:id, :d)"),
+                {"id": "corrupt", "d": corrupt},
+            )
+            conn.commit()
+
+            migration = load_migration(self.FILENAME)
+            for _ in range(2):
+                ctx = MigrationContext.configure(conn)
+                with Operations.context(ctx):
+                    migration.data_upgrades()
+                conn.commit()
+
+            result = conn.execute(
+                text("SELECT model_dir FROM model WHERE id = 'corrupt'")
+            ).scalar_one()
+
+        assert result == fixed

--- a/lib/tests/unit/test_model.py
+++ b/lib/tests/unit/test_model.py
@@ -360,6 +360,39 @@ class TestAddModel:
         assert model.metadata_ is not None
         assert model.metadata_["model_size_gb"] == 3.5
         assert path == str(tmp_path / "snapshots" / "abc123def")
+        # model_dir is normalized to the repo root (grandparent of the snapshot
+        # path), not the raw snapshot path (regression test for #406).
+        assert model.model_dir == str(tmp_path)
+
+    @patch("blackfish.server.models.model.fetch_model_metadata")
+    @patch("blackfish.server.models.model.model_info")
+    @patch("blackfish.server.models.model.snapshot_download")
+    def test_add_model_normalizes_model_dir(
+        self, mock_download, mock_info, mock_metadata, tmp_path: Path
+    ):
+        """model_dir is the repo root regardless of the snapshot revision.
+
+        Regression test for #406: the update path used to persist the raw
+        snapshot path, so an updated model mounted a directory one level too
+        deep. add_model now normalizes model_dir on the returned Model so every
+        caller (download, update, CLI) stores the same value.
+        """
+        repo_root = tmp_path / "models--openai--whisper-tiny"
+        snapshot_path = repo_root / "snapshots" / "169d4a43deadbeef"
+        mock_download.return_value = str(snapshot_path)
+        mock_info.return_value = MagicMock(
+            pipeline_tag="automatic-speech-recognition", card_data=None
+        )
+        mock_metadata.return_value = ModelMetadata(
+            model_size_gb=0.1, size_source="safetensors"
+        )
+
+        profile = MockProfile(home_dir=str(tmp_path))
+
+        model, path = add_model("openai/whisper-tiny", profile)
+
+        assert model.model_dir == str(repo_root)
+        assert path == str(snapshot_path)
 
     @patch("blackfish.server.models.model.fetch_model_metadata")
     @patch("blackfish.server.models.model.model_info")


### PR DESCRIPTION
The model update path persisted the raw Hugging Face snapshot path (.../models--<ns>--<model>/snapshots/<revision>) in Model.model_dir, while the download path stored the repo root. Services render their bind mounts from model_dir, so any updated model launched with a mount one directory level too deep and the inference server could not find it.

Normalize model_dir inside add_model() so every caller (API download, API update, CLI add) persists the repo root and cannot drift again. This also fixes the CLI add path, which had the same latent bug.

Add a data migration that rewrites existing rows whose model_dir still points inside a snapshots directory back to their repo root, plus regression tests covering add_model normalization, the update endpoint's persisted value, and the data migration.

Closes #406