### PR TITLE
feat(lib): resume a terminal batch job

### DIFF
--- a/lib/docs/usage/cli.md
+++ b/lib/docs/usage/cli.md
@@ -474,6 +474,8 @@ resubmits a walltime-killed job that still has work to do.
 
 A job that stops making progress across restarts (e.g. an input that always fails to process) is
 halted and reported as `STALLED`; one that exhausts its restart budget is reported as `EXHAUSTED`.
+Either can be put back into the restart loop with [`resume`](#resume-resume-a-batch-job) once the
+underlying problem is addressed.
 
 ### `ls` - List batch jobs
 
@@ -494,11 +496,28 @@ blackfish batch stop <job-id>
 Stops a running batch job and cancels its Slurm allocation. Partial results already written to the
 output directory are preserved.
 
-!!! warning
+!!! note
 
-    Stopping a job is final. A stopped job is never resubmitted, even if files remain unprocessed —
-    there is no resume-after-stop. To finish the remaining files, submit a new job pointed at the
-    same output directory; already-finished files are skipped.
+    A stopped job is never resubmitted on its own — the restart loop does not pick it back up. To
+    finish the remaining files, use [`resume`](#resume-resume-a-batch-job).
+
+### `resume` - Resume a batch job
+
+```shell
+blackfish batch resume <job-id>
+```
+
+Puts a terminal job back into the restart loop by resubmitting its allocation against the same
+output directory. Already-finished files are skipped, so the job continues where it left off — and
+picks up any inputs added to the input directory in the meantime.
+
+Only **stopped**, **stalled**, and **exhausted** jobs can be resumed. A **broken** job cannot: that
+status marks a metadata or configuration error whose cause has to be fixed first, and resubmitting
+would just reproduce it.
+
+Resuming resets the restart counters, so a job that exhausted its restart budget gets a fresh one.
+The input directory is re-checked first, so resuming a job whose inputs have since been deleted or
+moved fails immediately rather than inside the allocation.
 
 ### `rm` - Delete a batch job
 

--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -20,6 +20,7 @@ from blackfish.cli.services.speech_recognition import run_speech_recognition
 from blackfish.cli.batch import (
     list_batch_jobs,
     stop_batch_job,
+    resume_batch_job,
     remove_batch_job,
     run_batch_job,
 )
@@ -784,6 +785,7 @@ def batch() -> None:  # pragma: no cover
 
 batch.add_command(list_batch_jobs, "ls")
 batch.add_command(stop_batch_job, "stop")
+batch.add_command(resume_batch_job, "resume")
 batch.add_command(remove_batch_job, "rm")
 batch.add_command(run_batch_job, "run")
 

--- a/lib/src/blackfish/cli/batch.py
+++ b/lib/src/blackfish/cli/batch.py
@@ -273,6 +273,58 @@ def stop_batch_job(job_id: str) -> None:  # pragma: no cover
                 spinner.ok(f"{LogSymbols.SUCCESS.value}")
 
 
+@click.command(name="resume")
+@click.argument(
+    "job_id",
+    type=str,
+    required=True,
+)
+def resume_batch_job(job_id: str) -> None:  # pragma: no cover
+    """Resume a terminal batch job.
+
+    Resubmits the job's allocation against the same output directory
+    (already-finished files are skipped). Only stopped, stalled, or exhausted
+    jobs can be resumed. JOB_ID can be a full UUID or an abbreviated prefix.
+    """
+
+    # Resolve abbreviated ID if needed
+    full_job_id = _resolve_job_id(job_id)
+    if full_job_id is None:
+        return
+
+    with yaspin(text="Resuming batch job...") as spinner:
+        try:
+            res = api.put(f"/api/jobs/{full_job_id}/resume", json={})
+        except requests.exceptions.ConnectionError:
+            spinner.text = (
+                f"Failed to connect to Blackfish API on port {config.PORT}. "
+                "Is the server running?"
+            )
+            spinner.fail(f"{LogSymbols.ERROR.value}")
+            return
+
+        if not res.ok:
+            spinner.text = (
+                f"Failed to resume batch job {full_job_id[:DISPLAY_ID_LENGTH]} "
+                f"(status={res.status_code})."
+            )
+            spinner.fail(f"{LogSymbols.ERROR.value}")
+            try:
+                detail = res.json().get("detail", res.reason)
+                click.echo(f"Error: {detail}")
+            except Exception:
+                pass
+        else:
+            job_data = res.json()
+            status = job_data.get("status", "").lower()
+            if status == "broken":
+                spinner.text = f"Job {full_job_id[:DISPLAY_ID_LENGTH]} marked as broken due to missing metadata."
+                spinner.ok(f"{LogSymbols.WARNING.value}")
+            else:
+                spinner.text = f"Resumed batch job {full_job_id[:DISPLAY_ID_LENGTH]}."
+                spinner.ok(f"{LogSymbols.SUCCESS.value}")
+
+
 @click.command(name="rm")
 @click.argument(
     "job_id",

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -88,7 +88,6 @@ from blackfish.server.services.text_generation import TextGenerationConfig
 from blackfish.server.jobs.base import (
     BatchJob,
     BatchJobStatus,
-    _RESUMABLE_STATUSES,
     create_tigerflow_client,
     create_tigerflow_client_for_profile,
 )
@@ -1668,18 +1667,30 @@ async def resume_job(
     against the same output dir (finished files are skipped). BROKEN is not
     resumable. Like starting a job, this does not poll; the periodic job poll
     picks up the resubmitted allocation.
+
+    Runs `start`'s pre-flight (image staged, input_dir still present), so a
+    resume whose inputs have gone away is rejected with a 4xx instead of
+    failing later inside the allocation.
     """
     job = await get_batch_job(job_id, session)
     if job is None:
         raise NotFoundException(detail=f"Job {job_id} not found")
 
-    if job.status not in _RESUMABLE_STATUSES:
+    if not job.is_resumable():
         raise ClientException(
             detail=f"Job {job_id} is not resumable (status: {job.status})"
         )
 
+    client = create_tigerflow_client(job, state)
+
     try:
-        await job.resume(state)
+        await job.resume(state, client)
+    except ValueError as e:
+        # Pre-flight rejection (e.g. input_dir was deleted since the job ran):
+        # the request is bad, not the job — leave it in its terminal status
+        # rather than marking it BROKEN, and surface a 4xx.
+        logger.warning(f"Rejected resume for job {job_id}: {e}")
+        raise ValidationException(detail=str(e))
     except TigerFlowError as e:
         # Resubmit failed (e.g. SSH/sbatch error): mark BROKEN, mirror stop_job.
         logger.warning(f"Resume command failed for job {job_id}: {e}")

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -88,6 +88,7 @@ from blackfish.server.services.text_generation import TextGenerationConfig
 from blackfish.server.jobs.base import (
     BatchJob,
     BatchJobStatus,
+    _RESUMABLE_STATUSES,
     create_tigerflow_client,
     create_tigerflow_client_for_profile,
 )
@@ -1649,6 +1650,43 @@ async def stop_job(
     except Exception as e:
         logger.warning(f"Status check failed for job {job_id}: {e}")
         job.status = BatchJobStatus.BROKEN
+
+    session.add(job)
+    await session.flush()
+    return job
+
+
+@put("/api/jobs/{job_id:str}/resume", guards=ENDPOINT_GUARDS)
+async def resume_job(
+    job_id: str,
+    session: AsyncSession,
+    state: State,
+) -> BatchJob | None:
+    """Resume a terminal job by resubmitting its allocation.
+
+    Only STOPPED/STALLED/EXHAUSTED jobs are resumable — resubmitting continues
+    against the same output dir (finished files are skipped). BROKEN is not
+    resumable. Like starting a job, this does not poll; the periodic job poll
+    picks up the resubmitted allocation.
+    """
+    job = await get_batch_job(job_id, session)
+    if job is None:
+        raise NotFoundException(detail=f"Job {job_id} not found")
+
+    if job.status not in _RESUMABLE_STATUSES:
+        raise ClientException(
+            detail=f"Job {job_id} is not resumable (status: {job.status})"
+        )
+
+    try:
+        await job.resume(state)
+    except TigerFlowError as e:
+        # Resubmit failed (e.g. SSH/sbatch error): mark BROKEN, mirror stop_job.
+        logger.warning(f"Resume command failed for job {job_id}: {e}")
+        job.status = BatchJobStatus.BROKEN
+        session.add(job)
+        await session.flush()
+        return job
 
     session.add(job)
     await session.flush()
@@ -3578,6 +3616,7 @@ app = Litestar(
         get_job,
         get_job_results,
         stop_job,
+        resume_job,
         delete_job,
         get_model,
         get_models,

--- a/lib/src/blackfish/server/jobs/base.py
+++ b/lib/src/blackfish/server/jobs/base.py
@@ -518,7 +518,20 @@ class BatchJob(UUIDAuditBase):
         await self._cancel_allocation()
         self.status = BatchJobStatus.STOPPED
 
-    async def resume(self, app_config: "State | BlackfishConfig") -> None:
+    def is_resumable(self) -> bool:
+        """Whether the job is in a status a resubmit can continue from.
+
+        STOPPED/STALLED/EXHAUSTED qualify. BROKEN does not: it marks a
+        metadata/config error whose root cause must be fixed first, not
+        something a resubmit resolves.
+        """
+        return self.status in _RESUMABLE_STATUSES
+
+    async def resume(
+        self,
+        app_config: "State | BlackfishConfig",
+        client: TigerFlowClient,
+    ) -> None:
         """Put a terminal job back into the restart loop.
 
         Resubmits the allocation against the same ``output_dir`` — the tigerflow
@@ -527,32 +540,53 @@ class BatchJob(UUIDAuditBase):
         restart counters are reset so the guards don't immediately re-fire the
         terminal status the job just came from.
 
+        Runs the same pre-flight as ``start``: a job can sit terminal for days,
+        so the image and ``input_dir`` are re-verified rather than assumed —
+        otherwise a since-deleted input directory fails deep inside the sbatch
+        script instead of here.
+
         No-op if the job isn't terminal (mirrors ``stop``'s already-stopped
         guard). Like ``start``, this does not poll; the periodic ``/api/jobs``
         poll advances the resubmitted allocation on its next pass.
 
         Args:
             app_config: Application configuration (HOME_DIR, IMAGES, provider).
+            client: TigerFlowClient for the image/directory pre-flight.
+
+        Raises:
+            TigerFlowError: If the image is not staged, or the resubmit fails.
+            ValueError: If ``input_dir`` no longer exists.
         """
         logger.info(
             f"Resuming batch job {self.id} (status={format_status(self.status)})"
         )
 
-        if self.status not in _RESUMABLE_STATUSES:
+        if not self.is_resumable():
             logger.debug(
                 f"Batch job {self.id} is not resumable "
                 f"(status={format_status(self.status)}); skipping resume command."
             )
             return
 
-        # Reset the guards that produced the terminal status. processed_highwater
-        # is left as-is: a resumed run that makes new progress clears the stall
-        # guard naturally, and the stale mark is the correct baseline for the
-        # first post-resume boundary.
+        versions = await client.check_health()
+        self.tigerflow_version = versions.tigerflow
+        self.tigerflow_ml_version = versions.tigerflow_ml
+
+        await self._ensure_directories(client)
+
+        job_id = await self._submit(app_config)
+
+        # Reset the guards that produced the terminal status, but only once the
+        # resubmit has actually landed — a resume that fails anywhere above
+        # leaves the counters describing the run the job really had, rather than
+        # crediting it a restart budget it never got to use. _submit doesn't
+        # read them, so the ordering is free. processed_highwater is left as-is:
+        # a resumed run that makes new progress clears the stall guard naturally,
+        # and the stale mark is the correct baseline for the first post-resume
+        # boundary.
         self.restarts = 0
         self.stalled_restarts = 0
 
-        job_id = await self._submit(app_config)
         self.pid = job_id
         self.status = BatchJobStatus.RESUBMITTED
 

--- a/lib/src/blackfish/server/jobs/base.py
+++ b/lib/src/blackfish/server/jobs/base.py
@@ -80,6 +80,17 @@ _TERMINAL_STATUSES = frozenset(
     }
 )
 
+# Terminal statuses a job can be resumed from: resubmit the allocation against
+# the same output_dir to continue processing. Excludes BROKEN (a metadata/config
+# error whose root cause must be fixed first, not something a resubmit resolves).
+_RESUMABLE_STATUSES = frozenset(
+    {
+        BatchJobStatus.STOPPED,
+        BatchJobStatus.STALLED,
+        BatchJobStatus.EXHAUSTED,
+    }
+)
+
 # Slurm states in which the allocation is still holding (or awaiting) resources.
 _ALIVE_STATES = frozenset(
     {
@@ -506,6 +517,44 @@ class BatchJob(UUIDAuditBase):
         await client.stop(self.output_dir)
         await self._cancel_allocation()
         self.status = BatchJobStatus.STOPPED
+
+    async def resume(self, app_config: "State | BlackfishConfig") -> None:
+        """Put a terminal job back into the restart loop.
+
+        Resubmits the allocation against the same ``output_dir`` — the tigerflow
+        pipeline skips already-finished files, so this continues where the job
+        left off (or picks up inputs added since a STOPPED completion). The
+        restart counters are reset so the guards don't immediately re-fire the
+        terminal status the job just came from.
+
+        No-op if the job isn't terminal (mirrors ``stop``'s already-stopped
+        guard). Like ``start``, this does not poll; the periodic ``/api/jobs``
+        poll advances the resubmitted allocation on its next pass.
+
+        Args:
+            app_config: Application configuration (HOME_DIR, IMAGES, provider).
+        """
+        logger.info(
+            f"Resuming batch job {self.id} (status={format_status(self.status)})"
+        )
+
+        if self.status not in _RESUMABLE_STATUSES:
+            logger.debug(
+                f"Batch job {self.id} is not resumable "
+                f"(status={format_status(self.status)}); skipping resume command."
+            )
+            return
+
+        # Reset the guards that produced the terminal status. processed_highwater
+        # is left as-is: a resumed run that makes new progress clears the stall
+        # guard naturally, and the stale mark is the correct baseline for the
+        # first post-resume boundary.
+        self.restarts = 0
+        self.stalled_restarts = 0
+
+        job_id = await self._submit(app_config)
+        self.pid = job_id
+        self.status = BatchJobStatus.RESUBMITTED
 
     async def _cancel_allocation(self) -> None:
         """Cancel the Slurm allocation, if any. Best-effort."""

--- a/lib/tests/api/test_jobs.py
+++ b/lib/tests/api/test_jobs.py
@@ -499,6 +499,79 @@ class TestStopBatchJobAPI:
         assert response.status_code == 401
 
 
+class TestResumeBatchJobAPI:
+    """Test cases for the PUT /api/jobs/{job_id}/resume endpoint."""
+
+    @patch("blackfish.server.jobs.base.BatchJob._submit")
+    @patch("blackfish.server.asgi.create_tigerflow_client")
+    async def test_resume_job_success(
+        self,
+        mock_create_client,
+        mock_submit,
+        client: AsyncTestClient,
+        session: AsyncSession,
+    ):
+        """Resuming a terminal job resubmits it and returns it RESUBMITTED."""
+        job_id = "2a7a8e62-40cc-4240-a825-463e5b11a81f"
+
+        mock_create_client.return_value = AsyncMock()
+        mock_submit.return_value = "999"
+
+        # Put the job in a resumable terminal state with a spent restart budget.
+        job = await session.get(BatchJob, UUID(job_id))
+        if job:
+            job.status = BatchJobStatus.EXHAUSTED
+            job.restarts = 20
+            job.stalled_restarts = 1
+            await session.commit()
+
+        response = await client.put(f"/api/jobs/{job_id}/resume")
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["id"] == job_id
+        assert result["status"] == "resubmitted"
+        assert result["restarts"] == 0
+        assert result["stalled_restarts"] == 0
+        assert result["pid"] == "999"
+        mock_submit.assert_called_once()
+
+    @patch("blackfish.server.jobs.base.BatchJob._submit")
+    async def test_resume_job_not_resumable(
+        self,
+        mock_submit,
+        client: AsyncTestClient,
+        session: AsyncSession,
+    ):
+        """A running (non-terminal) job cannot be resumed — 400, no resubmit."""
+        job_id = "391769fc-5a40-43db-bbfa-cec80a8c3710"
+
+        job = await session.get(BatchJob, UUID(job_id))
+        if job:
+            job.status = BatchJobStatus.RUNNING
+            await session.commit()
+
+        response = await client.put(f"/api/jobs/{job_id}/resume")
+
+        assert response.status_code == 400
+        # The resumable guard rejects before any resubmit.
+        mock_submit.assert_not_called()
+
+    async def test_resume_job_not_found(self, client: AsyncTestClient):
+        """Resuming a job that doesn't exist returns 404."""
+        nonexistent_id = "550e8400-e29b-41d4-a716-446655440000"
+        response = await client.put(f"/api/jobs/{nonexistent_id}/resume")
+        assert response.status_code == 404
+
+    async def test_resume_job_authentication_required(
+        self, no_auth_client: AsyncTestClient
+    ):
+        """Authentication is required for resuming jobs."""
+        job_id = "2a7a8e62-40cc-4240-a825-463e5b11a81f"
+        response = await no_auth_client.put(f"/api/jobs/{job_id}/resume")
+        assert response.status_code == 401
+
+
 class TestGetJobResultsAPI:
     """Test cases for the GET /api/jobs/{id}/results endpoint."""
 

--- a/lib/tests/api/test_jobs.py
+++ b/lib/tests/api/test_jobs.py
@@ -5,6 +5,7 @@ from litestar.testing import AsyncTestClient
 from unittest.mock import patch, AsyncMock
 
 from blackfish.server.jobs.base import BatchJob, BatchJobStatus
+from blackfish.server.jobs.client import TigerFlowVersions
 
 pytestmark = pytest.mark.anyio
 
@@ -514,7 +515,14 @@ class TestResumeBatchJobAPI:
         """Resuming a terminal job resubmits it and returns it RESUBMITTED."""
         job_id = "2a7a8e62-40cc-4240-a825-463e5b11a81f"
 
-        mock_create_client.return_value = AsyncMock()
+        # resume runs start's pre-flight, so the client must answer both the
+        # health check and the input-dir probe.
+        mock_client = AsyncMock()
+        mock_client.check_health.return_value = TigerFlowVersions(
+            tigerflow="0.1.0", tigerflow_ml="0.1.0"
+        )
+        mock_client.runner.run = AsyncMock(return_value=(0, b"", b""))
+        mock_create_client.return_value = mock_client
         mock_submit.return_value = "999"
 
         # Put the job in a resumable terminal state with a spent restart budget.
@@ -556,6 +564,41 @@ class TestResumeBatchJobAPI:
         assert response.status_code == 400
         # The resumable guard rejects before any resubmit.
         mock_submit.assert_not_called()
+
+    @patch("blackfish.server.jobs.base.BatchJob._submit")
+    @patch("blackfish.server.asgi.create_tigerflow_client")
+    async def test_resume_job_missing_input_dir(
+        self,
+        mock_create_client,
+        mock_submit,
+        client: AsyncTestClient,
+        session: AsyncSession,
+    ):
+        """An input_dir deleted since the job ran is a bad request, not a broken
+        job: 400, no resubmit, and the job keeps its terminal status."""
+        job_id = "2a7a8e62-40cc-4240-a825-463e5b11a81f"
+
+        mock_client = AsyncMock()
+        mock_client.check_health.return_value = TigerFlowVersions(
+            tigerflow="0.1.0", tigerflow_ml="0.1.0"
+        )
+        mock_client.runner.run = AsyncMock(return_value=(1, b"", b""))  # test -d
+        mock_create_client.return_value = mock_client
+
+        job = await session.get(BatchJob, UUID(job_id))
+        if job:
+            job.status = BatchJobStatus.STOPPED
+            await session.commit()
+
+        response = await client.put(f"/api/jobs/{job_id}/resume")
+
+        assert response.status_code == 400
+        mock_submit.assert_not_called()
+
+        session.expire_all()
+        refreshed = await session.get(BatchJob, UUID(job_id))
+        assert refreshed is not None
+        assert refreshed.status == BatchJobStatus.STOPPED
 
     async def test_resume_job_not_found(self, client: AsyncTestClient):
         """Resuming a job that doesn't exist returns 404."""

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -497,6 +497,73 @@ class TestBatchJobStop:
         mock_remote.run.assert_not_called()  # nothing to cancel
 
 
+class TestBatchJobResume:
+    """Tests for BatchJob.resume()."""
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            BatchJobStatus.STOPPED,
+            BatchJobStatus.STALLED,
+            BatchJobStatus.EXHAUSTED,
+        ],
+    )
+    async def test_resume_resubmits_and_resets_counters(
+        self, status: BatchJobStatus
+    ) -> None:
+        """resume should resubmit and reset the restart guards for any resumable
+        terminal status, leaving the job RESUBMITTED."""
+        job = create_test_batch_job(
+            status=status,
+            restarts=20,
+            stalled_restarts=1,
+            processed_highwater=42,
+        )
+        submit = AsyncMock(return_value="777")
+        with patch.object(job, "_submit", new=submit):
+            await job.resume(MockAppConfig())
+
+        submit.assert_called_once()
+        assert job.pid == "777"
+        assert job.status == BatchJobStatus.RESUBMITTED
+        assert job.restarts == 0
+        assert job.stalled_restarts == 0
+        # processed_highwater is intentionally preserved as the stall baseline.
+        assert job.processed_highwater == 42
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            BatchJobStatus.RUNNING,
+            BatchJobStatus.PENDING,
+            BatchJobStatus.SUBMITTED,
+            BatchJobStatus.RESUBMITTED,
+            BatchJobStatus.BROKEN,
+        ],
+    )
+    async def test_resume_is_noop_when_not_resumable(
+        self, status: BatchJobStatus
+    ) -> None:
+        """resume should skip non-resumable jobs — active statuses and BROKEN
+        (a hard error a resubmit can't fix) — without submitting."""
+        job = create_test_batch_job(status=status, restarts=5)
+        submit = AsyncMock(return_value="777")
+        with patch.object(job, "_submit", new=submit):
+            await job.resume(MockAppConfig())
+
+        submit.assert_not_called()
+        assert job.status == status
+        assert job.restarts == 5  # counters untouched
+
+    async def test_resume_propagates_submit_error(self) -> None:
+        """A failed resubmit surfaces to the caller (the route maps it to BROKEN)."""
+        job = create_test_batch_job(status=BatchJobStatus.EXHAUSTED)
+        submit = AsyncMock(side_effect=TigerFlowError("submit", "host", "failed"))
+        with patch.object(job, "_submit", new=submit):
+            with pytest.raises(TigerFlowError):
+                await job.resume(MockAppConfig())
+
+
 class TestBatchJobEnsureDirectories:
     """Input validation + output setup at job start."""
 

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -81,6 +81,15 @@ def create_mock_client() -> AsyncMock:
     return client
 
 
+def create_resume_client() -> AsyncMock:
+    """A mock client whose pre-flight (check_health + `test -d`) succeeds."""
+    client = create_mock_client()
+    client.check_health.return_value = TigerFlowVersions(
+        tigerflow="0.1.0", tigerflow_ml="0.1.0"
+    )
+    return client
+
+
 class TestBatchJobStart:
     """Tests for BatchJob.start()."""
 
@@ -521,7 +530,7 @@ class TestBatchJobResume:
         )
         submit = AsyncMock(return_value="777")
         with patch.object(job, "_submit", new=submit):
-            await job.resume(MockAppConfig())
+            await job.resume(MockAppConfig(), create_resume_client())
 
         submit.assert_called_once()
         assert job.pid == "777"
@@ -549,19 +558,57 @@ class TestBatchJobResume:
         job = create_test_batch_job(status=status, restarts=5)
         submit = AsyncMock(return_value="777")
         with patch.object(job, "_submit", new=submit):
-            await job.resume(MockAppConfig())
+            await job.resume(MockAppConfig(), create_resume_client())
 
         submit.assert_not_called()
         assert job.status == status
         assert job.restarts == 5  # counters untouched
 
     async def test_resume_propagates_submit_error(self) -> None:
-        """A failed resubmit surfaces to the caller (the route maps it to BROKEN)."""
-        job = create_test_batch_job(status=BatchJobStatus.EXHAUSTED)
+        """A failed resubmit surfaces to the caller (the route maps it to BROKEN),
+        leaving the restart counters describing the run the job actually had."""
+        job = create_test_batch_job(
+            status=BatchJobStatus.EXHAUSTED, restarts=20, stalled_restarts=1
+        )
         submit = AsyncMock(side_effect=TigerFlowError("submit", "host", "failed"))
         with patch.object(job, "_submit", new=submit):
             with pytest.raises(TigerFlowError):
-                await job.resume(MockAppConfig())
+                await job.resume(MockAppConfig(), create_resume_client())
+
+        assert job.restarts == 20
+        assert job.stalled_restarts == 1
+
+    async def test_resume_rejects_missing_input_dir(self) -> None:
+        """A job can sit terminal for days; if input_dir has since been deleted,
+        resume must fail fast (as start does) rather than submit an allocation
+        that dies inside the sbatch script."""
+        job = create_test_batch_job(status=BatchJobStatus.STOPPED, restarts=20)
+        client = create_resume_client()
+        client.runner.run = AsyncMock(return_value=(1, b"", b""))  # test -d fails
+
+        submit = AsyncMock(return_value="777")
+        with patch.object(job, "_submit", new=submit):
+            with pytest.raises(ValueError, match="Input directory does not exist"):
+                await job.resume(MockAppConfig(), client)
+
+        submit.assert_not_called()
+        assert job.status == BatchJobStatus.STOPPED
+        # Counters describe the run the job actually had, not the rejected resume.
+        assert job.restarts == 20
+
+    async def test_resume_checks_image_before_submitting(self) -> None:
+        """resume re-verifies the image like start does; an unstaged image must
+        surface before the allocation is submitted."""
+        job = create_test_batch_job(status=BatchJobStatus.EXHAUSTED)
+        client = create_resume_client()
+        client.check_health.side_effect = TigerFlowError("health", "host", "missing")
+
+        submit = AsyncMock(return_value="777")
+        with patch.object(job, "_submit", new=submit):
+            with pytest.raises(TigerFlowError):
+                await job.resume(MockAppConfig(), client)
+
+        submit.assert_not_called()
 
 
 class TestBatchJobEnsureDirectories:


### PR DESCRIPTION
## Summary

- Adds `BatchJob.resume()` — puts a terminal job (STOPPED / STALLED / EXHAUSTED) back into the restart loop by resubmitting against the same `output_dir`. The tigerflow pipeline skips already-finished files, so a resume continues where the job left off (or picks up inputs added since a STOPPED completion). Resets `restarts`/`stalled_restarts`, sets status RESUBMITTED, and — like `start()` — does not poll (the periodic `/api/jobs` poll advances the resubmitted allocation).
- **BROKEN is intentionally not resumable** (a metadata/config error a resubmit can't fix). The resumable set lives in a new `_RESUMABLE_STATUSES` frozenset (terminal minus BROKEN); `resume()` is a no-op for any non-resumable status.
- Exposes it via `PUT /api/jobs/{id}/resume` (400 if not resumable, 404 if missing, BROKEN on a `TigerFlowError`) and a `blackfish batch resume <id>` CLI command, both mirroring the existing stop flow.

Backend half of #434 (the web Resume button + STALLED "fix the input first" warning follow in a second PR).

## Review feedback (d694e25)

- **Docs contradicted the feature** — the `stop` section warned there is "no resume-after-stop"; corrected, with a `resume` section alongside `stop`/`rm` and a pointer from *Walltime and restarts*.
- **`_RESUMABLE_STATUSES` imported across a module boundary** — replaced with a `BatchJob.is_resumable()` method; the constant stays private to `base.py`.
- **`resume()` skipped `start()`'s pre-flight** — now runs `check_health()` + `_ensure_directories()`. A job can sit terminal for days, so a since-deleted `input_dir` now yields a 400 (job left in its terminal status) instead of failing deep inside the sbatch script. Costs one remote round-trip per resume, matching what starting a job already does.
- **Counter reset before an awaited `_submit()`** — moved to after the resubmit lands, so a failed resume leaves `restarts`/`stalled_restarts` describing the run the job actually had.

## Test plan

- `cd lib && uv run pytest` — full suite **898 passed, 7 skipped**. New coverage:
  - **9 unit tests** (`TestBatchJobResume`): resume from each of STOPPED/STALLED/EXHAUSTED resubmits + resets counters + sets RESUBMITTED + preserves `processed_highwater`; no-op for RUNNING/PENDING/SUBMITTED/RESUBMITTED/**BROKEN**; submit error propagates.
  - **5 API tests** (`TestResumeBatchJobAPI`): terminal job → 200 + RESUBMITTED + reset counters; running job → 400 (no resubmit); missing `input_dir` → 400 with the job left in its terminal status; missing → 404; unauthenticated → 401.
- `uv run pre-commit run --files <the 6 changed files>` — all hooks pass (ruff, ruff-format, mypy, logger/mock guards).

> Note: repo-wide `just lint` autofix-reformats ~100 unrelated files in this environment (pre-existing ruff/pre-commit version drift, not from this PR); lint was therefore verified scoped to the changed files.

Part of #434 — backend half only. The web Resume button and the STALLED
"fix the input first" warning are the follow-up PR (see the issue's Sequencing
section).
