### PR TITLE
feat(web): sortable and filterable job and results tables

### DIFF
--- a/web/src/components/FilterHeader.jsx
+++ b/web/src/components/FilterHeader.jsx
@@ -1,0 +1,120 @@
+import { Popover, PopoverButton, PopoverPanel, Portal } from "@headlessui/react";
+import { FunnelIcon, CheckIcon } from "@heroicons/react/24/outline";
+import { FunnelIcon as FunnelSolidIcon } from "@heroicons/react/24/solid";
+import { getQueryFilters, toggleQueryFilter, setQueryFilters } from "@/lib/tableQuery";
+import PropTypes from "prop-types";
+
+/**
+ * A table header cell that is itself a multi-select filter dropdown. Clicking
+ * the label opens a checkbox menu; toggling options adds/removes
+ * `filterKey:value` tokens in the canonical query (values for one key are ORed
+ * by applyQuery). A funnel icon fills in when any option is selected.
+ *
+ * @param {object} props
+ * @param {string} props.label - column label
+ * @param {string} props.filterKey - query key this column writes (e.g. "status")
+ * @param {Array<{ value: string, label: string }>} props.options
+ * @param {string} props.query - canonical query string
+ * @param {(q: string) => void} props.setQuery
+ * @param {string} [props.clearLabel] - reset entry text (default "Clear")
+ * @param {string} [props.className] - passed through to the <th>
+ */
+function FilterHeader({
+  label,
+  filterKey,
+  options,
+  query,
+  setQuery,
+  clearLabel = "Clear",
+  className = "",
+}) {
+  const selected = getQueryFilters(query, filterKey);
+  const active = selected.length > 0;
+
+  return (
+    <th
+      scope="col"
+      className={`sticky top-0 z-10 py-3.5 text-sm font-semibold text-gray-900 dark:text-gray-100 backdrop-blur bg-gray-50 dark:bg-gray-800 ${className}`}
+    >
+      <Popover className="relative inline-block text-left">
+        <PopoverButton className="group inline-flex items-center gap-1 hover:text-gray-600 dark:hover:text-gray-300 focus:outline-none">
+          <span className={active ? "text-blue-600 dark:text-blue-400" : ""}>
+            {label}
+          </span>
+          {active ? (
+            <span className="inline-flex items-center gap-0.5 text-blue-600 dark:text-blue-400">
+              <FunnelSolidIcon className="h-3.5 w-3.5" aria-hidden="true" />
+              <span className="text-xs font-medium">{selected.length}</span>
+            </span>
+          ) : (
+            <FunnelIcon
+              className="h-3.5 w-3.5 opacity-0 group-hover:opacity-40"
+              aria-hidden="true"
+            />
+          )}
+        </PopoverButton>
+        <Portal>
+          <PopoverPanel
+            anchor="bottom start"
+            className="z-50 mt-1 w-48 rounded-md bg-white dark:bg-gray-700 shadow-lg ring-1 ring-black/5 dark:ring-gray-600 focus:outline-none"
+          >
+            <div className="py-1">
+              {options.map((opt) => {
+                const checked = selected.includes(opt.value.toLowerCase());
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() =>
+                      setQuery(toggleQueryFilter(query, filterKey, opt.value))
+                    }
+                    aria-pressed={checked}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-sm font-normal text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-none"
+                  >
+                    <span className="flex h-4 w-4 flex-none items-center justify-center rounded border border-gray-300 dark:border-gray-500">
+                      {checked && (
+                        <CheckIcon className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
+                      )}
+                    </span>
+                    <span className={checked ? "font-medium text-gray-900 dark:text-gray-100" : ""}>
+                      {opt.label}
+                    </span>
+                  </button>
+                );
+              })}
+              {active && (
+                <>
+                  <div className="my-1 border-t border-gray-200 dark:border-gray-600" />
+                  <button
+                    type="button"
+                    onClick={() => setQuery(setQueryFilters(query, filterKey, []))}
+                    className="block w-full px-3 py-2 text-left text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-none"
+                  >
+                    {clearLabel}
+                  </button>
+                </>
+              )}
+            </div>
+          </PopoverPanel>
+        </Portal>
+      </Popover>
+    </th>
+  );
+}
+
+FilterHeader.propTypes = {
+  label: PropTypes.string.isRequired,
+  filterKey: PropTypes.string.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  query: PropTypes.string.isRequired,
+  setQuery: PropTypes.func.isRequired,
+  clearLabel: PropTypes.string,
+  className: PropTypes.string,
+};
+
+export default FilterHeader;

--- a/web/src/components/FilterHeader.test.jsx
+++ b/web/src/components/FilterHeader.test.jsx
@@ -1,0 +1,96 @@
+import { render, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, test, expect, vi } from "vitest";
+import FilterHeader from "./FilterHeader";
+
+const options = [
+  { value: "running", label: "Running" },
+  { value: "stopped", label: "Stopped" },
+];
+
+function renderHeader(props) {
+  // A <th> must live inside a table row for valid DOM.
+  return render(
+    <table>
+      <thead>
+        <tr>
+          <FilterHeader
+            label="Status"
+            filterKey="status"
+            options={options}
+            query=""
+            setQuery={vi.fn()}
+            {...props}
+          />
+        </tr>
+      </thead>
+    </table>,
+  );
+}
+
+describe("FilterHeader", () => {
+  test("toggling an option adds its filterKey:value to the query", async () => {
+    const setQuery = vi.fn();
+    const { getByRole, getByText } = renderHeader({ query: "foo", setQuery });
+    await act(async () => {
+      await userEvent.click(getByRole("button", { name: /status/i }));
+    });
+    await act(async () => {
+      await userEvent.click(getByText("Running"));
+    });
+    expect(setQuery).toHaveBeenCalledWith("foo status:running");
+  });
+
+  test("toggling an already-selected option removes just that value", async () => {
+    const setQuery = vi.fn();
+    const { getByRole, getByText } = renderHeader({
+      query: "status:running status:stopped",
+      setQuery,
+    });
+    await act(async () => {
+      await userEvent.click(getByRole("button", { name: /status/i }));
+    });
+    await act(async () => {
+      await userEvent.click(getByText("Running"));
+    });
+    // stopped is preserved; only running is removed.
+    expect(setQuery).toHaveBeenCalledWith("status:stopped");
+  });
+
+  test("selecting a second option keeps the first (multi-select)", async () => {
+    const setQuery = vi.fn();
+    const { getByRole, getByText } = renderHeader({
+      query: "status:running",
+      setQuery,
+    });
+    await act(async () => {
+      await userEvent.click(getByRole("button", { name: /status/i }));
+    });
+    await act(async () => {
+      await userEvent.click(getByText("Stopped"));
+    });
+    expect(setQuery).toHaveBeenCalledWith("status:running status:stopped");
+  });
+
+  test("clear removes all of the column's values, keeping other tokens", async () => {
+    const setQuery = vi.fn();
+    const { getByRole, getByText } = renderHeader({
+      query: "keep status:running status:stopped",
+      setQuery,
+      clearLabel: "Clear statuses",
+    });
+    await act(async () => {
+      await userEvent.click(getByRole("button", { name: /status/i }));
+    });
+    await act(async () => {
+      await userEvent.click(getByText("Clear statuses"));
+    });
+    expect(setQuery).toHaveBeenCalledWith("keep");
+  });
+
+  test("shows a count when filters are active", () => {
+    const { getByRole } = renderHeader({ query: "status:running status:stopped" });
+    // The header button's accessible name includes the active count.
+    expect(getByRole("button", { name: /status.*2/i })).toBeInTheDocument();
+  });
+});

--- a/web/src/components/FilterMenu.jsx
+++ b/web/src/components/FilterMenu.jsx
@@ -1,0 +1,176 @@
+import { Popover, PopoverButton, PopoverPanel, Portal } from "@headlessui/react";
+import { ChevronDownIcon, CheckIcon } from "@heroicons/react/24/outline";
+import {
+  getQueryFilter,
+  getQueryFilters,
+  setQueryFilter,
+  toggleQueryFilter,
+  setQueryFilters,
+} from "@/lib/tableQuery";
+import PropTypes from "prop-types";
+
+// Count of currently-selected options across all sections, for the button badge.
+function countSelected(query, sections) {
+  return sections.reduce((n, s) => {
+    if (s.mode === "multi") return n + getQueryFilters(query, s.filterKey).length;
+    return n + (getQueryFilter(query, s.filterKey) != null ? 1 : 0);
+  }, 0);
+}
+
+/**
+ * A dropdown of grouped filter sections that edit the canonical query string.
+ * Each section targets its own query key and chooses its selection mode:
+ *   - "single": radio-like; picking an option replaces that key (mutually
+ *     exclusive options, e.g. active vs inactive).
+ *   - "multi": checkboxes; toggling adds/removes values for that key (ORed by
+ *     applyQuery), e.g. task types.
+ * The panel stays open across clicks so multi-select is usable.
+ *
+ * @param {object} props
+ * @param {string} props.label - button label when nothing is selected
+ * @param {Array<{ title: string, filterKey: string, mode: "single"|"multi",
+ *   options: Array<{ value: string, label: string }> }>} props.sections
+ * @param {string} props.query
+ * @param {(q: string) => void} props.setQuery
+ */
+function FilterMenu({ label, sections, query, setQuery }) {
+  const count = countSelected(query, sections);
+  const active = count > 0;
+
+  const clearAll = () => {
+    let next = query;
+    for (const s of sections) next = setQueryFilters(next, s.filterKey, []);
+    setQuery(next);
+  };
+
+  return (
+    <Popover className="relative flex-none">
+      {/* -ml-px collapses the shared border seam with the search input; the left
+          side is square and only the right is rounded so it reads as attached. */}
+      <PopoverButton className="inline-flex items-center gap-1 -ml-px rounded-r-md bg-gray-50 dark:bg-gray-800 px-2.5 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 ring-1 ring-inset ring-gray-300 dark:ring-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 focus:z-10 focus:outline-none">
+        <span className={active ? "text-blue-600 dark:text-blue-400" : ""}>
+          {label}
+        </span>
+        {active && (
+          <span className="text-xs font-medium text-blue-600 dark:text-blue-400">
+            {count}
+          </span>
+        )}
+        <ChevronDownIcon className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+      </PopoverButton>
+      <Portal>
+        <PopoverPanel
+          anchor="bottom end"
+          className="z-50 mt-1 w-56 rounded-md bg-white dark:bg-gray-700 shadow-lg ring-1 ring-black/5 dark:ring-gray-600 focus:outline-none"
+        >
+          <div className="py-1">
+            {sections.map((section, si) => (
+              <div key={section.filterKey}>
+                {si > 0 && (
+                  <div className="my-1 border-t border-gray-200 dark:border-gray-600" />
+                )}
+                <div className="px-3 pt-1.5 pb-1 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                  {section.title}
+                </div>
+                {section.options.map((opt) => {
+                  const checked =
+                    section.mode === "multi"
+                      ? getQueryFilters(query, section.filterKey).includes(
+                          opt.value.toLowerCase(),
+                        )
+                      : getQueryFilter(query, section.filterKey) ===
+                        opt.value.toLowerCase();
+                  const isMulti = section.mode === "multi";
+                  return (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      aria-pressed={checked}
+                      onClick={() => {
+                        if (isMulti) {
+                          setQuery(
+                            toggleQueryFilter(query, section.filterKey, opt.value),
+                          );
+                        } else {
+                          // Single-select: toggle off if re-picked, else set.
+                          setQuery(
+                            setQueryFilter(
+                              query,
+                              section.filterKey,
+                              checked ? null : opt.value,
+                            ),
+                          );
+                        }
+                      }}
+                      className={`flex w-full items-center px-3 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-none ${
+                        isMulti ? "gap-2" : "justify-between gap-2"
+                      }`}
+                    >
+                      {/* Multi: leading checkbox. Single: bold label + trailing
+                          check, matching the app's Listbox single-select style. */}
+                      {isMulti && (
+                        <span className="flex h-4 w-4 flex-none items-center justify-center rounded border border-gray-300 dark:border-gray-500">
+                          {checked && (
+                            <CheckIcon className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
+                          )}
+                        </span>
+                      )}
+                      <span
+                        className={
+                          checked
+                            ? "font-semibold text-gray-900 dark:text-gray-100"
+                            : "font-normal"
+                        }
+                      >
+                        {opt.label}
+                      </span>
+                      {!isMulti && checked && (
+                        <CheckIcon
+                          className="h-4 w-4 flex-none text-blue-600 dark:text-blue-400"
+                          aria-hidden="true"
+                        />
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+            {active && (
+              <>
+                <div className="my-1 border-t border-gray-200 dark:border-gray-600" />
+                <button
+                  type="button"
+                  onClick={clearAll}
+                  className="block w-full px-3 py-2 text-left text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-none"
+                >
+                  Clear filters
+                </button>
+              </>
+            )}
+          </div>
+        </PopoverPanel>
+      </Portal>
+    </Popover>
+  );
+}
+
+FilterMenu.propTypes = {
+  label: PropTypes.string.isRequired,
+  sections: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      filterKey: PropTypes.string.isRequired,
+      mode: PropTypes.oneOf(["single", "multi"]).isRequired,
+      options: PropTypes.arrayOf(
+        PropTypes.shape({
+          value: PropTypes.string.isRequired,
+          label: PropTypes.string.isRequired,
+        }),
+      ).isRequired,
+    }),
+  ).isRequired,
+  query: PropTypes.string.isRequired,
+  setQuery: PropTypes.func.isRequired,
+};
+
+export default FilterMenu;

--- a/web/src/components/FilterMenu.test.jsx
+++ b/web/src/components/FilterMenu.test.jsx
@@ -1,0 +1,105 @@
+import { render, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, test, expect, vi } from "vitest";
+import FilterMenu from "./FilterMenu";
+
+const sections = [
+  {
+    title: "Show",
+    filterKey: "filter",
+    mode: "single",
+    options: [
+      { value: "active", label: "Active jobs" },
+      { value: "inactive", label: "Inactive jobs" },
+    ],
+  },
+  {
+    title: "Tasks",
+    filterKey: "task",
+    mode: "multi",
+    options: [
+      { value: "transcribe", label: "Transcription" },
+      { value: "translate", label: "Translation" },
+    ],
+  },
+];
+
+function renderMenu(props) {
+  return render(
+    <FilterMenu
+      label="Filters"
+      sections={sections}
+      query=""
+      setQuery={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+async function openMenu(getByRole) {
+  await act(async () => {
+    await userEvent.click(getByRole("button", { name: /filters/i }));
+  });
+}
+
+describe("FilterMenu", () => {
+  test("a single-select section sets its key (replacing any prior value)", async () => {
+    const setQuery = vi.fn();
+    const { getByRole, getByText } = renderMenu({ query: "filter:active", setQuery });
+    await openMenu(getByRole);
+    await act(async () => {
+      await userEvent.click(getByText("Inactive jobs"));
+    });
+    expect(setQuery).toHaveBeenCalledWith("filter:inactive");
+  });
+
+  test("re-picking the selected single option toggles it off", async () => {
+    const setQuery = vi.fn();
+    const { getByRole, getByText } = renderMenu({ query: "filter:active", setQuery });
+    await openMenu(getByRole);
+    await act(async () => {
+      await userEvent.click(getByText("Active jobs"));
+    });
+    expect(setQuery).toHaveBeenCalledWith("");
+  });
+
+  test("a multi-select section toggles values, keeping others", async () => {
+    const setQuery = vi.fn();
+    const { getByRole, getByText } = renderMenu({
+      query: "task:transcribe",
+      setQuery,
+    });
+    await openMenu(getByRole);
+    await act(async () => {
+      await userEvent.click(getByText("Translation"));
+    });
+    expect(setQuery).toHaveBeenCalledWith("task:transcribe task:translate");
+  });
+
+  test("shows a total selected count on the button", async () => {
+    const { getByRole } = renderMenu({
+      query: "filter:active task:transcribe task:translate",
+    });
+    // 1 (single) + 2 (multi) = 3
+    expect(getByRole("button", { name: /filters.*3/i })).toBeInTheDocument();
+  });
+
+  test("Clear filters removes every section's values", async () => {
+    const setQuery = vi.fn();
+    const { getByRole, getByText } = renderMenu({
+      query: "keep filter:active task:transcribe",
+      setQuery,
+    });
+    await openMenu(getByRole);
+    await act(async () => {
+      await userEvent.click(getByText("Clear filters"));
+    });
+    expect(setQuery).toHaveBeenCalledWith("keep");
+  });
+
+  test("no Clear filters entry when nothing is selected", async () => {
+    const { getByRole, queryByText } = renderMenu({ query: "" });
+    await openMenu(getByRole);
+    expect(queryByText("Clear filters")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/SortableHeader.jsx
+++ b/web/src/components/SortableHeader.jsx
@@ -1,0 +1,73 @@
+import { ChevronUpIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
+import PropTypes from "prop-types";
+
+/**
+ * A sortable table header cell. Clicking cycles the column's sort direction
+ * (asc -> desc -> off) via `onSort`, and shows a chevron for the active column.
+ *
+ * @param {object} props
+ * @param {string} props.label - visible column label
+ * @param {string} props.sortKey - this column's sort key
+ * @param {string|null} props.activeKey - the currently-sorted key
+ * @param {"asc"|"desc"|null} props.direction - active sort direction
+ * @param {(key: string) => void} props.onSort
+ * @param {string} [props.className] - passed through to the <th>
+ * @param {"left"|"right"|"center"} [props.align]
+ */
+function SortableHeader({
+  label,
+  sortKey,
+  activeKey,
+  direction,
+  onSort,
+  className = "",
+  align = "left",
+}) {
+  const isActive = activeKey === sortKey && direction != null;
+  const justify =
+    align === "right" ? "justify-end" : align === "center" ? "justify-center" : "justify-start";
+
+  return (
+    <th
+      scope="col"
+      className={`sticky top-0 z-10 py-3.5 text-sm font-semibold text-gray-900 dark:text-gray-100 backdrop-blur bg-gray-50 dark:bg-gray-800 ${className}`}
+      aria-sort={
+        isActive ? (direction === "asc" ? "ascending" : "descending") : "none"
+      }
+    >
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className={`group inline-flex items-center gap-1 ${justify} w-full text-${align} hover:text-gray-600 dark:hover:text-gray-300 focus:outline-none`}
+      >
+        <span>{label}</span>
+        <span className="flex-none">
+          {isActive ? (
+            direction === "asc" ? (
+              <ChevronUpIcon className="h-4 w-4" aria-hidden="true" />
+            ) : (
+              <ChevronDownIcon className="h-4 w-4" aria-hidden="true" />
+            )
+          ) : (
+            <ChevronDownIcon
+              className="h-4 w-4 opacity-0 group-hover:opacity-30"
+              aria-hidden="true"
+            />
+          )}
+        </span>
+      </button>
+    </th>
+  );
+}
+
+SortableHeader.propTypes = {
+  label: PropTypes.string.isRequired,
+  sortKey: PropTypes.string.isRequired,
+  activeKey: PropTypes.string,
+  direction: PropTypes.oneOf(["asc", "desc"]),
+  onSort: PropTypes.func.isRequired,
+  className: PropTypes.string,
+  align: PropTypes.oneOf(["left", "right", "center"]),
+};
+
+export default SortableHeader;

--- a/web/src/components/SortableHeader.test.jsx
+++ b/web/src/components/SortableHeader.test.jsx
@@ -1,0 +1,47 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, test, expect, vi } from "vitest";
+import SortableHeader from "./SortableHeader";
+
+function renderHeader(props) {
+  return render(
+    <table>
+      <thead>
+        <tr>
+          <SortableHeader
+            label="Name"
+            sortKey="name"
+            activeKey={null}
+            direction={null}
+            onSort={vi.fn()}
+            {...props}
+          />
+        </tr>
+      </thead>
+    </table>,
+  );
+}
+
+describe("SortableHeader", () => {
+  test("clicking calls onSort with the column's key", async () => {
+    const onSort = vi.fn();
+    const { getByRole } = renderHeader({ onSort });
+    await userEvent.click(getByRole("button", { name: /name/i }));
+    expect(onSort).toHaveBeenCalledWith("name");
+  });
+
+  test("reports no sort direction when inactive", () => {
+    const { getByRole } = renderHeader({ activeKey: "other", direction: "asc" });
+    expect(getByRole("columnheader")).toHaveAttribute("aria-sort", "none");
+  });
+
+  test("reflects ascending sort when active", () => {
+    const { getByRole } = renderHeader({ activeKey: "name", direction: "asc" });
+    expect(getByRole("columnheader")).toHaveAttribute("aria-sort", "ascending");
+  });
+
+  test("reflects descending sort when active", () => {
+    const { getByRole } = renderHeader({ activeKey: "name", direction: "desc" });
+    expect(getByRole("columnheader")).toHaveAttribute("aria-sort", "descending");
+  });
+});

--- a/web/src/components/TableSearch.jsx
+++ b/web/src/components/TableSearch.jsx
@@ -1,0 +1,60 @@
+import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import PropTypes from "prop-types";
+
+/**
+ * Search bar for client-side tables. A single text input holds the canonical
+ * query (free text + `key:value` qualifiers). An optional attached control
+ * (e.g. a sectioned FilterMenu) is rendered via `children` and forms one
+ * rounded group with the input.
+ *
+ * @param {object} props
+ * @param {string} props.query
+ * @param {(q: string) => void} props.setQuery
+ * @param {string} [props.placeholder]
+ * @param {React.ReactNode} [props.children] - control attached after the input;
+ *   handles its own seam styling (-ml-px, rounded-r-md).
+ */
+function TableSearch({ query, setQuery, placeholder = "", children }) {
+  const hasAttached = children != null;
+
+  return (
+    <div className="flex items-center">
+      <div className="relative flex-1">
+        <MagnifyingGlassIcon
+          className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+          aria-hidden="true"
+        />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={placeholder}
+          aria-label="Search"
+          className={`w-full border-0 bg-white dark:bg-gray-700 py-1.5 pl-8 pr-8 text-sm text-gray-900 dark:text-gray-100 ring-1 ring-inset ring-gray-300 dark:ring-gray-600 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:z-10 focus:ring-2 focus:ring-inset focus:ring-blue-500 ${
+            hasAttached ? "rounded-l-md" : "rounded-md"
+          }`}
+        />
+        {query !== "" && (
+          <button
+            type="button"
+            onClick={() => setQuery("")}
+            aria-label="Clear search"
+            className="absolute right-2 top-1/2 z-10 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            <XMarkIcon className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+TableSearch.propTypes = {
+  query: PropTypes.string.isRequired,
+  setQuery: PropTypes.func.isRequired,
+  placeholder: PropTypes.string,
+  children: PropTypes.node,
+};
+
+export default TableSearch;

--- a/web/src/components/TableSearch.test.jsx
+++ b/web/src/components/TableSearch.test.jsx
@@ -1,0 +1,40 @@
+import { render, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, test, expect, vi } from "vitest";
+import TableSearch from "./TableSearch";
+
+describe("TableSearch", () => {
+  test("typing updates the query", async () => {
+    const setQuery = vi.fn();
+    const { getByLabelText } = render(
+      <TableSearch query="" setQuery={setQuery} />,
+    );
+    await act(async () => {
+      await userEvent.type(getByLabelText("Search"), "x");
+    });
+    expect(setQuery).toHaveBeenCalledWith("x");
+  });
+
+  test("clear button empties the query and only shows when non-empty", async () => {
+    const setQuery = vi.fn();
+    const { getByLabelText, queryByLabelText, rerender } = render(
+      <TableSearch query="" setQuery={setQuery} />,
+    );
+    expect(queryByLabelText("Clear search")).not.toBeInTheDocument();
+
+    rerender(<TableSearch query="foo" setQuery={setQuery} />);
+    await act(async () => {
+      await userEvent.click(getByLabelText("Clear search"));
+    });
+    expect(setQuery).toHaveBeenCalledWith("");
+  });
+
+  test("renders an attached control passed as children", () => {
+    const { getByText } = render(
+      <TableSearch query="" setQuery={vi.fn()}>
+        <button type="button">Filters</button>
+      </TableSearch>,
+    );
+    expect(getByText("Filters")).toBeInTheDocument();
+  });
+});

--- a/web/src/lib/tableQuery.js
+++ b/web/src/lib/tableQuery.js
@@ -1,0 +1,168 @@
+// GitHub-issues-style query parsing + matching for client-side table filtering.
+//
+// A query string mixes free text with `key:value` qualifiers, e.g.
+//   status:failed file:whisper report
+// parses to bare text ["report"] plus a qualifier {status: ["failed"], file:
+// ["whisper"]}. Repeating a key ORs its values (`status:failed status:success`).
+// Quoting a value preserves spaces: `name:"my job"`.
+
+/**
+ * Parse a raw query string into bare text terms and keyed qualifiers.
+ * @param {string} raw
+ * @returns {{ text: string[], filters: Record<string, string[]> }}
+ */
+export function parseQuery(raw) {
+  const text = [];
+  const filters = {};
+  if (!raw) return { text, filters };
+
+  // Tokenize on whitespace, but keep quoted spans (single- or double-quoted)
+  // together so `name:"my job"` is one token.
+  const tokens = raw.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [];
+
+  for (const token of tokens) {
+    const sep = token.indexOf(":");
+    // A leading ':' or no ':' means it's free text, not a qualifier.
+    if (sep > 0) {
+      const key = token.slice(0, sep).toLowerCase();
+      const value = unquote(token.slice(sep + 1));
+      if (value !== "") {
+        (filters[key] ??= []).push(value.toLowerCase());
+        continue;
+      }
+    }
+    const bare = unquote(token);
+    if (bare !== "") text.push(bare.toLowerCase());
+  }
+
+  return { text, filters };
+}
+
+function unquote(s) {
+  if (
+    s.length >= 2 &&
+    ((s[0] === '"' && s[s.length - 1] === '"') ||
+      (s[0] === "'" && s[s.length - 1] === "'"))
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+/**
+ * Filter rows against a parsed query. Filtering is qualifier-only: a token
+ * narrows the list only when it is `key:value` with a *known* key and a
+ * non-empty value. Bare text, a partial key (no `:` yet), `key:` with no value,
+ * and unknown keys are all ignored rather than treated as failed matches — so a
+ * query that has nothing actionable yet (still being typed) returns all rows
+ * instead of a premature empty result.
+ *
+ * @param {Array<object>} rows
+ * @param {string} raw - the raw query string
+ * @param {object} config
+ * @param {Record<string, (row: object) => string|null>} config.fields - maps a
+ *   qualifier key to a function returning the row's comparable string. Values
+ *   match as case-insensitive substrings.
+ * @returns {Array<object>}
+ */
+export function applyQuery(rows, raw, { fields = {} } = {}) {
+  const { filters } = parseQuery(raw);
+
+  // Keep only qualifiers whose key is known; unknown/partial keys are ignored.
+  const active = Object.entries(filters).filter(([key]) => fields[key]);
+  if (active.length === 0) return rows;
+
+  return rows.filter((row) => {
+    // Every active qualifier key must match (AND across keys); within a key,
+    // any of its values matches (OR).
+    for (const [key, values] of active) {
+      const rowVal = fields[key](row);
+      const rowStr = rowVal == null ? "" : String(rowVal).toLowerCase();
+      if (!values.some((v) => rowStr.includes(v))) return false;
+    }
+
+    return true;
+  });
+}
+
+/**
+ * Return a new query string with `key` set to exactly `value` (replacing any
+ * existing values for that key), or with `key` removed when `value` is null/"".
+ * Bare text and other qualifiers are preserved in their original order. Used by
+ * dropdown facets that edit the canonical query string.
+ *
+ * @param {string} raw
+ * @param {string} key
+ * @param {string|null} value
+ * @returns {string}
+ */
+export function setQueryFilter(raw, key, value) {
+  return setQueryFilters(raw, key, value == null || value === "" ? [] : [value]);
+}
+
+/**
+ * Return a new query string with `key` set to exactly `values` (replacing all
+ * existing values for that key). An empty array removes the key entirely. Bare
+ * text and other qualifiers are preserved in their original order.
+ *
+ * @param {string} raw
+ * @param {string} key
+ * @param {string[]} values
+ * @returns {string}
+ */
+export function setQueryFilters(raw, key, values) {
+  const tokens = (raw || "").match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [];
+  const kept = tokens.filter((t) => {
+    const sep = t.indexOf(":");
+    if (sep <= 0) return true;
+    return t.slice(0, sep).toLowerCase() !== key.toLowerCase();
+  });
+  for (const value of values) {
+    if (value == null || value === "") continue;
+    const needsQuote = /\s/.test(value);
+    kept.push(`${key}:${needsQuote ? `"${value}"` : value}`);
+  }
+  return kept.join(" ");
+}
+
+/**
+ * Add or remove a single value for `key`, preserving that key's other values.
+ * Used by multi-select dropdowns to toggle one checkbox.
+ *
+ * @param {string} raw
+ * @param {string} key
+ * @param {string} value
+ * @returns {string}
+ */
+export function toggleQueryFilter(raw, key, value) {
+  const v = value.toLowerCase();
+  const current = getQueryFilters(raw, key);
+  const next = current.includes(v)
+    ? current.filter((x) => x !== v)
+    : [...current, v];
+  return setQueryFilters(raw, key, next);
+}
+
+/**
+ * Read the (single) current value of a qualifier key from a raw query, or null
+ * if unset. Lets a single-select dropdown reflect the canonical query string.
+ * @param {string} raw
+ * @param {string} key
+ * @returns {string|null}
+ */
+export function getQueryFilter(raw, key) {
+  const values = getQueryFilters(raw, key);
+  return values.length > 0 ? values[0] : null;
+}
+
+/**
+ * Read all values of a qualifier key from a raw query (empty if unset). Lets a
+ * multi-select dropdown reflect the canonical query string.
+ * @param {string} raw
+ * @param {string} key
+ * @returns {string[]}
+ */
+export function getQueryFilters(raw, key) {
+  const { filters } = parseQuery(raw);
+  return filters[key.toLowerCase()] ?? [];
+}

--- a/web/src/lib/tableQuery.js
+++ b/web/src/lib/tableQuery.js
@@ -6,6 +6,12 @@
 // ["whisper"]}. Repeating a key ORs its values (`status:failed status:success`).
 // Quoting a value preserves spaces: `name:"my job"`.
 
+// Split a query into tokens on whitespace, keeping quoted spans (single- or
+// double-quoted) together so `name:"my job"` is one token.
+function tokenize(raw) {
+  return (raw || "").match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [];
+}
+
 /**
  * Parse a raw query string into bare text terms and keyed qualifiers.
  * @param {string} raw
@@ -16,9 +22,7 @@ export function parseQuery(raw) {
   const filters = {};
   if (!raw) return { text, filters };
 
-  // Tokenize on whitespace, but keep quoted spans (single- or double-quoted)
-  // together so `name:"my job"` is one token.
-  const tokens = raw.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [];
+  const tokens = tokenize(raw);
 
   for (const token of tokens) {
     const sep = token.indexOf(":");
@@ -62,15 +66,22 @@ function unquote(s) {
  * @param {object} config
  * @param {Record<string, (row: object) => string|null>} config.fields - maps a
  *   qualifier key to a function returning the row's comparable string. Values
- *   match as case-insensitive substrings.
+ *   match as case-insensitive substrings unless the key is in `exactFields`.
+ * @param {string[]} config.exactFields - keys whose values must match the row
+ *   value *exactly* (case-insensitive), not as a substring. Use for
+ *   enum/dropdown-driven filters where one value is a substring of another
+ *   (e.g. status `submitted` vs `resubmitted`), which substring matching would
+ *   otherwise conflate.
  * @returns {Array<object>}
  */
-export function applyQuery(rows, raw, { fields = {} } = {}) {
+export function applyQuery(rows, raw, { fields = {}, exactFields = [] } = {}) {
   const { filters } = parseQuery(raw);
 
   // Keep only qualifiers whose key is known; unknown/partial keys are ignored.
   const active = Object.entries(filters).filter(([key]) => fields[key]);
   if (active.length === 0) return rows;
+
+  const exact = new Set(exactFields.map((k) => k.toLowerCase()));
 
   return rows.filter((row) => {
     // Every active qualifier key must match (AND across keys); within a key,
@@ -78,7 +89,10 @@ export function applyQuery(rows, raw, { fields = {} } = {}) {
     for (const [key, values] of active) {
       const rowVal = fields[key](row);
       const rowStr = rowVal == null ? "" : String(rowVal).toLowerCase();
-      if (!values.some((v) => rowStr.includes(v))) return false;
+      const ok = exact.has(key)
+        ? values.some((v) => rowStr === v)
+        : values.some((v) => rowStr.includes(v));
+      if (!ok) return false;
     }
 
     return true;
@@ -111,7 +125,7 @@ export function setQueryFilter(raw, key, value) {
  * @returns {string}
  */
 export function setQueryFilters(raw, key, values) {
-  const tokens = (raw || "").match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [];
+  const tokens = tokenize(raw);
   const kept = tokens.filter((t) => {
     const sep = t.indexOf(":");
     if (sep <= 0) return true;

--- a/web/src/lib/tableQuery.test.js
+++ b/web/src/lib/tableQuery.test.js
@@ -1,0 +1,198 @@
+import { describe, test, expect } from "vitest";
+import {
+  parseQuery,
+  applyQuery,
+  setQueryFilter,
+  setQueryFilters,
+  toggleQueryFilter,
+  getQueryFilter,
+  getQueryFilters,
+} from "./tableQuery";
+
+describe("parseQuery", () => {
+  test("empty input yields empty text and filters", () => {
+    expect(parseQuery("")).toEqual({ text: [], filters: {} });
+    expect(parseQuery(null)).toEqual({ text: [], filters: {} });
+  });
+
+  test("splits bare terms and key:value qualifiers", () => {
+    expect(parseQuery("status:failed whisper report")).toEqual({
+      text: ["whisper", "report"],
+      filters: { status: ["failed"] },
+    });
+  });
+
+  test("lowercases keys, values, and bare terms", () => {
+    expect(parseQuery("Status:Failed Whisper")).toEqual({
+      text: ["whisper"],
+      filters: { status: ["failed"] },
+    });
+  });
+
+  test("repeating a key accumulates values (OR within a key)", () => {
+    expect(parseQuery("status:failed status:success")).toEqual({
+      text: [],
+      filters: { status: ["failed", "success"] },
+    });
+  });
+
+  test("quoted values preserve spaces", () => {
+    expect(parseQuery('name:"my job" foo')).toEqual({
+      text: ["foo"],
+      filters: { name: ["my job"] },
+    });
+  });
+
+  test("a leading colon is treated as free text, not a qualifier", () => {
+    expect(parseQuery(":oops")).toEqual({ text: [":oops"], filters: {} });
+  });
+
+  test("a trailing colon with no value is free text", () => {
+    expect(parseQuery("status:")).toEqual({ text: ["status:"], filters: {} });
+  });
+});
+
+describe("applyQuery", () => {
+  const rows = [
+    { input_file: "a/one.wav", output_file: "out/one.txt", status: "success" },
+    { input_file: "a/two.wav", output_file: null, status: "failed" },
+    { input_file: "b/three.mp3", output_file: "out/three.txt", status: "success" },
+  ];
+  const config = {
+    fields: {
+      status: (r) => r.status,
+      file: (r) => r.input_file,
+      out: (r) => r.output_file,
+    },
+  };
+
+  test("no query returns all rows unchanged", () => {
+    expect(applyQuery(rows, "", config)).toBe(rows);
+  });
+
+  test("bare text does not filter (qualifier-only)", () => {
+    // "three" has no key: — it's ignored, so all rows come back.
+    expect(applyQuery(rows, "three", config)).toBe(rows);
+  });
+
+  test("a partial key (no colon yet) is ignored, returning all rows", () => {
+    expect(applyQuery(rows, "stat", config)).toBe(rows);
+  });
+
+  test("a key with no value yet is ignored, returning all rows", () => {
+    // `status:` mid-typing must not filter or show an empty result.
+    expect(applyQuery(rows, "status:", config)).toBe(rows);
+  });
+
+  test("an unknown key is ignored (not a failed match), returning all rows", () => {
+    expect(applyQuery(rows, "bogus:x", config)).toBe(rows);
+  });
+
+  test("a complete known qualifier filters by its mapped field", () => {
+    expect(applyQuery(rows, "status:failed", config)).toEqual([rows[1]]);
+  });
+
+  test("qualifier values OR within a key", () => {
+    expect(applyQuery(rows, "status:failed status:success", config)).toEqual(
+      rows,
+    );
+  });
+
+  test("qualifiers across keys AND together", () => {
+    expect(applyQuery(rows, "status:success file:three", config)).toEqual([
+      rows[2],
+    ]);
+  });
+
+  test("known qualifiers apply even alongside ignored bare/partial tokens", () => {
+    expect(applyQuery(rows, "three status:failed stat", config)).toEqual([
+      rows[1],
+    ]);
+  });
+
+  test("a null mapped field never matches a qualifier value", () => {
+    // row[1] has output_file null; filtering on it should exclude it.
+    expect(applyQuery(rows, "out:one", config)).toEqual([rows[0]]);
+  });
+
+  test("qualifier values match as case-insensitive substrings", () => {
+    expect(applyQuery(rows, "file:THR", config)).toEqual([rows[2]]);
+    expect(applyQuery(rows, "status:fail", config)).toEqual([rows[1]]);
+  });
+});
+
+describe("setQueryFilter / getQueryFilter", () => {
+  test("sets a qualifier on an empty query", () => {
+    expect(setQueryFilter("", "status", "failed")).toBe("status:failed");
+  });
+
+  test("replaces an existing value for the same key", () => {
+    expect(setQueryFilter("status:success foo", "status", "failed")).toBe(
+      "foo status:failed",
+    );
+  });
+
+  test("clearing removes the qualifier but keeps the rest", () => {
+    expect(setQueryFilter("foo status:failed bar", "status", null)).toBe(
+      "foo bar",
+    );
+  });
+
+  test("quotes values containing spaces", () => {
+    expect(setQueryFilter("", "name", "my job")).toBe('name:"my job"');
+  });
+
+  test("getQueryFilter reads the current value or null", () => {
+    expect(getQueryFilter("a status:failed b", "status")).toBe("failed");
+    expect(getQueryFilter("a b", "status")).toBeNull();
+  });
+
+  test("round-trips through set then get", () => {
+    const q = setQueryFilter("keep me", "status", "success");
+    expect(getQueryFilter(q, "status")).toBe("success");
+  });
+});
+
+describe("multi-value filters", () => {
+  test("setQueryFilters writes several values for one key", () => {
+    expect(setQueryFilters("keep", "status", ["running", "stopped"])).toBe(
+      "keep status:running status:stopped",
+    );
+  });
+
+  test("setQueryFilters with an empty array removes the key", () => {
+    expect(setQueryFilters("a status:running b", "status", [])).toBe("a b");
+  });
+
+  test("getQueryFilters returns all values for a key", () => {
+    expect(getQueryFilters("status:running status:stopped x", "status")).toEqual(
+      ["running", "stopped"],
+    );
+    expect(getQueryFilters("x", "status")).toEqual([]);
+  });
+
+  test("toggleQueryFilter adds a value when absent", () => {
+    expect(toggleQueryFilter("status:running", "status", "stopped")).toBe(
+      "status:running status:stopped",
+    );
+  });
+
+  test("toggleQueryFilter removes a value when present, keeping the rest", () => {
+    expect(
+      toggleQueryFilter("status:running status:stopped", "status", "running"),
+    ).toBe("status:stopped");
+  });
+
+  test("multiple values for a key OR together in applyQuery", () => {
+    const cfg = { fields: { status: (r) => r.status } };
+    const data = [
+      { status: "running" },
+      { status: "stopped" },
+      { status: "pending" },
+    ];
+    expect(applyQuery(data, "status:running status:pending", cfg)).toEqual([
+      data[0],
+      data[2],
+    ]);
+  });
+});

--- a/web/src/lib/tableQuery.test.js
+++ b/web/src/lib/tableQuery.test.js
@@ -119,6 +119,32 @@ describe("applyQuery", () => {
     expect(applyQuery(rows, "file:THR", config)).toEqual([rows[2]]);
     expect(applyQuery(rows, "status:fail", config)).toEqual([rows[1]]);
   });
+
+  describe("exactFields", () => {
+    const jobs = [
+      { status: "submitted" },
+      { status: "resubmitted" },
+      { status: "running" },
+    ];
+    const cfg = { fields: { status: (r) => r.status }, exactFields: ["status"] };
+
+    test("matches the whole value, not a substring", () => {
+      // "resubmitted".includes("submitted") is true — exact matching must not
+      // let a Submitted filter also catch Resubmitted jobs.
+      expect(applyQuery(jobs, "status:submitted", cfg)).toEqual([jobs[0]]);
+    });
+
+    test("still ORs multiple exact values within a key", () => {
+      expect(applyQuery(jobs, "status:submitted status:running", cfg)).toEqual([
+        jobs[0],
+        jobs[2],
+      ]);
+    });
+
+    test("a partial value matches nothing under exact", () => {
+      expect(applyQuery(jobs, "status:sub", cfg)).toEqual([]);
+    });
+  });
 });
 
 describe("setQueryFilter / getQueryFilter", () => {

--- a/web/src/lib/useTableControls.js
+++ b/web/src/lib/useTableControls.js
@@ -1,0 +1,114 @@
+import { useMemo, useState } from "react";
+import { applyQuery, getQueryFilters } from "./tableQuery";
+
+// asc -> desc -> off, cycled by repeated clicks on the same header.
+const NEXT_DIR = { asc: "desc", desc: null, null: "asc" };
+
+/**
+ * Compare two non-null values. Numbers compare numerically; date-like strings
+ * by timestamp; else lexically. Null handling lives in the sort itself so that
+ * nulls stay last regardless of direction.
+ */
+function compare(a, b) {
+  if (typeof a === "number" && typeof b === "number") return a - b;
+
+  const da = Date.parse(a);
+  const db = Date.parse(b);
+  if (!Number.isNaN(da) && !Number.isNaN(db)) return da - db;
+
+  return String(a).localeCompare(String(b));
+}
+
+const isNil = (v) => v == null || v === "";
+
+/**
+ * Client-side table controls: a canonical query string (free text + key:value
+ * qualifiers) and clickable-header sort state, held in memory. Returns the
+ * derived rows plus the handlers a table's search bar and headers bind to.
+ *
+ * @param {Array<object>} rows
+ * @param {object} config
+ * @param {Record<string, (row: object) => string|null>} config.filterFields -
+ *   qualifier key -> accessor (see applyQuery)
+ * @param {Record<string, Record<string, (row: object) => boolean>>}
+ *   config.predicateFilters - dropdown-backed shortcut groups that express
+ *   intent awkward to type as raw qualifiers. Keyed by the query key the
+ *   dropdown writes (e.g. `filter`, `progress`), then by option value ->
+ *   predicate. One option per group applies at a time (single-select), ANDed
+ *   with every other group and with any typed field qualifiers.
+ * @param {Record<string, (row: object) => any>} config.sortFields - sort key ->
+ *   accessor returning the comparable value for that column
+ * @param {{ key: string, dir: "asc"|"desc" }} [config.defaultSort]
+ */
+export function useTableControls(
+  rows,
+  {
+    filterFields = {},
+    predicateFilters = {},
+    sortFields = {},
+    defaultSort = null,
+  } = {},
+) {
+  const [query, setQuery] = useState("");
+  const [sortKey, setSortKey] = useState(defaultSort?.key ?? null);
+  const [sortDir, setSortDir] = useState(defaultSort?.dir ?? null);
+
+  function toggleSort(key) {
+    if (key !== sortKey) {
+      setSortKey(key);
+      setSortDir("asc");
+      return;
+    }
+    const next = NEXT_DIR[String(sortDir)];
+    if (next == null) {
+      setSortKey(null);
+      setSortDir(null);
+    } else {
+      setSortDir(next);
+    }
+  }
+
+  const derived = useMemo(() => {
+    let filtered = applyQuery(rows, query, { fields: filterFields });
+
+    // Each predicate group is ANDed with the field qualifiers above and with
+    // every other group; within a group the selected options are ORed (a
+    // multi-select). Query values are lowercased by the parser, so match option
+    // keys case-insensitively.
+    for (const [groupKey, options] of Object.entries(predicateFilters)) {
+      const selected = getQueryFilters(query, groupKey);
+      if (selected.length === 0) continue;
+      const preds = Object.entries(options)
+        .filter(([k]) => selected.includes(k.toLowerCase()))
+        .map(([, pred]) => pred);
+      if (preds.length > 0) {
+        filtered = filtered.filter((row) => preds.some((p) => p(row)));
+      }
+    }
+
+    if (!sortKey || !sortDir || !sortFields[sortKey]) return filtered;
+
+    const accessor = sortFields[sortKey];
+    const factor = sortDir === "desc" ? -1 : 1;
+    // Stable sort: decorate with original index and break ties by it.
+    return filtered
+      .map((row, i) => [row, i])
+      .sort(([a, ai], [b, bi]) => {
+        const av = accessor(a);
+        const bv = accessor(b);
+        const aNil = isNil(av);
+        const bNil = isNil(bv);
+        // Nulls always sort last, independent of direction.
+        if (aNil || bNil) {
+          if (aNil && bNil) return ai - bi;
+          return aNil ? 1 : -1;
+        }
+        const c = compare(av, bv);
+        return c !== 0 ? c * factor : ai - bi;
+      })
+      .map(([row]) => row);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rows, query, sortKey, sortDir]);
+
+  return { query, setQuery, sortKey, sortDir, toggleSort, rows: derived };
+}

--- a/web/src/lib/useTableControls.js
+++ b/web/src/lib/useTableControls.js
@@ -1,9 +1,6 @@
 import { useMemo, useState } from "react";
 import { applyQuery, getQueryFilters } from "./tableQuery";
 
-// asc -> desc -> off, cycled by repeated clicks on the same header.
-const NEXT_DIR = { asc: "desc", desc: null, null: "asc" };
-
 /**
  * Compare two non-null values. Numbers compare numerically; date-like strings
  * by timestamp; else lexically. Null handling lives in the sort itself so that
@@ -30,6 +27,8 @@ const isNil = (v) => v == null || v === "";
  * @param {object} config
  * @param {Record<string, (row: object) => string|null>} config.filterFields -
  *   qualifier key -> accessor (see applyQuery)
+ * @param {string[]} config.exactFilterFields - filterFields keys matched by
+ *   exact value rather than substring (see applyQuery's exactFields)
  * @param {Record<string, Record<string, (row: object) => boolean>>}
  *   config.predicateFilters - dropdown-backed shortcut groups that express
  *   intent awkward to type as raw qualifiers. Keyed by the query key the
@@ -44,6 +43,7 @@ export function useTableControls(
   rows,
   {
     filterFields = {},
+    exactFilterFields = [],
     predicateFilters = {},
     sortFields = {},
     defaultSort = null,
@@ -59,17 +59,22 @@ export function useTableControls(
       setSortDir("asc");
       return;
     }
-    const next = NEXT_DIR[String(sortDir)];
-    if (next == null) {
-      setSortKey(null);
-      setSortDir(null);
+    // Same column: asc -> desc -> off. "Off" returns to the default sort rather
+    // than the rows' arbitrary source order, so the table never regresses to an
+    // unsorted state.
+    if (sortDir === "asc") {
+      setSortDir("desc");
     } else {
-      setSortDir(next);
+      setSortKey(defaultSort?.key ?? null);
+      setSortDir(defaultSort?.dir ?? null);
     }
   }
 
   const derived = useMemo(() => {
-    let filtered = applyQuery(rows, query, { fields: filterFields });
+    let filtered = applyQuery(rows, query, {
+      fields: filterFields,
+      exactFields: exactFilterFields,
+    });
 
     // Each predicate group is ANDed with the field qualifiers above and with
     // every other group; within a group the selected options are ORed (a

--- a/web/src/lib/useTableControls.test.jsx
+++ b/web/src/lib/useTableControls.test.jsx
@@ -35,6 +35,17 @@ describe("useTableControls", () => {
     expect(result.current.rows).toEqual(rows);
   });
 
+  test("exactFilterFields forwards to exact matching", () => {
+    const data = [{ name: "submitted" }, { name: "resubmitted" }];
+    const cfg = {
+      filterFields: { name: (r) => r.name },
+      exactFilterFields: ["name"],
+    };
+    const { result } = renderHook(() => useTableControls(data, cfg));
+    act(() => result.current.setQuery("name:submitted"));
+    expect(result.current.rows).toEqual([data[0]]);
+  });
+
   test("applies a predicate-filter option selected via <group>:<value>", () => {
     const cfg = {
       ...config,
@@ -122,8 +133,23 @@ describe("useTableControls", () => {
     ]);
 
     act(() => result.current.toggleSort("name"));
+    // No defaultSort here, so "off" clears to the rows' source order.
     expect(result.current.sortDir).toBeNull();
-    expect(result.current.rows).toEqual(rows); // back to original order
+    expect(result.current.rows).toEqual(rows);
+  });
+
+  test("cycling a sorted column off returns to the default sort", () => {
+    const cfg = { ...config, defaultSort: { key: "size", dir: "asc" } };
+    const { result } = renderHook(() => useTableControls(rows, cfg));
+
+    // Sort by name asc, then desc, then off -> should fall back to size asc,
+    // not the rows' arbitrary source order.
+    act(() => result.current.toggleSort("name")); // asc
+    act(() => result.current.toggleSort("name")); // desc
+    act(() => result.current.toggleSort("name")); // off -> default
+    expect(result.current.sortKey).toBe("size");
+    expect(result.current.sortDir).toBe("asc");
+    expect(result.current.rows.map((r) => r.size)).toEqual([2, 10, null]);
   });
 
   test("sorts numbers numerically with nulls last", () => {

--- a/web/src/lib/useTableControls.test.jsx
+++ b/web/src/lib/useTableControls.test.jsx
@@ -1,0 +1,162 @@
+import { describe, test, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTableControls } from "./useTableControls";
+
+const rows = [
+  { name: "beta", size: 2, when: "2026-01-02T00:00:00Z" },
+  { name: "alpha", size: 10, when: "2026-01-01T00:00:00Z" },
+  { name: "gamma", size: null, when: null },
+];
+
+const config = {
+  filterFields: { name: (r) => r.name },
+  sortFields: {
+    name: (r) => r.name,
+    size: (r) => r.size,
+    when: (r) => r.when,
+  },
+};
+
+describe("useTableControls", () => {
+  test("returns all rows unsorted with no query or sort", () => {
+    const { result } = renderHook(() => useTableControls(rows, config));
+    expect(result.current.rows).toEqual(rows);
+  });
+
+  test("filters by a qualifier in the query string", () => {
+    const { result } = renderHook(() => useTableControls(rows, config));
+    act(() => result.current.setQuery("name:alph"));
+    expect(result.current.rows.map((r) => r.name)).toEqual(["alpha"]);
+  });
+
+  test("bare text does not filter (qualifier-only)", () => {
+    const { result } = renderHook(() => useTableControls(rows, config));
+    act(() => result.current.setQuery("alph"));
+    expect(result.current.rows).toEqual(rows);
+  });
+
+  test("applies a predicate-filter option selected via <group>:<value>", () => {
+    const cfg = {
+      ...config,
+      predicateFilters: { size: { small: (r) => (r.size ?? Infinity) < 5 } },
+    };
+    const { result } = renderHook(() => useTableControls(rows, cfg));
+    act(() => result.current.setQuery("size:small"));
+    expect(result.current.rows.map((r) => r.name)).toEqual(["beta"]);
+  });
+
+  test("an unknown predicate-filter value applies nothing", () => {
+    const cfg = {
+      ...config,
+      predicateFilters: { size: { small: (r) => r.size < 5 } },
+    };
+    const { result } = renderHook(() => useTableControls(rows, cfg));
+    act(() => result.current.setQuery("size:bogus"));
+    expect(result.current.rows).toEqual(rows);
+  });
+
+  test("a predicate filter ANDs with a typed field qualifier", () => {
+    const cfg = {
+      ...config,
+      predicateFilters: { has: { when: (r) => r.when != null } },
+    };
+    const { result } = renderHook(() => useTableControls(rows, cfg));
+    // name:a matches alpha, beta, gamma; has:when drops gamma (null when).
+    act(() => result.current.setQuery("name:a has:when"));
+    expect(result.current.rows.map((r) => r.name).sort()).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  test("multiple options within a group OR together", () => {
+    const cfg = {
+      ...config,
+      predicateFilters: {
+        size: {
+          small: (r) => (r.size ?? Infinity) < 5,
+          big: (r) => (r.size ?? -Infinity) > 8,
+        },
+      },
+    };
+    const { result } = renderHook(() => useTableControls(rows, cfg));
+    // small -> beta(2); big -> alpha(10); gamma(null) matches neither.
+    act(() => result.current.setQuery("size:small size:big"));
+    expect(result.current.rows.map((r) => r.name).sort()).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  test("options from different groups AND together", () => {
+    const cfg = {
+      ...config,
+      predicateFilters: {
+        size: { small: (r) => (r.size ?? Infinity) < 5 },
+        has: { when: (r) => r.when != null },
+      },
+    };
+    const { result } = renderHook(() => useTableControls(rows, cfg));
+    // small -> beta, gamma(null->Infinity excluded); when -> beta, alpha.
+    act(() => result.current.setQuery("size:small has:when"));
+    expect(result.current.rows.map((r) => r.name)).toEqual(["beta"]);
+  });
+
+  test("toggles a column asc -> desc -> off", () => {
+    const { result } = renderHook(() => useTableControls(rows, config));
+
+    act(() => result.current.toggleSort("name"));
+    expect(result.current.sortDir).toBe("asc");
+    expect(result.current.rows.map((r) => r.name)).toEqual([
+      "alpha",
+      "beta",
+      "gamma",
+    ]);
+
+    act(() => result.current.toggleSort("name"));
+    expect(result.current.sortDir).toBe("desc");
+    expect(result.current.rows.map((r) => r.name)).toEqual([
+      "gamma",
+      "beta",
+      "alpha",
+    ]);
+
+    act(() => result.current.toggleSort("name"));
+    expect(result.current.sortDir).toBeNull();
+    expect(result.current.rows).toEqual(rows); // back to original order
+  });
+
+  test("sorts numbers numerically with nulls last", () => {
+    const { result } = renderHook(() => useTableControls(rows, config));
+    act(() => result.current.toggleSort("size")); // asc
+    expect(result.current.rows.map((r) => r.size)).toEqual([2, 10, null]);
+  });
+
+  test("nulls sort last even when descending", () => {
+    const { result } = renderHook(() => useTableControls(rows, config));
+    act(() => result.current.toggleSort("size"));
+    act(() => result.current.toggleSort("size")); // desc
+    expect(result.current.rows.map((r) => r.size)).toEqual([10, 2, null]);
+  });
+
+  test("sorts date-like strings chronologically", () => {
+    const { result } = renderHook(() => useTableControls(rows, config));
+    act(() => result.current.toggleSort("when")); // asc
+    expect(result.current.rows.map((r) => r.name)).toEqual([
+      "alpha",
+      "beta",
+      "gamma", // null when -> last
+    ]);
+  });
+
+  test("honors a default sort", () => {
+    const { result } = renderHook(() =>
+      useTableControls(rows, { ...config, defaultSort: { key: "name", dir: "desc" } }),
+    );
+    expect(result.current.rows.map((r) => r.name)).toEqual([
+      "gamma",
+      "beta",
+      "alpha",
+    ]);
+  });
+});

--- a/web/src/lib/util.js
+++ b/web/src/lib/util.js
@@ -282,6 +282,39 @@ export function formattedTimeInterval(refTime, currentTime) {
 };
 
 /**
+ * Milliseconds elapsed between two timestamps, or null if either is missing.
+ * @param {string|Date|null} startedAt
+ * @param {string|Date|null} finishedAt
+ * @return {number|null}
+ */
+export function elapsedMs(startedAt, finishedAt) {
+  if (!startedAt || !finishedAt) return null;
+  return new Date(finishedAt) - new Date(startedAt);
+}
+
+/**
+ * Format the interval between two timestamps as a short duration
+ * (e.g. "820ms", "3.4s", "2m 5s"). Returns "-" if either timestamp is missing.
+ * @param {string|Date|null} startedAt
+ * @param {string|Date|null} finishedAt
+ * @return {string}
+ */
+export function formatElapsed(startedAt, finishedAt) {
+  const diffMs = elapsedMs(startedAt, finishedAt);
+  if (diffMs == null) return "-";
+
+  if (diffMs < 1000) {
+    return `${diffMs}ms`;
+  } else if (diffMs < 60000) {
+    return `${(diffMs / 1000).toFixed(1)}s`;
+  } else {
+    const minutes = Math.floor(diffMs / 60000);
+    const seconds = ((diffMs % 60000) / 1000).toFixed(0);
+    return `${minutes}m ${seconds}s`;
+  }
+}
+
+/**
  * Whether a profile is a Slurm profile (local, localhost, or remote).
  * @param {object|null} profile
  * @return {boolean}

--- a/web/src/lib/util.test.js
+++ b/web/src/lib/util.test.js
@@ -15,6 +15,8 @@ import {
   selectTierByModelSize,
   isBatchJobActive,
   batchProgress,
+  elapsedMs,
+  formatElapsed,
 } from "@/lib/util";
 
 describe("Utils", () => {
@@ -471,6 +473,38 @@ describe("Utils", () => {
         failed: 0,
         total: 100,
       });
+    });
+  });
+
+  describe("elapsedMs", () => {
+    it("returns the millisecond difference", () => {
+      expect(
+        elapsedMs("2026-01-01T00:00:00Z", "2026-01-01T00:00:03Z"),
+      ).toBe(3000);
+    });
+
+    it("returns null when either timestamp is missing", () => {
+      expect(elapsedMs(null, "2026-01-01T00:00:03Z")).toBeNull();
+      expect(elapsedMs("2026-01-01T00:00:00Z", null)).toBeNull();
+      expect(elapsedMs(null, null)).toBeNull();
+    });
+  });
+
+  describe("formatElapsed", () => {
+    it("formats sub-second as ms", () => {
+      expect(formatElapsed("2026-01-01T00:00:00.000Z", "2026-01-01T00:00:00.820Z")).toBe("820ms");
+    });
+
+    it("formats seconds with one decimal", () => {
+      expect(formatElapsed("2026-01-01T00:00:00Z", "2026-01-01T00:00:03Z")).toBe("3.0s");
+    });
+
+    it("formats minutes and seconds", () => {
+      expect(formatElapsed("2026-01-01T00:00:00Z", "2026-01-01T00:02:05Z")).toBe("2m 5s");
+    });
+
+    it("returns '-' when a timestamp is missing", () => {
+      expect(formatElapsed(null, "2026-01-01T00:00:03Z")).toBe("-");
     });
   });
 

--- a/web/src/routes/jobs/components/JobResultsTable.jsx
+++ b/web/src/routes/jobs/components/JobResultsTable.jsx
@@ -28,6 +28,9 @@ const RESULT_FILTER_FIELDS = {
     out: (r) => r.output_file,
 };
 
+// status is dropdown-driven and enum-valued — match exactly, not by substring.
+const RESULT_EXACT_FILTER_FIELDS = ["status"];
+
 // Status is filtered via its header dropdown, not sorted — so it's absent here.
 const RESULT_SORT_FIELDS = {
     input_file: (r) => basename(r.input_file),
@@ -75,6 +78,7 @@ function JobResultsTable({
         rows: visibleResults,
     } = useTableControls(results, {
         filterFields: RESULT_FILTER_FIELDS,
+        exactFilterFields: RESULT_EXACT_FILTER_FIELDS,
         sortFields: RESULT_SORT_FIELDS,
         defaultSort: { key: "started_at", dir: "desc" },
     });

--- a/web/src/routes/jobs/components/JobResultsTable.jsx
+++ b/web/src/routes/jobs/components/JobResultsTable.jsx
@@ -5,9 +5,13 @@ import {
     CheckCircleIcon,
     XCircleIcon,
 } from "@heroicons/react/24/outline";
-import { lastModified } from "@/lib/util";
+import { lastModified, elapsedMs, formatElapsed } from "@/lib/util";
 import { assetPath } from "@/config";
 import Pagination from "@/components/Pagination";
+import SortableHeader from "@/components/SortableHeader";
+import FilterHeader from "@/components/FilterHeader";
+import TableSearch from "@/components/TableSearch";
+import { useTableControls } from "@/lib/useTableControls";
 import PropTypes from "prop-types";
 
 // The table shows file basenames (the full paths are in the result preview).
@@ -16,23 +20,26 @@ function basename(path) {
     return path.split("/").pop();
 }
 
-function formatElapsedTime(startedAt, finishedAt) {
-    if (!startedAt || !finishedAt) return "-";
+// Typed field qualifiers (substring match); see applyQuery. `status` is also
+// driven by the Status header dropdown.
+const RESULT_FILTER_FIELDS = {
+    status: (r) => (r.success ? "success" : "failed"),
+    file: (r) => r.input_file,
+    out: (r) => r.output_file,
+};
 
-    const start = new Date(startedAt);
-    const end = new Date(finishedAt);
-    const diffMs = end - start;
+// Status is filtered via its header dropdown, not sorted — so it's absent here.
+const RESULT_SORT_FIELDS = {
+    input_file: (r) => basename(r.input_file),
+    started_at: (r) => r.started_at,
+    elapsed: (r) => elapsedMs(r.started_at, r.finished_at),
+    output_file: (r) => basename(r.output_file),
+};
 
-    if (diffMs < 1000) {
-        return `${diffMs}ms`;
-    } else if (diffMs < 60000) {
-        return `${(diffMs / 1000).toFixed(1)}s`;
-    } else {
-        const minutes = Math.floor(diffMs / 60000);
-        const seconds = ((diffMs % 60000) / 1000).toFixed(0);
-        return `${minutes}m ${seconds}s`;
-    }
-}
+const RESULT_STATUS_OPTIONS = [
+    { value: "success", label: "Successful" },
+    { value: "failed", label: "Failed" },
+];
 
 function StatusIcon({ success }) {
     if (success) {
@@ -59,11 +66,33 @@ function JobResultsTable({
     const [currentPage, setCurrentPage] = useState(1);
     const resultsPerPage = 20;
 
-    const indexOfLastResult = currentPage * resultsPerPage;
+    const {
+        query,
+        setQuery,
+        sortKey,
+        sortDir,
+        toggleSort,
+        rows: visibleResults,
+    } = useTableControls(results, {
+        filterFields: RESULT_FILTER_FIELDS,
+        sortFields: RESULT_SORT_FIELDS,
+        defaultSort: { key: "started_at", dir: "desc" },
+    });
+
+    // Filtering can shrink the list under the current page; clamp to page 1
+    // whenever the query changes rather than stranding the user on an empty page.
+    const pageCount = Math.max(1, Math.ceil(visibleResults.length / resultsPerPage));
+    const page = Math.min(currentPage, pageCount);
+    const indexOfLastResult = page * resultsPerPage;
     const indexOfFirstResult = indexOfLastResult - resultsPerPage;
 
-    const currentResults = results.slice(indexOfFirstResult, indexOfLastResult);
+    const currentResults = visibleResults.slice(indexOfFirstResult, indexOfLastResult);
     const heightClass = "lg:h-[calc(100vh-11rem)]";
+
+    const handleQueryChange = (q) => {
+        setQuery(q);
+        setCurrentPage(1);
+    };
 
     return (
         <div id="job-results-table" name="job-results-table" className={`flex-none ${heightClass}`}>
@@ -79,9 +108,14 @@ function JobResultsTable({
                         {job.name}
                     </label>
                     <span className="text-sm text-gray-500 dark:text-gray-400">
-                        ({results.length} results)
+                        {visibleResults.length === results.length
+                            ? `(${results.length} results)`
+                            : `(${visibleResults.length} of ${results.length})`}
                     </span>
                 </div>
+            </div>
+            <div className="mb-4">
+                <TableSearch query={query} setQuery={handleQueryChange} />
             </div>
             <div className="flow-root">
                 <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
@@ -90,36 +124,48 @@ function JobResultsTable({
                             <table className="divide-y divide-gray-300 dark:divide-gray-600 table-fixed w-full">
                                 <thead>
                                     <tr>
-                                        <th
-                                            scope="col"
-                                            className="sticky top-0 z-10 py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 dark:text-gray-100 sm:pl-6 w-1/4 backdrop-blur bg-gray-50 dark:bg-gray-800"
-                                        >
-                                            Input File
-                                        </th>
-                                        <th
-                                            scope="col"
-                                            className="sticky top-0 z-10 px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100 w-36 backdrop-blur bg-gray-50 dark:bg-gray-800"
-                                        >
-                                            Started
-                                        </th>
-                                        <th
-                                            scope="col"
-                                            className="sticky top-0 z-10 px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100 w-24 backdrop-blur bg-gray-50 dark:bg-gray-800"
-                                        >
-                                            Elapsed
-                                        </th>
-                                        <th
-                                            scope="col"
-                                            className="sticky top-0 z-10 px-3 py-3.5 text-center text-sm font-semibold text-gray-900 dark:text-gray-100 w-16 backdrop-blur bg-gray-50 dark:bg-gray-800"
-                                        >
-                                            Status
-                                        </th>
-                                        <th
-                                            scope="col"
-                                            className="sticky top-0 z-10 px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100 w-1/4 backdrop-blur bg-gray-50 dark:bg-gray-800"
-                                        >
-                                            Output File
-                                        </th>
+                                        <SortableHeader
+                                            label="Input File"
+                                            sortKey="input_file"
+                                            activeKey={sortKey}
+                                            direction={sortDir}
+                                            onSort={toggleSort}
+                                            className="pl-4 pr-3 sm:pl-6 w-1/4"
+                                        />
+                                        <SortableHeader
+                                            label="Started"
+                                            sortKey="started_at"
+                                            activeKey={sortKey}
+                                            direction={sortDir}
+                                            onSort={toggleSort}
+                                            className="px-3 w-36"
+                                        />
+                                        <SortableHeader
+                                            label="Elapsed"
+                                            sortKey="elapsed"
+                                            activeKey={sortKey}
+                                            direction={sortDir}
+                                            onSort={toggleSort}
+                                            className="px-3 w-24"
+                                        />
+                                        {/* Status is filtered via its dropdown, not sorted. */}
+                                        <FilterHeader
+                                            label="Status"
+                                            filterKey="status"
+                                            options={RESULT_STATUS_OPTIONS}
+                                            clearLabel="Clear statuses"
+                                            query={query}
+                                            setQuery={handleQueryChange}
+                                            className="px-3 text-center w-20"
+                                        />
+                                        <SortableHeader
+                                            label="Output File"
+                                            sortKey="output_file"
+                                            activeKey={sortKey}
+                                            direction={sortDir}
+                                            onSort={toggleSort}
+                                            className="px-3 w-1/4"
+                                        />
                                         <th
                                             scope="col"
                                             className="sticky top-0 z-10 px-3 py-3.5 text-right text-sm font-semibold text-gray-900 dark:text-gray-100 w-12 backdrop-blur bg-gray-50 dark:bg-gray-800"
@@ -161,11 +207,13 @@ function JobResultsTable({
                                                 </div>
                                             </td>
                                         </tr>
-                                    ) : results.length === 0 ? (
+                                    ) : visibleResults.length === 0 ? (
                                         <tr>
                                             <td colSpan={6} className="h-64">
                                                 <div className="font-light sm:text-sm text-center align-middle text-gray-600 dark:text-gray-400">
-                                                    No results found
+                                                    {results.length === 0
+                                                        ? "No results found"
+                                                        : "No results match your search"}
                                                 </div>
                                             </td>
                                         </tr>
@@ -187,7 +235,7 @@ function JobResultsTable({
                                                     {result.started_at ? lastModified(result.started_at) : "-"}
                                                 </td>
                                                 <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-500 dark:text-gray-400">
-                                                    {result.started_at && result.finished_at ? formatElapsedTime(result.started_at, result.finished_at) : "-"}
+                                                    {formatElapsed(result.started_at, result.finished_at)}
                                                 </td>
                                                 <td className="whitespace-nowrap py-3 px-3">
                                                     <div className="flex justify-center">
@@ -220,8 +268,8 @@ function JobResultsTable({
             </div>
             <Pagination
                 filesPerPage={resultsPerPage}
-                totalFiles={results.length}
-                currentPage={currentPage}
+                totalFiles={visibleResults.length}
+                currentPage={page}
                 setCurrentPage={setCurrentPage}
                 disabled={false}
             />

--- a/web/src/routes/jobs/components/JobResultsTable.jsx
+++ b/web/src/routes/jobs/components/JobResultsTable.jsx
@@ -12,6 +12,7 @@ import SortableHeader from "@/components/SortableHeader";
 import FilterHeader from "@/components/FilterHeader";
 import TableSearch from "@/components/TableSearch";
 import { useTableControls } from "@/lib/useTableControls";
+import { COLUMN_HEIGHT } from "./layout";
 import PropTypes from "prop-types";
 
 // The table shows file basenames (the full paths are in the result preview).
@@ -91,7 +92,6 @@ function JobResultsTable({
     const indexOfFirstResult = indexOfLastResult - resultsPerPage;
 
     const currentResults = visibleResults.slice(indexOfFirstResult, indexOfLastResult);
-    const heightClass = "lg:h-[calc(100vh-11rem)]";
 
     const handleQueryChange = (q) => {
         setQuery(q);
@@ -99,8 +99,12 @@ function JobResultsTable({
     };
 
     return (
-        <div id="job-results-table" name="job-results-table" className={`flex-none ${heightClass}`}>
-            <div className="flex items-center justify-between mb-2 h-9">
+        <div
+            id="job-results-table"
+            name="job-results-table"
+            className={`flex-none lg:flex lg:flex-col ${COLUMN_HEIGHT}`}
+        >
+            <div className="flex-none flex items-center justify-between mb-2 h-9">
                 <div className="flex items-center gap-2">
                     <button
                         onClick={onBack}
@@ -118,165 +122,159 @@ function JobResultsTable({
                     </span>
                 </div>
             </div>
-            <div className="mb-4">
+            <div className="flex-none mb-4">
                 <TableSearch query={query} setQuery={handleQueryChange} />
             </div>
-            <div className="flow-root">
-                <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-                    <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-                        <div className={`ring-1 ring-gray-300 dark:ring-gray-600 sm:rounded-lg ${heightClass} overflow-y-auto`}>
-                            <table className="divide-y divide-gray-300 dark:divide-gray-600 table-fixed w-full">
-                                <thead>
-                                    <tr>
-                                        <SortableHeader
-                                            label="Input File"
-                                            sortKey="input_file"
-                                            activeKey={sortKey}
-                                            direction={sortDir}
-                                            onSort={toggleSort}
-                                            className="pl-4 pr-3 sm:pl-6 w-1/4"
+            {/* Pagination lives inside the bordered box so the box's bottom edge
+                is the column's bottom edge, aligned with the preview panel. */}
+            <div className="flex flex-col lg:flex-1 lg:min-h-0 ring-1 ring-gray-300 dark:ring-gray-600 sm:rounded-lg overflow-hidden">
+                <div className="lg:flex-1 lg:min-h-0 overflow-auto">
+                <table className="divide-y divide-gray-300 dark:divide-gray-600 table-fixed w-full">
+                    <thead>
+                        <tr>
+                            <SortableHeader
+                                label="Input File"
+                                sortKey="input_file"
+                                activeKey={sortKey}
+                                direction={sortDir}
+                                onSort={toggleSort}
+                                className="pl-4 pr-3 sm:pl-6 w-1/4"
+                            />
+                            <SortableHeader
+                                label="Started"
+                                sortKey="started_at"
+                                activeKey={sortKey}
+                                direction={sortDir}
+                                onSort={toggleSort}
+                                className="px-3 w-36"
+                            />
+                            <SortableHeader
+                                label="Elapsed"
+                                sortKey="elapsed"
+                                activeKey={sortKey}
+                                direction={sortDir}
+                                onSort={toggleSort}
+                                className="px-3 w-24"
+                            />
+                            {/* Status is filtered via its dropdown, not sorted. */}
+                            <FilterHeader
+                                label="Status"
+                                filterKey="status"
+                                options={RESULT_STATUS_OPTIONS}
+                                clearLabel="Clear statuses"
+                                query={query}
+                                setQuery={handleQueryChange}
+                                className="px-3 text-center w-20"
+                            />
+                            <SortableHeader
+                                label="Output File"
+                                sortKey="output_file"
+                                activeKey={sortKey}
+                                direction={sortDir}
+                                onSort={toggleSort}
+                                className="px-3 w-1/4"
+                            />
+                            <th
+                                scope="col"
+                                className="sticky top-0 z-10 px-3 py-3.5 text-right text-sm font-semibold text-gray-900 dark:text-gray-100 w-12 backdrop-blur bg-gray-50 dark:bg-gray-800"
+                            >
+                                <div className="flex gap-2 justify-end">
+                                    <button
+                                        onClick={() => onRefresh?.()}
+                                        title="Refresh"
+                                    >
+                                        <ArrowPathIcon
+                                            className={`h-5 w-5 text-gray-900 dark:text-gray-100 hover:text-gray-400 ${isLoading || isRefreshing ? "animate-spin" : ""}`}
                                         />
-                                        <SortableHeader
-                                            label="Started"
-                                            sortKey="started_at"
-                                            activeKey={sortKey}
-                                            direction={sortDir}
-                                            onSort={toggleSort}
-                                            className="px-3 w-36"
-                                        />
-                                        <SortableHeader
-                                            label="Elapsed"
-                                            sortKey="elapsed"
-                                            activeKey={sortKey}
-                                            direction={sortDir}
-                                            onSort={toggleSort}
-                                            className="px-3 w-24"
-                                        />
-                                        {/* Status is filtered via its dropdown, not sorted. */}
-                                        <FilterHeader
-                                            label="Status"
-                                            filterKey="status"
-                                            options={RESULT_STATUS_OPTIONS}
-                                            clearLabel="Clear statuses"
-                                            query={query}
-                                            setQuery={handleQueryChange}
-                                            className="px-3 text-center w-20"
-                                        />
-                                        <SortableHeader
-                                            label="Output File"
-                                            sortKey="output_file"
-                                            activeKey={sortKey}
-                                            direction={sortDir}
-                                            onSort={toggleSort}
-                                            className="px-3 w-1/4"
-                                        />
-                                        <th
-                                            scope="col"
-                                            className="sticky top-0 z-10 px-3 py-3.5 text-right text-sm font-semibold text-gray-900 dark:text-gray-100 w-12 backdrop-blur bg-gray-50 dark:bg-gray-800"
-                                        >
-                                            <div className="flex gap-2 justify-end">
-                                                <button
-                                                    onClick={() => onRefresh?.()}
-                                                    title="Refresh"
-                                                >
-                                                    <ArrowPathIcon
-                                                        className={`h-5 w-5 text-gray-900 dark:text-gray-100 hover:text-gray-400 ${isLoading || isRefreshing ? "animate-spin" : ""}`}
-                                                    />
-                                                </button>
-                                            </div>
-                                        </th>
+                                    </button>
+                                </div>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-800">
+                        {isLoading ? (
+                            <>
+                                {Array.from({ length: 5 }).map((_, i) => (
+                                    <tr key={i}>
+                                        <td colSpan={6} className="relative whitespace-nowrap py-3 px-5 animate-pulse">
+                                            <div className="bg-gray-100 dark:bg-gray-700 h-9 rounded-md"></div>
+                                        </td>
                                     </tr>
-                                </thead>
-                                <tbody className="divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-800">
-                                    {isLoading ? (
-                                        <>
-                                            {Array.from({ length: 5 }).map((_, i) => (
-                                                <tr key={i}>
-                                                    <td colSpan={6} className="relative whitespace-nowrap py-3 px-5 animate-pulse">
-                                                        <div className="bg-gray-100 dark:bg-gray-700 h-9 rounded-md"></div>
-                                                    </td>
-                                                </tr>
-                                            ))}
-                                        </>
-                                    ) : error ? (
-                                        <tr>
-                                            <td colSpan={6} className="h-64">
-                                                <div className="font-light sm:text-sm text-center align-middle text-gray-600 dark:text-gray-400">
-                                                    <img
-                                                        className="h-16 mb-5 w-auto ml-auto mr-auto opacity-80 dark:invert"
-                                                        src={assetPath("/img/dead-fish.png")}
-                                                        alt="Loading error."
-                                                    />
-                                                    {error?.message || "Failed to load results."}
-                                                </div>
-                                            </td>
-                                        </tr>
-                                    ) : visibleResults.length === 0 ? (
-                                        <tr>
-                                            <td colSpan={6} className="h-64">
-                                                <div className="font-light sm:text-sm text-center align-middle text-gray-600 dark:text-gray-400">
-                                                    {results.length === 0
-                                                        ? "No results found"
-                                                        : "No results match your search"}
-                                                </div>
-                                            </td>
-                                        </tr>
-                                    ) : (
-                                        currentResults.map((result) => (
-                                            <tr
-                                                key={result.id}
-                                                onClick={() => onResultSelect(result)}
-                                                className={`cursor-pointer ${
-                                                    selectedResult?.id === result.id
-                                                        ? "bg-blue-50 dark:bg-blue-900/20"
-                                                        : "bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
-                                                }`}
-                                            >
-                                                <td className="whitespace-nowrap py-3 pl-4 pr-3 text-left text-xs font-mono text-gray-900 dark:text-gray-100 sm:pl-6">
-                                                    <div className="overflow-x-scroll">{basename(result.input_file)}</div>
-                                                </td>
-                                                <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-900 dark:text-gray-100">
-                                                    {result.started_at ? lastModified(result.started_at) : "-"}
-                                                </td>
-                                                <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-500 dark:text-gray-400">
-                                                    {formatElapsed(result.started_at, result.finished_at)}
-                                                </td>
-                                                <td className="whitespace-nowrap py-3 px-3">
-                                                    <div className="flex justify-center">
-                                                        <StatusIcon success={result.success} />
-                                                    </div>
-                                                </td>
-                                                <td className="whitespace-nowrap py-3 px-3 text-left text-xs font-mono text-gray-900 dark:text-gray-100">
-                                                    <div className="overflow-x-scroll">
-                                                        {basename(result.output_file)}
-                                                    </div>
-                                                </td>
-                                                <td className="whitespace-nowrap py-3 px-3 text-right">
-                                                </td>
-                                            </tr>
-                                        ))
-                                    )}
-                                    <tr className="bg-white dark:bg-gray-800">
-                                        <td className="whitespace-nowrap h-16"></td>
-                                        <td className="whitespace-nowrap h-16"></td>
-                                        <td className="whitespace-nowrap h-16"></td>
-                                        <td className="whitespace-nowrap h-16"></td>
-                                        <td className="whitespace-nowrap h-16"></td>
-                                        <td className="whitespace-nowrap h-16"></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
+                                ))}
+                            </>
+                        ) : error ? (
+                            <tr>
+                                <td colSpan={6} className="h-64">
+                                    <div className="font-light sm:text-sm text-center align-middle text-gray-600 dark:text-gray-400">
+                                        <img
+                                            className="h-16 mb-5 w-auto ml-auto mr-auto opacity-80 dark:invert"
+                                            src={assetPath("/img/dead-fish.png")}
+                                            alt="Loading error."
+                                        />
+                                        {error?.message || "Failed to load results."}
+                                    </div>
+                                </td>
+                            </tr>
+                        ) : visibleResults.length === 0 ? (
+                            <tr>
+                                <td colSpan={6} className="h-64">
+                                    <div className="font-light sm:text-sm text-center align-middle text-gray-600 dark:text-gray-400">
+                                        {results.length === 0
+                                            ? "No results found"
+                                            : "No results match your search"}
+                                    </div>
+                                </td>
+                            </tr>
+                        ) : (
+                            currentResults.map((result) => (
+                                <tr
+                                    key={result.id}
+                                    onClick={() => onResultSelect(result)}
+                                    className={`cursor-pointer ${
+                                        selectedResult?.id === result.id
+                                            ? "bg-blue-50 dark:bg-blue-900/20"
+                                            : "bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
+                                    }`}
+                                >
+                                    <td className="whitespace-nowrap py-3 pl-4 pr-3 text-left text-xs font-mono text-gray-900 dark:text-gray-100 sm:pl-6">
+                                        <div className="overflow-x-scroll">{basename(result.input_file)}</div>
+                                    </td>
+                                    <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-900 dark:text-gray-100">
+                                        {result.started_at ? lastModified(result.started_at) : "-"}
+                                    </td>
+                                    <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-500 dark:text-gray-400">
+                                        {formatElapsed(result.started_at, result.finished_at)}
+                                    </td>
+                                    <td className="whitespace-nowrap py-3 px-3">
+                                        <div className="flex justify-center">
+                                            <StatusIcon success={result.success} />
+                                        </div>
+                                    </td>
+                                    <td className="whitespace-nowrap py-3 px-3 text-left text-xs font-mono text-gray-900 dark:text-gray-100">
+                                        <div className="overflow-x-scroll">
+                                            {basename(result.output_file)}
+                                        </div>
+                                    </td>
+                                    <td className="whitespace-nowrap py-3 px-3 text-right">
+                                    </td>
+                                </tr>
+                            ))
+                        )}
+                    </tbody>
+                </table>
                 </div>
+                {pageCount > 1 && (
+                    <div className="flex-none border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+                        <Pagination
+                            filesPerPage={resultsPerPage}
+                            totalFiles={visibleResults.length}
+                            currentPage={page}
+                            setCurrentPage={setCurrentPage}
+                            disabled={false}
+                        />
+                    </div>
+                )}
             </div>
-            <Pagination
-                filesPerPage={resultsPerPage}
-                totalFiles={visibleResults.length}
-                currentPage={page}
-                setCurrentPage={setCurrentPage}
-                disabled={false}
-            />
         </div>
     );
 }

--- a/web/src/routes/jobs/components/JobResultsTable.jsx
+++ b/web/src/routes/jobs/components/JobResultsTable.jsx
@@ -68,7 +68,10 @@ function JobResultsTable({
     onRefresh = null,
 }) {
     const [currentPage, setCurrentPage] = useState(1);
-    const resultsPerPage = 20;
+    // Enough rows to overflow a full-height box on any realistic viewport: a
+    // page that fits without scrolling reads as "that's everything", which the
+    // pager below then contradicts.
+    const resultsPerPage = 50;
 
     const {
         query,

--- a/web/src/routes/jobs/components/JobsContainer.jsx
+++ b/web/src/routes/jobs/components/JobsContainer.jsx
@@ -7,6 +7,7 @@ import JobResultsTable from "./JobResultsTable";
 import JobDetailsPanel from "./JobDetailsPanel";
 import ResultPreview from "./ResultPreview";
 import NewJobModal from "./NewJobModal";
+import { COLUMN_HEIGHT } from "./layout";
 
 // Mock data for development - matches API BatchJob structure
 const MOCK_JOBS = [
@@ -374,13 +375,13 @@ function JobsContainer() {
                     />
                 )}
             </div>
-            <div className="w-full lg:flex-1 lg:min-w-[24rem] mb-2">
-                <div className="flex items-center justify-between mb-2 h-9">
+            <div className={`w-full lg:flex-1 lg:min-w-[24rem] lg:flex lg:flex-col ${COLUMN_HEIGHT}`}>
+                <div className="flex-none flex items-center justify-between mb-2 h-9">
                     <label className="font-medium text-sm leading-6 text-gray-900 dark:text-gray-100">
                         {showResultPreview ? "Result Preview" : "Job Details"}
                     </label>
                 </div>
-                <div className="ring-1 ring-gray-300 dark:ring-gray-600 rounded-lg lg:h-[calc(100vh-11rem)] overflow-y-auto">
+                <div className="lg:flex-1 lg:min-h-0 ring-1 ring-gray-300 dark:ring-gray-600 rounded-lg overflow-y-auto">
                     {showResultPreview ? (
                         <ResultPreview
                             result={selectedResult}

--- a/web/src/routes/jobs/components/JobsTable.jsx
+++ b/web/src/routes/jobs/components/JobsTable.jsx
@@ -136,7 +136,9 @@ ProgressDisplay.propTypes = {
 function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = false, isRefreshing = false, onRefresh, onNewClick, profile, useMockData, setUseMockData }) {
     const isSlurm = profile?.schema === "slurm";
     const [currentPage, setCurrentPage] = useState(1);
-    const jobsPerPage = 20;
+    // See JobResultsTable: a page short enough to fit without scrolling makes
+    // the pager look wrong.
+    const jobsPerPage = 50;
 
     const {
         query,

--- a/web/src/routes/jobs/components/JobsTable.jsx
+++ b/web/src/routes/jobs/components/JobsTable.jsx
@@ -12,6 +12,7 @@ import FilterHeader from "@/components/FilterHeader";
 import FilterMenu from "@/components/FilterMenu";
 import TableSearch from "@/components/TableSearch";
 import { useTableControls } from "@/lib/useTableControls";
+import { COLUMN_HEIGHT } from "./layout";
 import { TASKS } from "./NewJobModal";
 import StatusBadge from "./StatusBadge";
 import PropTypes from "prop-types";
@@ -159,7 +160,6 @@ function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = fa
     const indexOfFirstJob = indexOfLastJob - jobsPerPage;
 
     const currentJobs = visibleJobs.slice(indexOfFirstJob, indexOfLastJob);
-    const heightClass = "lg:h-[calc(100vh-11rem)]";
 
     const handleQueryChange = (q) => {
         setQuery(q);
@@ -167,8 +167,12 @@ function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = fa
     };
 
     return (
-        <div id="jobs-table" name="jobs-table" className={`flex-none ${heightClass}`}>
-            <div className="flex items-center justify-between mb-2 h-9">
+        <div
+            id="jobs-table"
+            name="jobs-table"
+            className={`flex-none lg:flex lg:flex-col ${COLUMN_HEIGHT}`}
+        >
+            <div className="flex-none flex items-center justify-between mb-2 h-9">
                 <label className="font-medium text-sm leading-6 text-gray-900 dark:text-gray-100">
                     Jobs
                 </label>
@@ -213,7 +217,7 @@ function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = fa
                     )}
                 </div>
             </div>
-            <div className="mb-4">
+            <div className="flex-none mb-4">
                 <TableSearch query={query} setQuery={handleQueryChange}>
                     <FilterMenu
                         label="Filters"
@@ -223,162 +227,156 @@ function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = fa
                     />
                 </TableSearch>
             </div>
-            <div className="flow-root">
-                <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-                    <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-                        <div className={`ring-1 ring-gray-300 dark:ring-gray-600 sm:rounded-lg ${heightClass} overflow-y-auto relative z-0`}>
-                            <table className="divide-y divide-gray-300 dark:divide-gray-600 table-fixed w-full">
-                                <thead>
-                                    <tr>
-                                        <SortableHeader
-                                            label="Name"
-                                            sortKey="name"
-                                            activeKey={sortKey}
-                                            direction={sortDir}
-                                            onSort={toggleSort}
-                                            className="pl-4 pr-3 sm:pl-6 w-1/4"
+            {/* Pagination lives inside the bordered box so the box's bottom edge
+                is the column's bottom edge, aligned with the details panel. */}
+            <div className="flex flex-col lg:flex-1 lg:min-h-0 ring-1 ring-gray-300 dark:ring-gray-600 sm:rounded-lg overflow-hidden">
+                <div className="lg:flex-1 lg:min-h-0 overflow-auto relative z-0">
+                <table className="divide-y divide-gray-300 dark:divide-gray-600 table-fixed w-full">
+                    <thead>
+                        <tr>
+                            <SortableHeader
+                                label="Name"
+                                sortKey="name"
+                                activeKey={sortKey}
+                                direction={sortDir}
+                                onSort={toggleSort}
+                                className="pl-4 pr-3 sm:pl-6 w-1/4"
+                            />
+                            <SortableHeader
+                                label="ID"
+                                sortKey="id"
+                                activeKey={sortKey}
+                                direction={sortDir}
+                                onSort={toggleSort}
+                                className="px-3 w-24"
+                            />
+                            <SortableHeader
+                                label="Submitted"
+                                sortKey="created_at"
+                                activeKey={sortKey}
+                                direction={sortDir}
+                                onSort={toggleSort}
+                                className="px-3 w-36"
+                            />
+                            {/* Status & Progress headers are filter
+                                dropdowns, not sortable columns. */}
+                            <FilterHeader
+                                label="Status"
+                                filterKey="status"
+                                options={STATUS_OPTIONS}
+                                clearLabel="Clear statuses"
+                                query={query}
+                                setQuery={handleQueryChange}
+                                className="px-3 text-left w-24"
+                            />
+                            <FilterHeader
+                                label="Progress"
+                                filterKey="progress"
+                                options={PROGRESS_OPTIONS}
+                                clearLabel="Clear"
+                                query={query}
+                                setQuery={handleQueryChange}
+                                className="px-3 text-left w-32"
+                            />
+                            <th
+                                scope="col"
+                                className="sticky top-0 z-10 px-3 py-3.5 text-right text-sm font-semibold text-gray-900 dark:text-gray-100 w-20 backdrop-blur bg-gray-50 dark:bg-gray-800"
+                            >
+                                <div className="flex gap-2 justify-end">
+                                    <button
+                                        onClick={onRefresh}
+                                        disabled={isRefreshing}
+                                        title="Refresh"
+                                        className="text-gray-900 dark:text-gray-100 hover:text-gray-400 disabled:opacity-50"
+                                    >
+                                        <ArrowPathIcon
+                                            className={`h-5 w-5 ${isRefreshing ? "animate-spin" : ""}`}
                                         />
-                                        <SortableHeader
-                                            label="ID"
-                                            sortKey="id"
-                                            activeKey={sortKey}
-                                            direction={sortDir}
-                                            onSort={toggleSort}
-                                            className="px-3 w-24"
+                                    </button>
+                                </div>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-800">
+                        {isLoading ? (
+                            <>
+                                {Array.from({ length: 5 }).map((_, i) => (
+                                    <tr key={i}>
+                                        <td colSpan={6} className="relative whitespace-nowrap py-3 px-5 animate-pulse">
+                                            <div className="bg-gray-100 dark:bg-gray-700 h-9 rounded-md"></div>
+                                        </td>
+                                    </tr>
+                                ))}
+                            </>
+                        ) : visibleJobs.length === 0 ? (
+                            <tr>
+                                <td colSpan={6} className="h-64">
+                                    <div className="font-light sm:text-sm text-center align-middle text-gray-600 dark:text-gray-400">
+                                        {jobs.length === 0
+                                            ? "No jobs found"
+                                            : "No jobs match your search"}
+                                    </div>
+                                </td>
+                            </tr>
+                        ) : (
+                            currentJobs.map((job) => (
+                                <tr
+                                    key={job.id}
+                                    onClick={() => onJobClick(job)}
+                                    className={`cursor-pointer ${
+                                        selectedJob?.id === job.id
+                                            ? "bg-blue-50 dark:bg-blue-900/20"
+                                            : "bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
+                                    }`}
+                                >
+                                    <td className="whitespace-nowrap py-3 pl-4 pr-3 text-left text-sm text-gray-900 dark:text-gray-100 sm:pl-6">
+                                        <div className="overflow-x-scroll">{job.name}</div>
+                                    </td>
+                                    <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-500 dark:text-gray-400 font-mono text-xs" title={job.id}>
+                                        {job.id?.slice(0, 8)}
+                                    </td>
+                                    <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-900 dark:text-gray-100">
+                                        {lastModified(job.created_at)}
+                                    </td>
+                                    <td className="whitespace-nowrap py-3 px-3 text-left text-sm">
+                                        <StatusBadge status={job.status} errored={job.errored} />
+                                    </td>
+                                    <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-900 dark:text-gray-100">
+                                        <ProgressDisplay
+                                            finished={job.finished}
+                                            staged={job.staged}
+                                            errored={job.errored}
                                         />
-                                        <SortableHeader
-                                            label="Submitted"
-                                            sortKey="created_at"
-                                            activeKey={sortKey}
-                                            direction={sortDir}
-                                            onSort={toggleSort}
-                                            className="px-3 w-36"
-                                        />
-                                        {/* Status & Progress headers are filter
-                                            dropdowns, not sortable columns. */}
-                                        <FilterHeader
-                                            label="Status"
-                                            filterKey="status"
-                                            options={STATUS_OPTIONS}
-                                            clearLabel="Clear statuses"
-                                            query={query}
-                                            setQuery={handleQueryChange}
-                                            className="px-3 text-left w-24"
-                                        />
-                                        <FilterHeader
-                                            label="Progress"
-                                            filterKey="progress"
-                                            options={PROGRESS_OPTIONS}
-                                            clearLabel="Clear"
-                                            query={query}
-                                            setQuery={handleQueryChange}
-                                            className="px-3 text-left w-32"
-                                        />
-                                        <th
-                                            scope="col"
-                                            className="sticky top-0 z-10 px-3 py-3.5 text-right text-sm font-semibold text-gray-900 dark:text-gray-100 w-20 backdrop-blur bg-gray-50 dark:bg-gray-800"
+                                    </td>
+                                    <td className="whitespace-nowrap py-3 px-3 text-right">
+                                        <button
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                onJobDrillIn(job);
+                                            }}
+                                            className="text-gray-900 dark:text-gray-100 hover:text-gray-400"
                                         >
-                                            <div className="flex gap-2 justify-end">
-                                                <button
-                                                    onClick={onRefresh}
-                                                    disabled={isRefreshing}
-                                                    title="Refresh"
-                                                    className="text-gray-900 dark:text-gray-100 hover:text-gray-400 disabled:opacity-50"
-                                                >
-                                                    <ArrowPathIcon
-                                                        className={`h-5 w-5 ${isRefreshing ? "animate-spin" : ""}`}
-                                                    />
-                                                </button>
-                                            </div>
-                                        </th>
-                                    </tr>
-                                </thead>
-                                <tbody className="divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-800">
-                                    {isLoading ? (
-                                        <>
-                                            {Array.from({ length: 5 }).map((_, i) => (
-                                                <tr key={i}>
-                                                    <td colSpan={6} className="relative whitespace-nowrap py-3 px-5 animate-pulse">
-                                                        <div className="bg-gray-100 dark:bg-gray-700 h-9 rounded-md"></div>
-                                                    </td>
-                                                </tr>
-                                            ))}
-                                        </>
-                                    ) : visibleJobs.length === 0 ? (
-                                        <tr>
-                                            <td colSpan={6} className="h-64">
-                                                <div className="font-light sm:text-sm text-center align-middle text-gray-600 dark:text-gray-400">
-                                                    {jobs.length === 0
-                                                        ? "No jobs found"
-                                                        : "No jobs match your search"}
-                                                </div>
-                                            </td>
-                                        </tr>
-                                    ) : (
-                                        currentJobs.map((job) => (
-                                            <tr
-                                                key={job.id}
-                                                onClick={() => onJobClick(job)}
-                                                className={`cursor-pointer ${
-                                                    selectedJob?.id === job.id
-                                                        ? "bg-blue-50 dark:bg-blue-900/20"
-                                                        : "bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
-                                                }`}
-                                            >
-                                                <td className="whitespace-nowrap py-3 pl-4 pr-3 text-left text-sm text-gray-900 dark:text-gray-100 sm:pl-6">
-                                                    <div className="overflow-x-scroll">{job.name}</div>
-                                                </td>
-                                                <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-500 dark:text-gray-400 font-mono text-xs" title={job.id}>
-                                                    {job.id?.slice(0, 8)}
-                                                </td>
-                                                <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-900 dark:text-gray-100">
-                                                    {lastModified(job.created_at)}
-                                                </td>
-                                                <td className="whitespace-nowrap py-3 px-3 text-left text-sm">
-                                                    <StatusBadge status={job.status} errored={job.errored} />
-                                                </td>
-                                                <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-900 dark:text-gray-100">
-                                                    <ProgressDisplay
-                                                        finished={job.finished}
-                                                        staged={job.staged}
-                                                        errored={job.errored}
-                                                    />
-                                                </td>
-                                                <td className="whitespace-nowrap py-3 px-3 text-right">
-                                                    <button
-                                                        onClick={(e) => {
-                                                            e.stopPropagation();
-                                                            onJobDrillIn(job);
-                                                        }}
-                                                        className="text-gray-900 dark:text-gray-100 hover:text-gray-400"
-                                                    >
-                                                        <ChevronRightIcon className="h-4 w-4" />
-                                                    </button>
-                                                </td>
-                                            </tr>
-                                        ))
-                                    )}
-                                    <tr className="bg-white dark:bg-gray-800">
-                                        <td className="whitespace-nowrap h-16"></td>
-                                        <td className="whitespace-nowrap h-16"></td>
-                                        <td className="whitespace-nowrap h-16"></td>
-                                        <td className="whitespace-nowrap h-16"></td>
-                                        <td className="whitespace-nowrap h-16"></td>
-                                        <td className="whitespace-nowrap h-16"></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
+                                            <ChevronRightIcon className="h-4 w-4" />
+                                        </button>
+                                    </td>
+                                </tr>
+                            ))
+                        )}
+                    </tbody>
+                </table>
                 </div>
+                {pageCount > 1 && (
+                    <div className="flex-none border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+                        <Pagination
+                            filesPerPage={jobsPerPage}
+                            totalFiles={visibleJobs.length}
+                            currentPage={page}
+                            setCurrentPage={setCurrentPage}
+                            disabled={false}
+                        />
+                    </div>
+                )}
             </div>
-            <Pagination
-                filesPerPage={jobsPerPage}
-                totalFiles={visibleJobs.length}
-                currentPage={page}
-                setCurrentPage={setCurrentPage}
-                disabled={false}
-            />
         </div>
     );
 }

--- a/web/src/routes/jobs/components/JobsTable.jsx
+++ b/web/src/routes/jobs/components/JobsTable.jsx
@@ -5,11 +5,99 @@ import {
     ArrowPathIcon,
     ChevronDownIcon,
 } from "@heroicons/react/24/outline";
-import { lastModified, batchProgress } from "@/lib/util";
+import { lastModified, batchProgress, isBatchJobActive, BatchJobStatus } from "@/lib/util";
 import Pagination from "@/components/Pagination";
+import SortableHeader from "@/components/SortableHeader";
+import FilterHeader from "@/components/FilterHeader";
+import FilterMenu from "@/components/FilterMenu";
+import TableSearch from "@/components/TableSearch";
+import { useTableControls } from "@/lib/useTableControls";
 import { TASKS } from "./NewJobModal";
 import StatusBadge from "./StatusBadge";
 import PropTypes from "prop-types";
+
+const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+// Typed field qualifiers (substring match); see applyQuery.
+const JOB_FILTER_FIELDS = {
+    name: (j) => j.name,
+    status: (j) => j.status,
+    task: (j) => j.task,
+    id: (j) => j.id,
+};
+
+// Only columns with a meaningful ordering are sortable. Status and Progress are
+// categorical/bucketed — they're filtered via dropdowns, not sorted.
+const JOB_SORT_FIELDS = {
+    name: (j) => j.name,
+    id: (j) => j.id,
+    created_at: (j) => j.created_at,
+};
+
+// Dropdown-backed predicate groups (see useTableControls.predicateFilters).
+// Keyed by the query key each dropdown writes, then option value -> predicate.
+const JOB_PREDICATE_FILTERS = {
+    // "Filters": intent awkward to type as raw qualifiers.
+    filter: {
+        active: (j) => isBatchJobActive(j.status),
+        inactive: (j) => !isBatchJobActive(j.status),
+        failed: (j) => (Number(j.errored) || 0) > 0,
+        recent: (j) => {
+            const t = Date.parse(j.created_at);
+            // Compared against render time; a few seconds' drift is immaterial
+            // for a 7-day window.
+            return !Number.isNaN(t) && Date.now() - t < RECENT_WINDOW_MS;
+        },
+    },
+    // "Progress": completion state, derived from batchProgress.
+    progress: {
+        "not-started": (j) => batchProgress(j).done === 0,
+        "in-progress": (j) => {
+            const { done, total } = batchProgress(j);
+            return total != null && done > 0 && done < total;
+        },
+        complete: (j) => {
+            const { done, total } = batchProgress(j);
+            return total != null && done >= total;
+        },
+        failures: (j) => (Number(j.errored) || 0) > 0,
+    },
+};
+
+// The single "Filters" dropdown attached to the search bar: a "Show" section
+// (single-select shortcuts) and a "Tasks" section (multi-select task types).
+const JOB_FILTER_SECTIONS = [
+    {
+        title: "Show",
+        filterKey: "filter",
+        mode: "single",
+        options: [
+            { value: "active", label: "Active jobs" },
+            { value: "inactive", label: "Inactive jobs" },
+            { value: "failed", label: "Jobs with failures" },
+            { value: "recent", label: "Recent jobs (< 7 days)" },
+        ],
+    },
+    {
+        title: "Tasks",
+        filterKey: "task",
+        mode: "multi",
+        options: TASKS.map((t) => ({ value: t.id, label: t.name })),
+    },
+];
+
+// Column-header filter menus (Status, Progress). Each writes its own query key.
+const STATUS_OPTIONS = Object.values(BatchJobStatus).map((s) => ({
+    value: s,
+    label: s.charAt(0).toUpperCase() + s.slice(1),
+}));
+
+const PROGRESS_OPTIONS = [
+    { value: "not-started", label: "Not started" },
+    { value: "in-progress", label: "In progress" },
+    { value: "complete", label: "Complete" },
+    { value: "failures", label: "With failures" },
+];
 
 function ProgressDisplay({ finished, staged, errored }) {
     const { done, failed, total } = batchProgress({ finished, staged, errored });
@@ -45,15 +133,33 @@ function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = fa
     const [currentPage, setCurrentPage] = useState(1);
     const jobsPerPage = 20;
 
-    const indexOfLastJob = currentPage * jobsPerPage;
+    const {
+        query,
+        setQuery,
+        sortKey,
+        sortDir,
+        toggleSort,
+        rows: visibleJobs,
+    } = useTableControls(jobs, {
+        filterFields: JOB_FILTER_FIELDS,
+        predicateFilters: JOB_PREDICATE_FILTERS,
+        sortFields: JOB_SORT_FIELDS,
+        defaultSort: { key: "created_at", dir: "desc" },
+    });
+
+    // Filtering can shrink the list under the current page; clamp to a valid page.
+    const pageCount = Math.max(1, Math.ceil(visibleJobs.length / jobsPerPage));
+    const page = Math.min(currentPage, pageCount);
+    const indexOfLastJob = page * jobsPerPage;
     const indexOfFirstJob = indexOfLastJob - jobsPerPage;
 
-    const sortedJobs = [...jobs].sort((a, b) =>
-        new Date(b.created_at) - new Date(a.created_at)
-    );
-
-    const currentJobs = sortedJobs.slice(indexOfFirstJob, indexOfLastJob);
+    const currentJobs = visibleJobs.slice(indexOfFirstJob, indexOfLastJob);
     const heightClass = "lg:h-[calc(100vh-11rem)]";
+
+    const handleQueryChange = (q) => {
+        setQuery(q);
+        setCurrentPage(1);
+    };
 
     return (
         <div id="jobs-table" name="jobs-table" className={`flex-none ${heightClass}`}>
@@ -102,6 +208,16 @@ function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = fa
                     )}
                 </div>
             </div>
+            <div className="mb-4">
+                <TableSearch query={query} setQuery={handleQueryChange}>
+                    <FilterMenu
+                        label="Filters"
+                        sections={JOB_FILTER_SECTIONS}
+                        query={query}
+                        setQuery={handleQueryChange}
+                    />
+                </TableSearch>
+            </div>
             <div className="flow-root">
                 <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
                     <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
@@ -109,36 +225,50 @@ function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = fa
                             <table className="divide-y divide-gray-300 dark:divide-gray-600 table-fixed w-full">
                                 <thead>
                                     <tr>
-                                        <th
-                                            scope="col"
-                                            className="sticky top-0 z-10 py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 dark:text-gray-100 sm:pl-6 w-1/4 backdrop-blur bg-gray-50 dark:bg-gray-800"
-                                        >
-                                            Name
-                                        </th>
-                                        <th
-                                            scope="col"
-                                            className="sticky top-0 z-10 px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100 w-24 backdrop-blur bg-gray-50 dark:bg-gray-800"
-                                        >
-                                            ID
-                                        </th>
-                                        <th
-                                            scope="col"
-                                            className="sticky top-0 z-10 px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100 w-36 backdrop-blur bg-gray-50 dark:bg-gray-800"
-                                        >
-                                            Submitted
-                                        </th>
-                                        <th
-                                            scope="col"
-                                            className="sticky top-0 z-10 px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100 w-24 backdrop-blur bg-gray-50 dark:bg-gray-800"
-                                        >
-                                            Status
-                                        </th>
-                                        <th
-                                            scope="col"
-                                            className="sticky top-0 z-10 px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100 w-32 backdrop-blur bg-gray-50 dark:bg-gray-800"
-                                        >
-                                            Progress
-                                        </th>
+                                        <SortableHeader
+                                            label="Name"
+                                            sortKey="name"
+                                            activeKey={sortKey}
+                                            direction={sortDir}
+                                            onSort={toggleSort}
+                                            className="pl-4 pr-3 sm:pl-6 w-1/4"
+                                        />
+                                        <SortableHeader
+                                            label="ID"
+                                            sortKey="id"
+                                            activeKey={sortKey}
+                                            direction={sortDir}
+                                            onSort={toggleSort}
+                                            className="px-3 w-24"
+                                        />
+                                        <SortableHeader
+                                            label="Submitted"
+                                            sortKey="created_at"
+                                            activeKey={sortKey}
+                                            direction={sortDir}
+                                            onSort={toggleSort}
+                                            className="px-3 w-36"
+                                        />
+                                        {/* Status & Progress headers are filter
+                                            dropdowns, not sortable columns. */}
+                                        <FilterHeader
+                                            label="Status"
+                                            filterKey="status"
+                                            options={STATUS_OPTIONS}
+                                            clearLabel="Clear statuses"
+                                            query={query}
+                                            setQuery={handleQueryChange}
+                                            className="px-3 text-left w-24"
+                                        />
+                                        <FilterHeader
+                                            label="Progress"
+                                            filterKey="progress"
+                                            options={PROGRESS_OPTIONS}
+                                            clearLabel="Clear"
+                                            query={query}
+                                            setQuery={handleQueryChange}
+                                            className="px-3 text-left w-32"
+                                        />
                                         <th
                                             scope="col"
                                             className="sticky top-0 z-10 px-3 py-3.5 text-right text-sm font-semibold text-gray-900 dark:text-gray-100 w-20 backdrop-blur bg-gray-50 dark:bg-gray-800"
@@ -169,11 +299,13 @@ function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = fa
                                                 </tr>
                                             ))}
                                         </>
-                                    ) : jobs.length === 0 ? (
+                                    ) : visibleJobs.length === 0 ? (
                                         <tr>
                                             <td colSpan={6} className="h-64">
                                                 <div className="font-light sm:text-sm text-center align-middle text-gray-600 dark:text-gray-400">
-                                                    No jobs found
+                                                    {jobs.length === 0
+                                                        ? "No jobs found"
+                                                        : "No jobs match your search"}
                                                 </div>
                                             </td>
                                         </tr>
@@ -237,8 +369,8 @@ function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = fa
             </div>
             <Pagination
                 filesPerPage={jobsPerPage}
-                totalFiles={sortedJobs.length}
-                currentPage={currentPage}
+                totalFiles={visibleJobs.length}
+                currentPage={page}
                 setCurrentPage={setCurrentPage}
                 disabled={false}
             />

--- a/web/src/routes/jobs/components/JobsTable.jsx
+++ b/web/src/routes/jobs/components/JobsTable.jsx
@@ -26,6 +26,10 @@ const JOB_FILTER_FIELDS = {
     id: (j) => j.id,
 };
 
+// status is dropdown-driven and enum-valued; match it exactly so filtering
+// "submitted" doesn't also catch "resubmitted" (substring collision).
+const JOB_EXACT_FILTER_FIELDS = ["status"];
+
 // Only columns with a meaningful ordering are sortable. Status and Progress are
 // categorical/bucketed — they're filtered via dropdowns, not sorted.
 const JOB_SORT_FIELDS = {
@@ -142,6 +146,7 @@ function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = fa
         rows: visibleJobs,
     } = useTableControls(jobs, {
         filterFields: JOB_FILTER_FIELDS,
+        exactFilterFields: JOB_EXACT_FILTER_FIELDS,
         predicateFilters: JOB_PREDICATE_FILTERS,
         sortFields: JOB_SORT_FIELDS,
         defaultSort: { key: "created_at", dir: "desc" },

--- a/web/src/routes/jobs/components/ResultPreview.jsx
+++ b/web/src/routes/jobs/components/ResultPreview.jsx
@@ -10,7 +10,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { blackfishApiURL } from "@/config";
 import { getFileType, truncateTextPreview } from "@/lib/fileApi";
-import { isRemoteProfile } from "@/lib/util";
+import { isRemoteProfile, formatElapsed } from "@/lib/util";
 import {
     parseDetections,
     buildLabelColorMap,
@@ -59,24 +59,6 @@ function formatDateTime(isoString) {
     if (!isoString) return "-";
     const date = new Date(isoString);
     return date.toLocaleString();
-}
-
-function formatElapsedTime(startedAt, finishedAt) {
-    if (!startedAt || !finishedAt) return "-";
-
-    const start = new Date(startedAt);
-    const end = new Date(finishedAt);
-    const diffMs = end - start;
-
-    if (diffMs < 1000) {
-        return `${diffMs}ms`;
-    } else if (diffMs < 60000) {
-        return `${(diffMs / 1000).toFixed(1)}s`;
-    } else {
-        const minutes = Math.floor(diffMs / 60000);
-        const seconds = ((diffMs % 60000) / 1000).toFixed(0);
-        return `${minutes}m ${seconds}s`;
-    }
 }
 
 // An object-detection result: an image input with a JSON output file. Used to
@@ -671,7 +653,7 @@ function ResultPreview({ result, job, profile = null }) {
                     <div className="flex justify-between">
                         <span className="text-gray-500 dark:text-gray-400">Elapsed:</span>
                         <span className="text-gray-900 dark:text-gray-100">
-                            {formatElapsedTime(result.started_at, result.finished_at)}
+                            {formatElapsed(result.started_at, result.finished_at)}
                         </span>
                     </div>
                 </div>

--- a/web/src/routes/jobs/components/layout.js
+++ b/web/src/routes/jobs/components/layout.js
@@ -1,0 +1,6 @@
+// Shared height for the two columns of the jobs page. The left column (jobs or
+// results table) and the right column (job details or result preview) start at
+// the same y, so giving them the same height makes their bottom edges line up.
+// Each column is a flex column: fixed-height header/search rows, and a bordered
+// body that flexes to fill whatever is left.
+export const COLUMN_HEIGHT = "lg:h-[calc(100vh-8.25rem)]";

--- a/web/vitest.config.mjs
+++ b/web/vitest.config.mjs
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
-import path from 'path';
+import { fileURLToPath } from 'url';
 
 export default defineConfig({
   plugins: [react()],
@@ -18,7 +18,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
 });


### PR DESCRIPTION
## Summary

- Add a shared, client-side **table-controls layer** reused by both batch-job tables: a query engine (`tableQuery.js`) that parses free text + `key:value` qualifiers (values ORed within a key), a `useTableControls` hook (null-safe, type-aware sort + predicate filters), and four reusable components — `SortableHeader`, `FilterHeader` (multi-select column dropdown), `FilterMenu` (sectioned search-bar dropdown), and `TableSearch`.
- **Jobs table:** sort Name / ID / Submitted; filter **Status** and **Progress** via multi-select header dropdowns; a sectioned **Filters** menu with single-select shortcuts ("Show": active / inactive / with failures / recent) and multi-select **Tasks**.
- **Results table:** sort file/time columns; filter **Status** via a header dropdown. Deduplicated `formatElapsed`/`elapsedMs` into `lib/util` (previously copy-pasted across `JobResultsTable` and `ResultPreview`).

Filtering is qualifier-only (bare text and partial/unknown keys are ignored, so a half-typed query never shows a premature empty state). Single-select rows use the app's `Listbox` convention (bold + trailing check); multi-select rows use a leading checkbox. No backend/API changes — all client-side over already-fetched rows.

## Test plan

- `cd web && npm test` — 453 tests pass, including new coverage for `tableQuery`, `useTableControls`, `FilterMenu`, `FilterHeader`, `TableSearch`, and the `elapsedMs`/`formatElapsed` util helpers.
- `cd web && npm run lint` — 0 errors.
- `cd web && npm run build` — builds clean.
- Manual: on the Jobs table, sort each sortable header; open Status/Progress header dropdowns and multi-select; use the Filters menu (Show single-select, Tasks multi-select); confirm selections AND across groups and the count/clear affordances work. On the Results table, sort columns and filter via the Status header dropdown.

Closes #436.