### PR TITLE
fix(web): don't collapse batch progress denominator when staged is unknown

### DIFF
--- a/web/src/lib/util.js
+++ b/web/src/lib/util.js
@@ -65,6 +65,29 @@ export const isBatchJobActive = (status) =>
   BATCH_JOB_ACTIVE_STATUSES.has(status);
 
 /**
+ * Compute batch-job progress for display.
+ *
+ * The backend leaves `staged` (items remaining) at its last known value while a
+ * job re-allocates, so a numeric `staged` — including 0 — is always a real,
+ * displayable remaining count. `staged` is only null/undefined before a job's
+ * first successful observation, when there is genuinely no total to show. We
+ * must distinguish those two cases: `Number(null) || 0` would collapse a
+ * not-yet-known total to a bogus 0, spiking the bar to 100%.
+ *
+ * @param {object} job - Batch job with `finished`, `staged`, `errored`.
+ * @return {{done: number, failed: number, total: number|null}} `total` is null
+ *   when the remaining count is unknown (render as N/A / indeterminate).
+ */
+export function batchProgress({ finished, staged, errored } = {}) {
+  const done = Number(finished) || 0;
+  const failed = Number(errored) || 0;
+  // null/undefined staged => no total yet. A numeric staged (incl. 0) is real.
+  const hasStaged = staged !== null && staged !== undefined;
+  const total = hasStaged ? done + (Number(staged) || 0) + failed : null;
+  return { done, failed, total };
+}
+
+/**
  * Status color scheme:
  * - green: operational (healthy)
  * - yellow: transitional (starting, pending, submitted) or degraded (unhealthy)

--- a/web/src/lib/util.test.js
+++ b/web/src/lib/util.test.js
@@ -14,6 +14,7 @@ import {
   isServiceRunning,
   selectTierByModelSize,
   isBatchJobActive,
+  batchProgress,
 } from "@/lib/util";
 
 describe("Utils", () => {
@@ -417,6 +418,59 @@ describe("Utils", () => {
       for (const s of ["stopped", "stalled", "exhausted", "broken"]) {
         expect(isBatchJobActive(s)).toBe(false);
       }
+    });
+  });
+
+  describe("batchProgress", () => {
+    it("sums finished, staged, and errored into the total", () => {
+      expect(batchProgress({ finished: 23, staged: 77, errored: 0 })).toEqual({
+        done: 23,
+        failed: 0,
+        total: 100,
+      });
+      expect(batchProgress({ finished: 48, staged: 0, errored: 12 })).toEqual({
+        done: 48,
+        failed: 12,
+        total: 60,
+      });
+    });
+
+    it("treats staged=0 as a real total (0 remaining), not unknown", () => {
+      // A finished job: nothing remaining, but the total is still known.
+      expect(batchProgress({ finished: 50, staged: 0, errored: 2 })).toEqual({
+        done: 50,
+        failed: 2,
+        total: 52,
+      });
+    });
+
+    it("returns total=null when staged is null (job not yet observed)", () => {
+      // The between-first-observation case: no denominator to show. Must NOT
+      // collapse to done+errored (which would spike the bar to ~100%).
+      expect(batchProgress({ finished: 0, staged: null, errored: 0 })).toEqual({
+        done: 0,
+        failed: 0,
+        total: null,
+      });
+      expect(batchProgress({ finished: 5, staged: null, errored: 1 })).toEqual({
+        done: 5,
+        failed: 1,
+        total: null,
+      });
+    });
+
+    it("returns total=null when staged is undefined or absent", () => {
+      expect(batchProgress({ finished: 5, errored: 1 }).total).toBeNull();
+      expect(batchProgress({}).total).toBeNull();
+      expect(batchProgress().total).toBeNull();
+    });
+
+    it("coerces string-valued fields to numbers", () => {
+      expect(batchProgress({ finished: "23", staged: "77", errored: "0" })).toEqual({
+        done: 23,
+        failed: 0,
+        total: 100,
+      });
     });
   });
 

--- a/web/src/routes/jobs/components/JobDetailsPanel.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.jsx
@@ -8,7 +8,7 @@ import {
     ExclamationTriangleIcon,
 } from "@heroicons/react/24/outline";
 import StatusBadge from "./StatusBadge";
-import { isBatchJobActive } from "@/lib/util";
+import { isBatchJobActive, batchProgress } from "@/lib/util";
 import PropTypes from "prop-types";
 
 // A batch job resubmits its Slurm allocation until the input dir is fully
@@ -84,12 +84,9 @@ export function formatParamValue(key, value) {
     return String(value);
 }
 
-function ProgressBar({ finished, staged, errored }) {
-    const done = Number(finished) || 0;
-    const pending = Number(staged) || 0;
-    const failed = Number(errored) || 0;
-    const total = done + pending + failed;
-    if (total === 0) return null;
+function ProgressBar({ done, failed, total }) {
+    // No denominator (job not yet observed) or no work at all: nothing to draw.
+    if (!total) return null;
 
     const donePct = (done / total) * 100;
     const failedPct = (failed / total) * 100;
@@ -111,9 +108,9 @@ function ProgressBar({ finished, staged, errored }) {
 }
 
 ProgressBar.propTypes = {
-    finished: PropTypes.number,
-    staged: PropTypes.number,
-    errored: PropTypes.number,
+    done: PropTypes.number,
+    failed: PropTypes.number,
+    total: PropTypes.number,
 };
 
 function JobDetailsPanel({ job, onStopJob, onDeleteJob, jobActionInProgress }) {
@@ -133,10 +130,9 @@ function JobDetailsPanel({ job, onStopJob, onDeleteJob, jobActionInProgress }) {
         );
     }
 
-    const done = Number(job.finished) || 0;
-    const pending = Number(job.staged) || 0;
-    const failed = Number(job.errored) || 0;
-    const total = done + pending + failed;
+    const { done, failed, total } = batchProgress(job);
+    // total is null before the job's first observation: no denominator to show.
+    const pending = total === null ? 0 : total - done - failed;
     const reason = terminalReason(job);
     const restarts = Number(job.restarts) || 0;
 
@@ -208,18 +204,14 @@ function JobDetailsPanel({ job, onStopJob, onDeleteJob, jobActionInProgress }) {
                         )}
                     </div>
                 </div>
-                <ProgressBar
-                    finished={job.finished}
-                    staged={job.staged}
-                    errored={job.errored}
-                />
+                <ProgressBar done={done} failed={failed} total={total} />
                 <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400 mt-1">
                     {restarts > 0 ? (
                         <span>Restarted {restarts} time{restarts === 1 ? "" : "s"}</span>
                     ) : (
                         <span />
                     )}
-                    <span>{total} total</span>
+                    <span>{total === null ? "N/A" : `${total} total`}</span>
                 </div>
             </div>
 

--- a/web/src/routes/jobs/components/JobsContainer.jsx
+++ b/web/src/routes/jobs/components/JobsContainer.jsx
@@ -11,6 +11,22 @@ import NewJobModal from "./NewJobModal";
 // Mock data for development - matches API BatchJob structure
 const MOCK_JOBS = [
     {
+        // Just submitted: staged is null until the first observation reports an
+        // input count, so progress renders as N/A rather than a collapsed bar.
+        id: "job-000c",
+        name: "Video Captioning",
+        created_at: "2024-01-17T10:00:00Z",
+        status: "submitted",
+        staged: null,
+        finished: 0,
+        errored: 0,
+        task: "transcribe",
+        repo_id: "openai/whisper-large-v3",
+        revision: "main",
+        input_dir: "/scratch/user/audio/input",
+        output_dir: "/scratch/user/audio/output",
+    },
+    {
         // Terminal: restart budget exhausted with work remaining.
         id: "job-000",
         name: "Meeting Transcription",

--- a/web/src/routes/jobs/components/JobsTable.jsx
+++ b/web/src/routes/jobs/components/JobsTable.jsx
@@ -5,17 +5,19 @@ import {
     ArrowPathIcon,
     ChevronDownIcon,
 } from "@heroicons/react/24/outline";
-import { lastModified } from "@/lib/util";
+import { lastModified, batchProgress } from "@/lib/util";
 import Pagination from "@/components/Pagination";
 import { TASKS } from "./NewJobModal";
 import StatusBadge from "./StatusBadge";
 import PropTypes from "prop-types";
 
 function ProgressDisplay({ finished, staged, errored }) {
-    const done = Number(finished) || 0;
-    const pending = Number(staged) || 0;
-    const failed = Number(errored) || 0;
-    const total = done + pending + failed;
+    const { done, failed, total } = batchProgress({ finished, staged, errored });
+    // total is null before a job's first observation: no denominator to show.
+    if (total === null) {
+        return <span className="text-xs text-gray-400 dark:text-gray-500">N/A</span>;
+    }
+    const pending = total - done - failed;
     return (
         <div className="flex items-center gap-1.5 text-xs">
             <span className="text-green-600 dark:text-green-400">{done}</span>


### PR DESCRIPTION
## Summary

- Batch progress in both the jobs table and the details panel computed `total = finished + staged + errored` with `Number(staged) || 0`. When a job's `staged` is `null` (its first observation, before the input count is known), that collapsed the denominator to `finished + errored` and spiked the bar to ~100%, then snapped back once an allocation staged work.
- Added a shared `batchProgress` helper in `util.js` that distinguishes `null`/`undefined` staged (→ `total: null`, render **N/A** with no bar) from a real `staged` of `0` (→ a genuine "0 remaining" denominator). The backend already leaves `staged` at its last-known value while re-allocating, so the display only needs to handle the genuinely-unobserved case.
- Both `ProgressDisplay` (table) and `ProgressBar` (details panel) now use the helper; added two mock fixtures (a just-submitted null-staged job and a terminal `exhausted` job) so both states are visible in dev Mock mode.

Part of #414 (the progress-denominator half; restart-state surfacing is a follow-up PR).

## Test plan

- `cd web && npm test` — 377 passing, incl. 5 new `batchProgress` cases covering: normal sum, `staged: 0` as a real total, `staged: null`/`undefined`/absent → `total: null`, and string-field coercion.
- `cd web && npm run lint` — 0 errors.
- `npm run dev`, open Jobs, toggle **Mock**:
  - "Video Captioning" (`staged: null`) → Progress shows **N/A**; details panel shows no bar and **N/A** for total.
  - "Meeting Transcription" (`exhausted`, 48 done / 12 failed, `staged: 0`) → **48 / 60 (12 failed)**, 80/20 green-red bar — confirms a real `staged: 0` still renders a proper denominator.