### PR TITLE
fix(web): show pagination in the audio file browser

### DIFF
--- a/web/src/components/AudioFileBrowser.jsx
+++ b/web/src/components/AudioFileBrowser.jsx
@@ -37,9 +37,7 @@ function AudioFileBrowserTable({
   content,
   path,
   root,
-  filesPerPage,
   setAudioPath,
-  query,
   setPath,
   selected,
   setSelected,
@@ -48,20 +46,8 @@ function AudioFileBrowserTable({
   refresh,
   status
 }) {
-  const [currentPage, setCurrentPage] = useState(1);
-
-  const indexOfLastFile = currentPage * filesPerPage;
-  const indexOfFirstFile = indexOfLastFile - filesPerPage;
-  const filteredContent =
-    query === ""
-      ? content
-      : content?.filter((item) => {
-        return item.name.toLowerCase().includes(query.toLowerCase());
-      });
-  const currentFiles =
-    !filteredContent
-      ? []
-      : filteredContent.slice(indexOfFirstFile, indexOfLastFile);
+  // `content` is the already-filtered, already-paginated page of files.
+  const currentFiles = content ?? [];
 
   return (
     <div
@@ -285,13 +271,6 @@ function AudioFileBrowserTable({
           </div>
         </div>
       </div>
-      <Pagination
-        filesPerPage={filesPerPage}
-        totalFiles={!filteredContent ? 0 : filteredContent.length}
-        currentPage={currentPage}
-        setCurrentPage={setCurrentPage}
-        disabled={status.disabled}
-      />
     </div>
   );
 }
@@ -300,9 +279,7 @@ AudioFileBrowserTable.propTypes = {
   content: PropTypes.array,
   path: PropTypes.string,
   root: PropTypes.string,
-  filesPerPage: PropTypes.number,
   setAudioPath: PropTypes.func,
-  query: PropTypes.string,
   setPath: PropTypes.func,
   selected: PropTypes.string,
   setSelected: PropTypes.func,
@@ -320,16 +297,36 @@ AudioFileBrowserTable.propTypes = {
  * @param {Object} options.status - Health of file browser connection.
  * @return {JSX.Element}
  */
-function AudioFileBrowser({ root, setAudioPath, status }) {
+const FILES_PER_PAGE = 20;
+
+function AudioFileBrowser({ root, setAudioPath, status, children }) {
   const [path, setPath] = useState(root);
   const [pathError, setPathError] = useState(false);
   const [selected, setSelected] = useState("");
   const [query, setQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
   const { files, error, isLoading, refresh } = useFileSystem(path); // TODO: only fetch files if !status.disabled
 
   useEffect(() => {
     setPath(root);
   }, [root]);
+
+  // Filter and paginate here so the footer (below) can host the pagination
+  // alongside the submit control passed in as `children`.
+  const filteredContent =
+    query === ""
+      ? files
+      : files?.filter((item) => item.name.toLowerCase().includes(query.toLowerCase()));
+  const totalFiles = filteredContent ? filteredContent.length : 0;
+  const indexOfLastFile = currentPage * FILES_PER_PAGE;
+  const currentFiles = filteredContent
+    ? filteredContent.slice(indexOfLastFile - FILES_PER_PAGE, indexOfLastFile)
+    : [];
+
+  // Reset to the first page when the directory or filter changes.
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [path, query]);
 
   return (
     <div
@@ -350,12 +347,10 @@ function AudioFileBrowser({ root, setAudioPath, status }) {
       <FilterInput className="sm:flex-auto" query={query} setQuery={setQuery} disabled={status.disabled} />
 
       <AudioFileBrowserTable
-        content={files}
+        content={currentFiles}
         path={path}
         root={root}
-        filesPerPage={20}
         setAudioPath={setAudioPath}
-        query={query}
         setPath={setPath}
         setPathError={setPathError}
         selected={selected}
@@ -365,6 +360,21 @@ function AudioFileBrowser({ root, setAudioPath, status }) {
         refresh={refresh}
         status={status}
       />
+
+      {/* Bare row below the table (matching the File Manager's pagination
+          style): centered pagination with the submit control (children) on
+          the right. Fixed height so the layout doesn't shift when pagination
+          is hidden (single page). */}
+      <div className="relative flex items-center justify-center h-12 mt-2">
+        <Pagination
+          filesPerPage={FILES_PER_PAGE}
+          totalFiles={totalFiles}
+          currentPage={currentPage}
+          setCurrentPage={setCurrentPage}
+          disabled={status.disabled}
+        />
+        <div className="absolute right-0">{children}</div>
+      </div>
     </div>
   );
 }
@@ -373,6 +383,7 @@ AudioFileBrowser.propTypes = {
   root: PropTypes.string,
   setAudioPath: PropTypes.func,
   status: PropTypes.object,
+  children: PropTypes.node,
 };
 
 export default AudioFileBrowser;

--- a/web/src/components/AudioFileBrowser.test.jsx
+++ b/web/src/components/AudioFileBrowser.test.jsx
@@ -438,6 +438,70 @@ test("AudioFileBrowser loading state with files", async () => {
   expect(baseElement).toMatchSnapshot();
 });
 
+function mockFiles(n) {
+  useFileSystem.mockReturnValue({
+    files: Array.from({ length: n }, (_, i) => ({
+      name: `file ${i}`,
+      is_dir: false,
+      path: `path/to/file_${i}.mp3`,
+      size: 64,
+      modified_at: "2025-06-19T14:16:50",
+    })),
+    error: null,
+    isLoading: false,
+    refresh: (e) => e,
+  });
+}
+
+test("renders pagination when there is more than one page", async () => {
+  mockFiles(30); // > FILES_PER_PAGE (20) -> 2 pages
+  const { getByText, queryByText } = await act(async () =>
+    render(<AudioFileBrowser root="/" setAudioPath={(e) => e} status={{ disabled: false }} />)
+  );
+  // Page-number buttons for both pages are shown.
+  expect(getByText("1")).toBeInTheDocument();
+  expect(getByText("2")).toBeInTheDocument();
+  expect(queryByText("3")).not.toBeInTheDocument();
+});
+
+test("hides pagination for a single page", async () => {
+  mockFiles(5); // <= FILES_PER_PAGE -> 1 page
+  const { queryByText } = await act(async () =>
+    render(<AudioFileBrowser root="/" setAudioPath={(e) => e} status={{ disabled: false }} />)
+  );
+  // No page-number buttons rendered for a single page.
+  expect(queryByText("1")).not.toBeInTheDocument();
+});
+
+test("renders the submit control passed as children in the footer", async () => {
+  mockFiles(30);
+  const { getByTestId } = await act(async () =>
+    render(
+      <AudioFileBrowser root="/" setAudioPath={(e) => e} status={{ disabled: false }}>
+        <button data-testid="submit">Go</button>
+      </AudioFileBrowser>
+    )
+  );
+  expect(getByTestId("submit")).toBeInTheDocument();
+});
+
+test("resets to the first page when the filter changes", async () => {
+  mockFiles(50); // 3 pages
+  const user = userEvent.setup();
+  const { getByText, getByPlaceholderText, queryByText } = await act(async () =>
+    render(<AudioFileBrowser root="/" setAudioPath={(e) => e} status={{ disabled: false }} />)
+  );
+  // Go to page 3.
+  await act(async () => {
+    await user.click(getByText("3"));
+  });
+  // Typing a filter should reset back to page 1 (page 3 no longer shown).
+  await act(async () => {
+    await user.type(getByPlaceholderText("*"), "file 1");
+  });
+  expect(queryByText("3")).not.toBeInTheDocument();
+});
+
 afterAll(() => {
   global.Date = originalDate;
 });

--- a/web/src/components/FileManagerTable.jsx
+++ b/web/src/components/FileManagerTable.jsx
@@ -339,13 +339,15 @@ function FileManagerTable({
                 </div>
             </div>
             {showPagination && (
-                <Pagination
-                    filesPerPage={filesPerPage}
-                    totalFiles={sortedContent.length}
-                    currentPage={currentPage}
-                    setCurrentPage={setCurrentPage}
-                    disabled={isDisabled}
-                />
+                <div className="flex items-center justify-center h-12 mt-2">
+                    <Pagination
+                        filesPerPage={filesPerPage}
+                        totalFiles={sortedContent.length}
+                        currentPage={currentPage}
+                        setCurrentPage={setCurrentPage}
+                        disabled={isDisabled}
+                    />
+                </div>
             )}
         </div>
     );

--- a/web/src/components/Pagination.jsx
+++ b/web/src/components/Pagination.jsx
@@ -40,6 +40,10 @@ export function getPageItems(currentPage, totalPages, siblings = 1) {
 
 function Pagination({ filesPerPage, totalFiles, currentPage, setCurrentPage, disabled }) {
   const totalPages = Math.ceil(totalFiles / filesPerPage);
+
+  // Nothing to paginate (0 or 1 page): render nothing rather than lone arrows.
+  if (totalPages <= 1) return null;
+
   const pageItems = getPageItems(currentPage, totalPages);
 
   return (
@@ -53,16 +57,6 @@ function Pagination({ filesPerPage, totalFiles, currentPage, setCurrentPage, dis
       >
         <ArrowLeftIcon className="w-4 h-4" />
       </button>
-
-      {totalPages === 0 && (
-        <button
-          key={1}
-          disabled
-          className="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm font-light bg-white dark:bg-gray-800 text-gray-300 dark:text-gray-600"
-        >
-          1
-        </button>
-      )}
 
       {pageItems.map((item, index) =>
         item === "…" ? (

--- a/web/src/components/Pagination.test.jsx
+++ b/web/src/components/Pagination.test.jsx
@@ -37,6 +37,19 @@ describe("getPageItems", () => {
   });
 });
 
+test("renders nothing for a single page", () => {
+  // totalFiles (5) <= filesPerPage (20) -> one page -> no controls at all.
+  const { container } = render(
+    <Pagination
+      filesPerPage={20}
+      totalFiles={5}
+      currentPage={1}
+      setCurrentPage={(e) => e}
+    />
+  );
+  expect(container).toBeEmptyDOMElement();
+});
+
 test("Enabled Pagination", async () => {
   const user = userEvent.setup();
   const {baseElement, getAllByRole} = render(

--- a/web/src/components/__snapshots__/AudioFileBrowser.test.jsx.snap
+++ b/web/src/components/__snapshots__/AudioFileBrowser.test.jsx.snap
@@ -270,52 +270,13 @@ exports[`AudioFileBrowser back navigation 1`] = `
             </div>
           </div>
         </div>
+      </div>
+      <div
+        class="relative flex items-center justify-center h-12 mt-2"
+      >
         <div
-          class="flex justify-center py-1"
-        >
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
+          class="absolute right-0"
+        />
       </div>
     </div>
   </div>
@@ -533,52 +494,13 @@ exports[`AudioFileBrowser disabled interactions 1`] = `
             </div>
           </div>
         </div>
+      </div>
+      <div
+        class="relative flex items-center justify-center h-12 mt-2"
+      >
         <div
-          class="flex justify-center py-1"
-        >
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
+          class="absolute right-0"
+        />
       </div>
     </div>
   </div>
@@ -922,52 +844,13 @@ exports[`AudioFileBrowser folder navigation 1`] = `
             </div>
           </div>
         </div>
+      </div>
+      <div
+        class="relative flex items-center justify-center h-12 mt-2"
+      >
         <div
-          class="flex justify-center py-1"
-        >
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
+          class="absolute right-0"
+        />
       </div>
     </div>
   </div>
@@ -1211,52 +1094,13 @@ exports[`AudioFileBrowser loading state with files 1`] = `
             </div>
           </div>
         </div>
+      </div>
+      <div
+        class="relative flex items-center justify-center h-12 mt-2"
+      >
         <div
-          class="flex justify-center py-1"
-        >
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
+          class="absolute right-0"
+        />
       </div>
     </div>
   </div>
@@ -1662,52 +1506,13 @@ exports[`AudioFileBrowser with directories and interactions 1`] = `
             </div>
           </div>
         </div>
+      </div>
+      <div
+        class="relative flex items-center justify-center h-12 mt-2"
+      >
         <div
-          class="flex justify-center py-1"
-        >
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
+          class="absolute right-0"
+        />
       </div>
     </div>
   </div>
@@ -1920,58 +1725,13 @@ exports[`AudioFileBrowser with empty files 1`] = `
             </div>
           </div>
         </div>
+      </div>
+      <div
+        class="relative flex items-center justify-center h-12 mt-2"
+      >
         <div
-          class="flex justify-center py-1"
-        >
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-          <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm font-light bg-white dark:bg-gray-800 text-gray-300 dark:text-gray-600"
-            disabled=""
-          >
-            1
-          </button>
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
+          class="absolute right-0"
+        />
       </div>
     </div>
   </div>
@@ -2184,58 +1944,13 @@ exports[`AudioFileBrowser with error 1`] = `
             </div>
           </div>
         </div>
+      </div>
+      <div
+        class="relative flex items-center justify-center h-12 mt-2"
+      >
         <div
-          class="flex justify-center py-1"
-        >
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-          <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm font-light bg-white dark:bg-gray-800 text-gray-300 dark:text-gray-600"
-            disabled=""
-          >
-            1
-          </button>
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
+          class="absolute right-0"
+        />
       </div>
     </div>
   </div>
@@ -2448,58 +2163,13 @@ exports[`AudioFileBrowser with no service selected 1`] = `
             </div>
           </div>
         </div>
+      </div>
+      <div
+        class="relative flex items-center justify-center h-12 mt-2"
+      >
         <div
-          class="flex justify-center py-1"
-        >
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-          <button
-            class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm font-light bg-white dark:bg-gray-800 text-gray-300 dark:text-gray-600"
-            disabled=""
-          >
-            1
-          </button>
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
+          class="absolute right-0"
+        />
       </div>
     </div>
   </div>
@@ -2717,52 +2387,13 @@ exports[`Disabled AudioFileBrowser 1`] = `
             </div>
           </div>
         </div>
+      </div>
+      <div
+        class="relative flex items-center justify-center h-12 mt-2"
+      >
         <div
-          class="flex justify-center py-1"
-        >
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
+          class="absolute right-0"
+        />
       </div>
     </div>
   </div>
@@ -3626,52 +3257,13 @@ exports[`Enabled AudioFileBrowser 1`] = `
             </div>
           </div>
         </div>
+      </div>
+      <div
+        class="relative flex items-center justify-center h-12 mt-2"
+      >
         <div
-          class="flex justify-center py-1"
-        >
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
+          class="absolute right-0"
+        />
       </div>
     </div>
   </div>
@@ -3889,52 +3481,13 @@ exports[`Loading AudioFileBrowser 1`] = `
             </div>
           </div>
         </div>
+      </div>
+      <div
+        class="relative flex items-center justify-center h-12 mt-2"
+      >
         <div
-          class="flex justify-center py-1"
-        >
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-          <button
-            class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-            disabled=""
-          >
-            <svg
-              aria-hidden="true"
-              class="w-4 h-4"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
+          class="absolute right-0"
+        />
       </div>
     </div>
   </div>

--- a/web/src/components/__snapshots__/Pagination.test.jsx.snap
+++ b/web/src/components/__snapshots__/Pagination.test.jsx.snap
@@ -318,59 +318,6 @@ exports[`Enabled Pagination 2`] = `
 
 exports[`Pagination with no files 1`] = `
 <body>
-  <div>
-    <div
-      class="flex justify-center py-1"
-    >
-      <button
-        class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-        disabled=""
-      >
-        <svg
-          aria-hidden="true"
-          class="w-4 h-4"
-          data-slot="icon"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
-      </button>
-      <button
-        class="h-8 w-8 px-1 py-1 mx-1 rounded-md text-center sm:text-sm font-light bg-white dark:bg-gray-800 text-gray-300 dark:text-gray-600"
-        disabled=""
-      >
-        1
-      </button>
-      <button
-        class="text-gray-700 dark:text-gray-300 disabled:text-gray-300 dark:disabled:text-gray-600"
-        disabled=""
-      >
-        <svg
-          aria-hidden="true"
-          class="w-4 h-4"
-          data-slot="icon"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
-      </button>
-    </div>
-  </div>
+  <div />
 </body>
 `;

--- a/web/src/routes/speech-recognition/components/SpeechRecognitionContainer.jsx
+++ b/web/src/routes/speech-recognition/components/SpeechRecognitionContainer.jsx
@@ -46,13 +46,12 @@ function SpeechRecognitionContainer({
 
   return (
     <div className="bg-white dark:bg-gray-800">
-      <div className="relative w-full lg:w-5/6 max-w-6xl">
+      <div className="w-full lg:w-5/6 max-w-6xl">
         <AudioFileBrowser
           root={selectedService ? selectedService.mount : ""}
           setAudioPath={setAudioPath}
           status={fileBrowserStatus}
-        />
-        <div className="absolute bottom-0 py-2 px-5 bg-gray-50 dark:bg-gray-800 w-full max-w-6xl rounded-es-md rounded-ee-md">
+        >
           <SpeechRecognitionSubmit
             selectedService={selectedService}
             audioPath={audioPath}
@@ -60,7 +59,7 @@ function SpeechRecognitionContainer({
             parameters={parameters}
             setIsLoading={setIsLoading}
           />
-        </div>
+        </AudioFileBrowser>
       </div>
       <SpeechRecognitionAudioPreview
         audioPath={audioPath}


### PR DESCRIPTION
## Summary

The audio file browser's pagination wasn't visible: it was covered by the Submit bar, which was `absolute bottom-0` with an opaque background pinned to the panel bottom.

- Lift pagination out of `AudioFileBrowserTable` into `AudioFileBrowser`, which now owns the page state, filters/slices the files, and renders a row below the table holding the pagination (centered) and the submit control (passed in as `children`, pinned right).
- The Submit control is now passed as a child of `AudioFileBrowser` instead of a separate absolute-positioned bar.
- `Pagination` renders nothing for a single page (≤ N items) instead of showing lone disabled arrows — applies to both browsers.
- The pagination row has a constant height (`h-12`) so the layout doesn't shift between small (no pagination) and large directories, with top spacing from the table.
- Apply the same fixed-height pagination row in the File Manager so the two browsers are consistent.
- Reset to page 1 when the directory or filter changes (previously kept a now-invalid page).

## Test plan

- `cd web && npm test` — 367 passed. Snapshots updated for AudioFileBrowser (footer/structure) and Pagination (single-page now renders nothing).
- `cd web && npm run lint` — 0 errors.
- Verified visually: pagination shows for > N files (centered, submit on the right), hidden for ≤ N with the row height reserved (no jump), and consistent with the File Manager.