### PR TITLE
feat(web): overlay object-detection bounding boxes on image preview

### DIFF
--- a/web/src/lib/detections.js
+++ b/web/src/lib/detections.js
@@ -1,0 +1,112 @@
+// Helpers for object-detection bounding-box overlays.
+//
+// The detection output is a JSON array produced by the inference backend. Each
+// element has the shape:
+//   { label: string, score: number, box: { xmin, ymin, xmax, ymax } }
+// where the box coordinates are absolute pixels in the input image's natural
+// dimensions.
+
+/**
+ * A fixed, color-blind-friendly palette. Labels are assigned colors
+ * deterministically by insertion order so the same label always keeps the same
+ * color within a preview (and repeats predictably if there are many labels).
+ */
+export const DETECTION_COLORS = [
+    "#ef4444", // red-500
+    "#3b82f6", // blue-500
+    "#22c55e", // green-500
+    "#f59e0b", // amber-500
+    "#a855f7", // purple-500
+    "#ec4899", // pink-500
+    "#14b8a6", // teal-500
+    "#f97316", // orange-500
+    "#84cc16", // lime-500
+    "#06b6d4", // cyan-500
+];
+
+/**
+ * Build a stable label -> color map for a list of detections. Labels are
+ * ordered by first appearance so colors are consistent across renders of the
+ * same output.
+ */
+export function buildLabelColorMap(detections) {
+    const map = new Map();
+    for (const det of detections) {
+        if (!map.has(det.label)) {
+            map.set(det.label, DETECTION_COLORS[map.size % DETECTION_COLORS.length]);
+        }
+    }
+    return map;
+}
+
+/**
+ * Summarize the distinct labels in a list of detections: one entry per label
+ * with its color, count, and the maximum confidence seen for that label.
+ * Ordered by first appearance (matching the color assignment).
+ */
+export function summarizeLabels(detections) {
+    const colorMap = buildLabelColorMap(detections);
+    const byLabel = new Map();
+    for (const det of detections) {
+        const existing = byLabel.get(det.label);
+        if (existing) {
+            existing.count += 1;
+            existing.maxScore = Math.max(existing.maxScore, det.score);
+        } else {
+            byLabel.set(det.label, {
+                label: det.label,
+                color: colorMap.get(det.label),
+                count: 1,
+                maxScore: det.score,
+            });
+        }
+    }
+    return Array.from(byLabel.values());
+}
+
+/**
+ * Filter detections by a set of hidden labels and a minimum confidence.
+ * `hiddenLabels` is a Set of label strings to exclude; `minConfidence` is a
+ * lower bound (inclusive) on the score.
+ */
+export function filterDetections(detections, hiddenLabels, minConfidence = 0) {
+    return detections.filter(
+        (det) => !hiddenLabels.has(det.label) && det.score >= minConfidence
+    );
+}
+
+/**
+ * Parse the raw detection-output text into a normalized array of detections.
+ * Returns [] for empty/invalid input or shapes we don't recognize (e.g. the
+ * per-frame video output), so callers can safely treat "no boxes" uniformly.
+ */
+export function parseDetections(text) {
+    if (!text) return [];
+
+    let data;
+    try {
+        data = JSON.parse(text);
+    } catch {
+        return [];
+    }
+
+    if (!Array.isArray(data)) return [];
+
+    return data.filter(isValidDetection);
+}
+
+function isValidDetection(det) {
+    if (!det || typeof det !== "object") return false;
+    if (typeof det.label !== "string") return false;
+    if (typeof det.score !== "number") return false;
+    const box = det.box;
+    if (!box || typeof box !== "object") return false;
+    return ["xmin", "ymin", "xmax", "ymax"].every(
+        (k) => typeof box[k] === "number"
+    );
+}
+
+/** Format a detection's confidence for display, e.g. "dog (0.98)". */
+export function formatDetectionLabel(detection) {
+    return `${detection.label} (${detection.score.toFixed(2)})`;
+}

--- a/web/src/lib/detections.test.js
+++ b/web/src/lib/detections.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import {
+    parseDetections,
+    buildLabelColorMap,
+    formatDetectionLabel,
+    summarizeLabels,
+    filterDetections,
+    DETECTION_COLORS,
+} from "./detections";
+
+const det = (label, score, box = { xmin: 0, ymin: 0, xmax: 10, ymax: 10 }) => ({
+    label,
+    score,
+    box,
+});
+
+describe("parseDetections", () => {
+    it("parses a valid detection array", () => {
+        const text = JSON.stringify([det("dog", 0.98), det("cat", 0.87)]);
+        const result = parseDetections(text);
+        expect(result).toHaveLength(2);
+        expect(result[0].label).toBe("dog");
+        expect(result[1].box.xmax).toBe(10);
+    });
+
+    it("returns [] for empty or nullish input", () => {
+        expect(parseDetections("")).toEqual([]);
+        expect(parseDetections(null)).toEqual([]);
+        expect(parseDetections(undefined)).toEqual([]);
+    });
+
+    it("returns [] for invalid JSON", () => {
+        expect(parseDetections("not json{")).toEqual([]);
+    });
+
+    it("returns [] for non-array JSON (e.g. per-frame video output)", () => {
+        expect(parseDetections(JSON.stringify({ frame: 0, detections: [] }))).toEqual([]);
+    });
+
+    it("filters out malformed detection entries", () => {
+        const text = JSON.stringify([
+            det("dog", 0.9),
+            { label: "missing-box", score: 0.5 },
+            { label: "bad-score", score: "high", box: { xmin: 0, ymin: 0, xmax: 1, ymax: 1 } },
+            { label: 42, score: 0.5, box: { xmin: 0, ymin: 0, xmax: 1, ymax: 1 } },
+            { score: 0.5, box: { xmin: 0, ymin: 0, xmax: 1, ymax: 1 } },
+            { label: "partial-box", score: 0.5, box: { xmin: 0, ymin: 0 } },
+        ]);
+        const result = parseDetections(text);
+        expect(result).toHaveLength(1);
+        expect(result[0].label).toBe("dog");
+    });
+});
+
+describe("buildLabelColorMap", () => {
+    it("assigns colors by first appearance and reuses them per label", () => {
+        const map = buildLabelColorMap([det("dog", 0.9), det("cat", 0.8), det("dog", 0.7)]);
+        expect(map.size).toBe(2);
+        expect(map.get("dog")).toBe(DETECTION_COLORS[0]);
+        expect(map.get("cat")).toBe(DETECTION_COLORS[1]);
+    });
+
+    it("wraps around the palette when labels exceed its length", () => {
+        const dets = DETECTION_COLORS.map((_, i) => det(`label-${i}`, 0.5)).concat([
+            det("overflow", 0.5),
+        ]);
+        const map = buildLabelColorMap(dets);
+        expect(map.get("overflow")).toBe(DETECTION_COLORS[0]);
+    });
+
+    it("handles an empty list", () => {
+        expect(buildLabelColorMap([]).size).toBe(0);
+    });
+});
+
+describe("summarizeLabels", () => {
+    it("groups by label with count, color, and max score", () => {
+        const summary = summarizeLabels([
+            det("dog", 0.9),
+            det("cat", 0.8),
+            det("dog", 0.95),
+        ]);
+        expect(summary).toHaveLength(2);
+
+        const dog = summary.find((s) => s.label === "dog");
+        expect(dog.count).toBe(2);
+        expect(dog.maxScore).toBe(0.95);
+        expect(dog.color).toBe(DETECTION_COLORS[0]);
+
+        const cat = summary.find((s) => s.label === "cat");
+        expect(cat.count).toBe(1);
+        expect(cat.color).toBe(DETECTION_COLORS[1]);
+    });
+
+    it("preserves first-appearance order", () => {
+        const summary = summarizeLabels([det("cat", 0.5), det("dog", 0.5)]);
+        expect(summary.map((s) => s.label)).toEqual(["cat", "dog"]);
+    });
+
+    it("returns [] for no detections", () => {
+        expect(summarizeLabels([])).toEqual([]);
+    });
+});
+
+describe("filterDetections", () => {
+    const dets = [det("dog", 0.9), det("cat", 0.4), det("dog", 0.5)];
+
+    it("excludes hidden labels", () => {
+        const result = filterDetections(dets, new Set(["cat"]), 0);
+        expect(result).toHaveLength(2);
+        expect(result.every((d) => d.label === "dog")).toBe(true);
+    });
+
+    it("excludes detections below the confidence threshold", () => {
+        const result = filterDetections(dets, new Set(), 0.6);
+        expect(result).toHaveLength(1);
+        expect(result[0].score).toBe(0.9);
+    });
+
+    it("applies both filters together", () => {
+        const result = filterDetections(dets, new Set(["dog"]), 0.6);
+        expect(result).toEqual([]);
+    });
+
+    it("includes everything with no hidden labels and zero threshold", () => {
+        expect(filterDetections(dets, new Set(), 0)).toHaveLength(3);
+    });
+
+    it("treats the threshold as inclusive", () => {
+        expect(filterDetections(dets, new Set(), 0.5)).toHaveLength(2);
+    });
+});
+
+describe("formatDetectionLabel", () => {
+    it("formats label with two-decimal confidence", () => {
+        expect(formatDetectionLabel(det("dog", 0.98))).toBe("dog (0.98)");
+        expect(formatDetectionLabel(det("cat", 0.8))).toBe("cat (0.80)");
+        expect(formatDetectionLabel(det("bird", 0.876))).toBe("bird (0.88)");
+    });
+});

--- a/web/src/routes/jobs/components/ResultPreview.jsx
+++ b/web/src/routes/jobs/components/ResultPreview.jsx
@@ -1,13 +1,23 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import {
     DocumentIcon,
     CheckCircleIcon,
     CheckIcon,
     XCircleIcon,
+    XMarkIcon,
+    AdjustmentsHorizontalIcon,
 } from "@heroicons/react/24/outline";
 import { blackfishApiURL } from "@/config";
 import { getFileType, truncateTextPreview } from "@/lib/fileApi";
 import { isRemoteProfile } from "@/lib/util";
+import {
+    parseDetections,
+    buildLabelColorMap,
+    formatDetectionLabel,
+    summarizeLabels,
+    filterDetections,
+} from "@/lib/detections";
 import PropTypes from "prop-types";
 
 function TruncatedPath({ path, maxWidth = "max-w-[14rem]" }) {
@@ -69,7 +79,296 @@ function formatElapsedTime(startedAt, finishedAt) {
     }
 }
 
-function OutputFilePreview({ file, profile = null }) {
+// An object-detection result: an image input with a JSON output file. Used to
+// decide whether to offer the bounding-box overlay on the input image.
+export function isDetectionResult(inputFile, outputFile) {
+    return (
+        getFileType(inputFile) === "image" &&
+        Boolean(outputFile) &&
+        outputFile.toLowerCase().endsWith(".json")
+    );
+}
+
+// Fetch and parse object-detection boxes from a JSON detection file. Returns []
+// while loading, on error, or when there is no detection file.
+function useDetections(detectionFile, profileParam) {
+    const [detections, setDetections] = useState([]);
+
+    useEffect(() => {
+        let cancelled = false;
+        setDetections([]);
+        if (!detectionFile) return;
+
+        const url = `${blackfishApiURL}/api/text?path=${encodeURIComponent(detectionFile)}${profileParam}`;
+        fetch(url)
+            .then(res => (res.ok ? res.text() : Promise.reject(new Error("Failed to load detections"))))
+            .then(text => {
+                if (!cancelled) setDetections(parseDetections(text));
+            })
+            .catch(() => {
+                if (!cancelled) setDetections([]);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [detectionFile, profileParam]);
+
+    return detections;
+}
+
+// An image preview that can superimpose object-detection bounding boxes. The
+// (already filtered) `detections` and their `colorMap` are owned by the parent
+// so the filter controls can live in the shared preview header, and colors stay
+// stable regardless of which categories are currently shown.
+function DetectableImage({ src, alt, detections = [], colorMap = new Map() }) {
+    // Natural (intrinsic) image size, needed to scale absolute-pixel boxes to
+    // the rendered element size.
+    const [natural, setNatural] = useState(null);
+    const [loaded, setLoaded] = useState(false);
+    const [error, setError] = useState(false);
+
+    // Reset load state when the image source changes.
+    useEffect(() => {
+        setLoaded(false);
+        setError(false);
+    }, [src]);
+
+    const markLoaded = useCallback((img) => {
+        setNatural({ width: img.naturalWidth, height: img.naturalHeight });
+        setLoaded(true);
+    }, []);
+
+    // Handle images the browser already has cached: they can fire `load` before
+    // React attaches onLoad, so check `complete` when the element mounts.
+    const imgRef = useCallback((img) => {
+        if (img && img.complete && img.naturalWidth > 0) {
+            markLoaded(img);
+        }
+    }, [markLoaded]);
+
+    if (error) {
+        return (
+            <div className="text-center py-4">
+                <DocumentIcon className="mx-auto h-8 w-8 text-gray-300 dark:text-gray-600" />
+                <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                    Failed to load image
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="relative">
+            <img
+                ref={imgRef}
+                src={src}
+                alt={alt}
+                onLoad={(e) => markLoaded(e.target)}
+                onError={() => setError(true)}
+                className={`w-full h-auto rounded-lg ${loaded ? "border border-gray-200 dark:border-gray-700" : "block"}`}
+            />
+            {!loaded && (
+                <div className="absolute inset-0 animate-pulse rounded-lg bg-gray-200 dark:bg-gray-700 min-h-[8rem]" />
+            )}
+            {loaded && detections.length > 0 && natural && (
+                <svg
+                    className="absolute inset-0 w-full h-full pointer-events-none"
+                    viewBox={`0 0 ${natural.width} ${natural.height}`}
+                    preserveAspectRatio="none"
+                >
+                    {detections.map((det, i) => {
+                        const { xmin, ymin, xmax, ymax } = det.box;
+                        const color = colorMap.get(det.label);
+                        const label = formatDetectionLabel(det);
+                        // Scale stroke/text with image size so they stay
+                        // legible regardless of the source resolution.
+                        const stroke = Math.max(natural.width, natural.height) * 0.004;
+                        const fontSize = Math.max(natural.width, natural.height) * 0.02;
+                        const padX = fontSize * 0.3;
+                        const textWidth = label.length * fontSize * 0.55;
+                        const tagHeight = fontSize * 1.3;
+                        // Draw the label tag above the box, but flip it just
+                        // inside the top edge when there isn't room above (box
+                        // near the top of the image) so it never gets clipped.
+                        const above = ymin - tagHeight >= 0;
+                        const tagY = above ? ymin - tagHeight : ymin;
+                        const textY = tagY + fontSize * 0.95;
+                        return (
+                            <g key={i}>
+                                <rect
+                                    x={xmin}
+                                    y={ymin}
+                                    width={xmax - xmin}
+                                    height={ymax - ymin}
+                                    fill="none"
+                                    stroke={color}
+                                    strokeWidth={stroke}
+                                />
+                                <rect
+                                    x={xmin}
+                                    y={tagY}
+                                    width={textWidth + padX * 2}
+                                    height={tagHeight}
+                                    fill={color}
+                                />
+                                <text
+                                    x={xmin + padX}
+                                    y={textY}
+                                    fill="#ffffff"
+                                    fontSize={fontSize}
+                                    fontFamily="ui-sans-serif, system-ui, sans-serif"
+                                >
+                                    {label}
+                                </text>
+                            </g>
+                        );
+                    })}
+                </svg>
+            )}
+        </div>
+    );
+}
+
+DetectableImage.propTypes = {
+    src: PropTypes.string.isRequired,
+    alt: PropTypes.string,
+    detections: PropTypes.array,
+    colorMap: PropTypes.instanceOf(Map),
+};
+
+// Popover for filtering the overlaid detections: toggle categories on/off and
+// set a minimum confidence. Mirrors the service launch "Parameters" popover.
+function DetectionFilterPopover({
+    labels,
+    hiddenLabels,
+    onToggleLabel,
+    onShowAll,
+    onHideAll,
+    minConfidence,
+    onConfidenceChange,
+}) {
+    const allShown = hiddenLabels.size === 0;
+    const allHidden = hiddenLabels.size >= labels.length;
+    return (
+        <Popover className="relative">
+            <PopoverButton
+                title="Filter boxes"
+                className="p-1.5 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-700 focus:outline-none"
+            >
+                <AdjustmentsHorizontalIcon className="h-5 w-5" />
+            </PopoverButton>
+            <PopoverPanel
+                anchor="left end"
+                className="z-50 mr-2 w-72 rounded-lg bg-white dark:bg-gray-800 shadow-lg ring-1 ring-gray-200 dark:ring-gray-700 p-4"
+            >
+                {({ close }) => (
+                    <div>
+                        <div className="flex items-center justify-between mb-3">
+                            <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                                Bounding boxes
+                            </span>
+                            <button
+                                onClick={close}
+                                className="p-1 rounded-md text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 focus:outline-none"
+                            >
+                                <XMarkIcon className="h-4 w-4" />
+                            </button>
+                        </div>
+
+                        {/* Confidence threshold */}
+                        <div className="mb-4">
+                            <div className="flex items-center justify-between mb-1">
+                                <label
+                                    htmlFor="detection-confidence"
+                                    className="text-xs text-gray-600 dark:text-gray-300"
+                                >
+                                    Min. confidence
+                                </label>
+                                <span className="text-xs font-mono text-gray-900 dark:text-gray-100">
+                                    {minConfidence.toFixed(2)}
+                                </span>
+                            </div>
+                            <input
+                                id="detection-confidence"
+                                type="range"
+                                min="0"
+                                max="1"
+                                step="0.01"
+                                value={minConfidence}
+                                onChange={(e) => onConfidenceChange(Number(e.target.value))}
+                                className="w-full accent-blue-600"
+                            />
+                        </div>
+
+                        {/* Category toggles */}
+                        <div className="flex items-center justify-between mb-2">
+                            <span className="text-xs font-medium text-gray-600 dark:text-gray-300">
+                                Categories
+                            </span>
+                            <div className="flex items-center gap-1 text-xs">
+                                <button
+                                    type="button"
+                                    onClick={onShowAll}
+                                    disabled={allShown}
+                                    className="text-blue-600 dark:text-blue-400 hover:underline disabled:text-gray-300 dark:disabled:text-gray-600 disabled:no-underline disabled:cursor-default focus:outline-none"
+                                >
+                                    All
+                                </button>
+                                <span className="text-gray-300 dark:text-gray-600">/</span>
+                                <button
+                                    type="button"
+                                    onClick={onHideAll}
+                                    disabled={allHidden}
+                                    className="text-blue-600 dark:text-blue-400 hover:underline disabled:text-gray-300 dark:disabled:text-gray-600 disabled:no-underline disabled:cursor-default focus:outline-none"
+                                >
+                                    None
+                                </button>
+                            </div>
+                        </div>
+                        <div className="space-y-1.5 max-h-56 overflow-y-auto">
+                            {labels.map((entry) => (
+                                <label
+                                    key={entry.label}
+                                    className="flex items-center gap-2 text-xs text-gray-700 dark:text-gray-200 cursor-pointer select-none"
+                                >
+                                    <input
+                                        type="checkbox"
+                                        checked={!hiddenLabels.has(entry.label)}
+                                        onChange={() => onToggleLabel(entry.label)}
+                                        className="rounded border-gray-300 dark:border-gray-600"
+                                    />
+                                    <span
+                                        className="inline-block h-3 w-3 rounded-sm flex-shrink-0"
+                                        style={{ backgroundColor: entry.color }}
+                                    />
+                                    <span className="truncate flex-1" title={entry.label}>
+                                        {entry.label}
+                                    </span>
+                                    <span className="text-gray-400 dark:text-gray-500 font-mono">
+                                        {entry.count}
+                                    </span>
+                                </label>
+                            ))}
+                        </div>
+                    </div>
+                )}
+            </PopoverPanel>
+        </Popover>
+    );
+}
+
+DetectionFilterPopover.propTypes = {
+    labels: PropTypes.array.isRequired,
+    hiddenLabels: PropTypes.instanceOf(Set).isRequired,
+    onToggleLabel: PropTypes.func.isRequired,
+    onShowAll: PropTypes.func.isRequired,
+    onHideAll: PropTypes.func.isRequired,
+    minConfidence: PropTypes.number.isRequired,
+    onConfidenceChange: PropTypes.func.isRequired,
+};
+
+function OutputFilePreview({ file, profile = null, detections = [], colorMap = new Map() }) {
     const [textContent, setTextContent] = useState(null);
     const [textLoading, setTextLoading] = useState(false);
     const [textError, setTextError] = useState(null);
@@ -112,13 +411,12 @@ function OutputFilePreview({ file, profile = null }) {
     return (
         <div>
             {fileType === "image" && (
-                <div className="relative">
-                    <img
-                        src={`${blackfishApiURL}/api/image?path=${encodeURIComponent(file)}${profileParam}`}
-                        alt={file}
-                        className="w-full h-auto rounded-lg border border-gray-200 dark:border-gray-700"
-                    />
-                </div>
+                <DetectableImage
+                    src={`${blackfishApiURL}/api/image?path=${encodeURIComponent(file)}${profileParam}`}
+                    alt={file}
+                    detections={detections}
+                    colorMap={colorMap}
+                />
             )}
 
             {fileType === "text" && (
@@ -175,6 +473,8 @@ function OutputFilePreview({ file, profile = null }) {
 OutputFilePreview.propTypes = {
     file: PropTypes.string,
     profile: PropTypes.object,
+    detections: PropTypes.array,
+    colorMap: PropTypes.instanceOf(Map),
 };
 
 // The initial toggle side: output when it exists (success), else input.
@@ -197,6 +497,50 @@ function FilePreviewPanel({ inputFile, outputFile, profile = null }) {
     const activeSide = resolvePreviewSide(side, hasOutput);
     const file = activeSide === "output" ? outputFile : inputFile;
 
+    const profileParam = isRemoteProfile(profile)
+        ? `&profile=${encodeURIComponent(profile.name)}`
+        : "";
+
+    // For object-detection results, offer a bounding-box overlay on the input
+    // image, drawn from the JSON output file.
+    const detectionFile = isDetectionResult(inputFile, outputFile) ? outputFile : null;
+    const detections = useDetections(detectionFile, profileParam);
+    const [hiddenLabels, setHiddenLabels] = useState(() => new Set());
+    const [minConfidence, setMinConfidence] = useState(0);
+
+    // Reset filters when the underlying detection set changes.
+    useEffect(() => {
+        setHiddenLabels(new Set());
+        setMinConfidence(0);
+    }, [detectionFile]);
+
+    const labelSummary = useMemo(() => summarizeLabels(detections), [detections]);
+    // Stable label -> color map built from the full detection set, so a box's
+    // color never changes as categories are toggled on and off.
+    const colorMap = useMemo(() => buildLabelColorMap(detections), [detections]);
+    const visibleDetections = useMemo(
+        () => filterDetections(detections, hiddenLabels, minConfidence),
+        [detections, hiddenLabels, minConfidence]
+    );
+
+    const toggleLabel = useCallback((label) => {
+        setHiddenLabels((prev) => {
+            const next = new Set(prev);
+            if (next.has(label)) next.delete(label);
+            else next.add(label);
+            return next;
+        });
+    }, []);
+
+    const showAllLabels = useCallback(() => setHiddenLabels(new Set()), []);
+    const hideAllLabels = useCallback(
+        () => setHiddenLabels(new Set(labelSummary.map((entry) => entry.label))),
+        [labelSummary]
+    );
+
+    // Only overlay boxes on the input image side, and only when there's data.
+    const canShowBoxes = activeSide === "input" && detections.length > 0;
+
     const tabClass = (isActive) =>
         `px-2 py-1 text-xs rounded-md ${isActive
             ? "bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm font-medium"
@@ -209,27 +553,45 @@ function FilePreviewPanel({ inputFile, outputFile, profile = null }) {
                 <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">
                     Preview
                 </h4>
-                <div className="inline-flex gap-1 rounded-lg bg-gray-100 dark:bg-gray-900 p-0.5">
-                    <button
-                        type="button"
-                        onClick={() => setSide("input")}
-                        className={tabClass(activeSide === "input")}
-                    >
-                        Input
-                    </button>
-                    <button
-                        type="button"
-                        onClick={() => setSide("output")}
-                        disabled={!hasOutput}
-                        title={hasOutput ? undefined : "No output for this file"}
-                        className={`${tabClass(activeSide === "output")} disabled:opacity-40 disabled:cursor-not-allowed`}
-                    >
-                        Output
-                    </button>
+                <div className="flex items-center gap-2">
+                    {canShowBoxes && (
+                        <DetectionFilterPopover
+                            labels={labelSummary}
+                            hiddenLabels={hiddenLabels}
+                            onToggleLabel={toggleLabel}
+                            onShowAll={showAllLabels}
+                            onHideAll={hideAllLabels}
+                            minConfidence={minConfidence}
+                            onConfidenceChange={setMinConfidence}
+                        />
+                    )}
+                    <div className="inline-flex gap-1 rounded-lg bg-gray-100 dark:bg-gray-900 p-0.5">
+                        <button
+                            type="button"
+                            onClick={() => setSide("input")}
+                            className={tabClass(activeSide === "input")}
+                        >
+                            Input
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => setSide("output")}
+                            disabled={!hasOutput}
+                            title={hasOutput ? undefined : "No output for this file"}
+                            className={`${tabClass(activeSide === "output")} disabled:opacity-40 disabled:cursor-not-allowed`}
+                        >
+                            Output
+                        </button>
+                    </div>
                 </div>
             </div>
             <div className="flex-1 min-h-0 overflow-y-auto">
-                <OutputFilePreview file={file} profile={profile} />
+                <OutputFilePreview
+                    file={file}
+                    profile={profile}
+                    detections={canShowBoxes ? visibleDetections : []}
+                    colorMap={colorMap}
+                />
             </div>
         </div>
     );

--- a/web/src/routes/jobs/components/ResultPreview.test.jsx
+++ b/web/src/routes/jobs/components/ResultPreview.test.jsx
@@ -1,6 +1,10 @@
 import { describe, test, expect } from "vitest";
 
-import { defaultPreviewSide, resolvePreviewSide } from "./ResultPreview";
+import {
+  defaultPreviewSide,
+  resolvePreviewSide,
+  isDetectionResult,
+} from "./ResultPreview";
 
 describe("defaultPreviewSide", () => {
   test("defaults to output when output exists (success)", () => {
@@ -21,5 +25,23 @@ describe("resolvePreviewSide", () => {
 
   test("falls back to input when output is chosen but unavailable", () => {
     expect(resolvePreviewSide("output", false)).toBe("input");
+  });
+});
+
+describe("isDetectionResult", () => {
+  test("is true for an image input with a JSON output", () => {
+    expect(isDetectionResult("photo.jpg", "photo.json")).toBe(true);
+    expect(isDetectionResult("PHOTO.PNG", "OUT.JSON")).toBe(true);
+  });
+
+  test("is false when the input is not an image", () => {
+    expect(isDetectionResult("clip.mp4", "clip.json")).toBe(false);
+    expect(isDetectionResult("notes.txt", "notes.json")).toBe(false);
+  });
+
+  test("is false when the output is not JSON", () => {
+    expect(isDetectionResult("photo.jpg", "photo.txt")).toBe(false);
+    expect(isDetectionResult("photo.jpg", null)).toBe(false);
+    expect(isDetectionResult("photo.jpg", undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Add a bounding-box overlay to the job result preview for object-detection results (image input + JSON output). Boxes are color-coded per label with the label and confidence value drawn as a tag.
- Add a filter popover (opens up-and-left of the sliders button, clear of the image) to toggle categories on/off (with All/None), and set a minimum-confidence threshold via a slider.
- Add a loading skeleton for the input image, plus a graceful "Failed to load image" fallback.

## Implementation notes

- New pure helpers in `web/src/lib/detections.js` (parse/validate detections, stable per-label color map, label summary, filter) with unit tests.
- Colors are assigned from the **full** detection set and passed down, so a box's color never changes as categories are filtered.
- The overlay renders as an SVG whose `viewBox` matches the image's natural pixel dimensions, so box coordinates scale correctly without manual math. Label tags flip inside the top edge when there isn't room above.
- Non-detection previews (other images, text, audio) are untouched; the video per-frame detection shape is intentionally ignored (no boxes) rather than mis-drawn.

## Test plan

- `cd web && npm run lint` — 0 errors (1 pre-existing warning in an unrelated file).
- `cd web && npm test` — 410 tests pass, including new `detections.test.js` and `isDetectionResult` coverage.
- Manual: select an object-detection result in the Jobs view → input image shows boxes; open the popover → toggle categories and adjust the confidence slider; verify box colors stay stable while filtering; throttle the network to see the loading skeleton.