### PR TITLE
test(web): await user.keyboard to fix flaky UI CI

### DIFF
--- a/web/src/components/FilterInput.test.jsx
+++ b/web/src/components/FilterInput.test.jsx
@@ -42,7 +42,7 @@ test("Disabled FilterInput", async () => {
   await act(async () => {
     const input = getByRole("textbox");
     input.focus();
-    user.keyboard("Hi there");
+    await user.keyboard("Hi there");
   });
   expect(baseElement).toMatchSnapshot();
 });


### PR DESCRIPTION
## Summary

`FilterInput.test.jsx` fired `user.keyboard("Hi there")` without awaiting it (unlike the `{Escape}` case just above). The keystroke dispatches resolved after the test finished and the DOM was torn down, so the trailing `dispatchEvent` calls surfaced as an unhandled rejection (`parameter 1 is not of type 'Event'`). CI treats unhandled errors as failures, so this intermittently failed **UI CI** on main; it could also perturb a later test's `waitFor` into the "Maximum wait 15s exceeded" timeout. Awaiting the call fixes it.

## Test plan

- `cd web && npm test` — 360 passed; the full suite passes locally (the leak only fails under CI's stricter unhandled-error handling, so CI green on this branch is the real proof).
- `cd web && npm run lint` — 0 errors.
- Verified there are no other un-awaited `user-event` calls in the test suite.