### PR TITLE
chore(release): v1.0.0b1

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "blackfish-ai"
-version = "1.0.0a6"
+version = "1.0.0b1"
 description = "An open-source AI-as-a-Service platform."
 readme = "README.md"
 license = "MIT"

--- a/lib/uv.lock
+++ b/lib/uv.lock
@@ -239,7 +239,7 @@ wheels = [
 
 [[package]]
 name = "blackfish-ai"
-version = "1.0.0a6"
+version = "1.0.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy" },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blackfish-ui",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blackfish-ui",
-      "version": "1.0.0-alpha.6",
+      "version": "1.0.0-beta.1",
       "dependencies": {
         "@headlessui/react": "^2.1",
         "@heroicons/react": "^2.0.18",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blackfish-ui",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-beta.1",
   "private": true,
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump for the **v1.0.0b1** (beta) release: `1.0.0a6` → `1.0.0b1` (`1.0.0-alpha.6` → `1.0.0-beta.1` on the web side).

**Beta rationale:** the batch-jobs-via-container work (the headline of this cycle) is validated on a remote Slurm cluster but not yet in an Open OnDemand environment. b1 is the artifact for that validation.

## Test plan

- Version-bump only; no source changes.
- `uv lock --check` passes (lock consistent with the bumped pyproject).
- `importlib.metadata.version("blackfish-ai")` resolves to `1.0.0b1`.
- CI green on this branch confirms the bumped build is sound before tagging.