### PR TITLE
feat(web): make the left nav sidebar collapsible

### DIFF
--- a/web/src/components/Navbar.jsx
+++ b/web/src/components/Navbar.jsx
@@ -16,7 +16,13 @@ import PropTypes from "prop-types";
  * @param {boolean} props.showSidebar - Whether to show hamburger menu (mobile)
  * @param {function} props.onOpenSidebar - Callback for hamburger click
  */
-function Navbar({ variant = "default", showSidebar = false, onOpenSidebar }) {
+function Navbar({
+  variant = "default",
+  showSidebar = false,
+  onOpenSidebar,
+  sidebarCollapsed = false,
+  onToggleSidebarCollapse,
+}) {
   const { profile, setProfile } = useContext(ProfileContext);
   const { theme, toggleTheme } = useTheme();
   const { openSettings } = useSettings();
@@ -76,13 +82,19 @@ function Navbar({ variant = "default", showSidebar = false, onOpenSidebar }) {
     <>
       {/* Desktop header */}
       <div className="hidden lg:fixed lg:inset-x-0 lg:top-0 lg:z-50 lg:flex lg:h-12 lg:items-center lg:justify-between lg:bg-white dark:lg:bg-gray-900 lg:pl-6 lg:pr-4 lg:border-b lg:border-gray-200 dark:lg:border-gray-700">
-        <Link to="/dashboard" className="flex items-center gap-2">
-          <img
-            className="h-8 w-8 dark:drop-shadow-[0_0_8px_rgba(255,255,255,0.6)]"
-            src={assetPath("/img/orca.png")}
-            alt="blackfish"
-          />
-        </Link>
+        {onToggleSidebarCollapse ? (
+          <button
+            type="button"
+            onClick={onToggleSidebarCollapse}
+            className="-m-2.5 p-2.5 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-200 focus:outline-none"
+            aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+          >
+            <Bars3Icon className="h-6 w-6" />
+          </button>
+        ) : (
+          <div /> // Placeholder to keep controls right-aligned
+        )}
         <div className="flex items-center gap-4">
           <button
             onClick={toggleTheme}
@@ -166,6 +178,8 @@ Navbar.propTypes = {
   variant: PropTypes.oneOf(["dashboard", "default"]),
   showSidebar: PropTypes.bool,
   onOpenSidebar: PropTypes.func,
+  sidebarCollapsed: PropTypes.bool,
+  onToggleSidebarCollapse: PropTypes.func,
 };
 
 export default Navbar;

--- a/web/src/components/Sidebar.jsx
+++ b/web/src/components/Sidebar.jsx
@@ -96,7 +96,8 @@ function Sidebar({ collapsed = false }) {
         >
             {/* Logo header - orca mark, aligned with the nav icons below */}
             <div className="-mx-2 shrink-0">
-                <div
+                <Link
+                    to="/dashboard"
                     className={classNames(
                         "flex items-center p-2",
                         collapsed ? "justify-center" : "pl-1"
@@ -107,7 +108,7 @@ function Sidebar({ collapsed = false }) {
                         src={assetPath("/img/orca.png")}
                         alt="blackfish"
                     />
-                </div>
+                </Link>
             </div>
             <nav className="flex flex-1 flex-col">
                 <ul role="list" className="flex flex-1 flex-col gap-y-7 pt-4">

--- a/web/src/components/Sidebar.jsx
+++ b/web/src/components/Sidebar.jsx
@@ -11,6 +11,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { assetPath } from "@/config";
 import { ProfileContext } from "@/components/ProfileSelect";
+import PropTypes from "prop-types";
 
 const navigation = [
     { name: "Dashboard", href: "/dashboard", icon: HomeIcon },
@@ -28,7 +29,7 @@ function classNames(...classes) {
     return classes.filter(Boolean).join(" ");
 }
 
-function Sidebar() {
+function Sidebar({ collapsed = false }) {
     const location = useLocation();
     const pathname = location.pathname;
     const { profile } = useContext(ProfileContext);
@@ -37,98 +38,109 @@ function Sidebar() {
     const isCurrent = (href) => pathname === href || pathname.startsWith(href + "/");
     const isDisabled = (item) => item.slurmOnly && !isSlurm;
 
+    const renderItem = (item) => {
+        const current = isCurrent(item.href);
+        const disabled = isDisabled(item);
+        const iconClasses = classNames(
+            current
+                ? "text-gray-900 dark:text-white"
+                : "text-gray-700 group-hover:text-gray-400 dark:text-gray-200 dark:group-hover:text-white",
+            "h-6 w-6 shrink-0"
+        );
+        const rowClasses = classNames(
+            "group flex items-center gap-x-3 rounded-md p-2 text-sm",
+            collapsed && "justify-center"
+        );
+
+        if (disabled) {
+            return (
+                <span
+                    className={classNames(
+                        rowClasses,
+                        "text-gray-400 dark:text-white/50 cursor-not-allowed"
+                    )}
+                    title={collapsed ? `${item.name} — requires Slurm profile` : "Requires Slurm profile"}
+                >
+                    <item.icon
+                        aria-hidden="true"
+                        className="h-6 w-6 shrink-0 text-gray-400 dark:text-white/50"
+                    />
+                    {!collapsed && item.name}
+                </span>
+            );
+        }
+
+        return (
+            <Link
+                to={item.href}
+                title={collapsed ? item.name : undefined}
+                className={classNames(
+                    current
+                        ? "bg-gray-100 dark:bg-white/10 text-gray-900 dark:text-white font-medium"
+                        : "text-gray-700 dark:text-gray-200 font-normal hover:text-gray-400 dark:hover:text-white",
+                    rowClasses
+                )}
+            >
+                <item.icon aria-hidden="true" className={iconClasses} />
+                {!collapsed && item.name}
+            </Link>
+        );
+    };
+
     return (
-        <div className="flex grow flex-col gap-y-5 overflow-y-auto border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-blue-500 pl-6 pr-4 pt-4">
-            {/* Logo - only visible in mobile drawer */}
-            <div className="flex h-12 shrink-0 items-center lg:hidden">
-                <Link to="/dashboard" className="flex items-center gap-2">
+        <div
+            className={classNames(
+                "flex grow flex-col gap-y-5 overflow-y-auto overflow-x-hidden border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-blue-500 pt-4",
+                collapsed ? "px-2" : "pl-6 pr-4"
+            )}
+        >
+            {/* Logo header - orca mark, aligned with the nav icons below */}
+            <div className="-mx-2 shrink-0">
+                <div
+                    className={classNames(
+                        "flex items-center p-2",
+                        collapsed ? "justify-center" : "pl-1"
+                    )}
+                >
                     <img
-                        className="h-8 w-8 dark:drop-shadow-[0_0_8px_rgba(255,255,255,0.6)]"
+                        className="h-10 w-10 shrink-0 dark:drop-shadow-[0_0_8px_rgba(255,255,255,0.6)]"
                         src={assetPath("/img/orca.png")}
                         alt="blackfish"
                     />
-                    <span className="text-2xl text-gray-900 dark:text-white font-semibold leading-none pt-2 tracking-wider font-logo">Blackfish</span>
-                </Link>
+                </div>
             </div>
             <nav className="flex flex-1 flex-col">
                 <ul role="list" className="flex flex-1 flex-col gap-y-7 pt-4">
                     <li>
                         <ul role="list" className="-mx-2 space-y-1">
                             {navigation.map((item) => (
-                                <li key={item.name}>
-                                    {isDisabled(item) ? (
-                                        <span
-                                            className="group flex gap-x-3 rounded-md p-2 text-sm text-gray-400 dark:text-white/50 cursor-not-allowed"
-                                            title="Requires Slurm profile"
-                                        >
-                                            <item.icon
-                                                aria-hidden="true"
-                                                className="h-6 w-6 shrink-0 text-gray-400 dark:text-white/50"
-                                            />
-                                            {item.name}
-                                        </span>
-                                    ) : (
-                                        <Link
-                                            to={item.href}
-                                            className={classNames(
-                                                isCurrent(item.href)
-                                                    ? "bg-gray-100 dark:bg-white/10 text-gray-900 dark:text-white font-medium"
-                                                    : "text-gray-700 dark:text-gray-200 font-normal hover:text-gray-400 dark:hover:text-white",
-                                                "group flex gap-x-3 rounded-md p-2 text-sm"
-                                            )}
-                                        >
-                                            <item.icon
-                                                aria-hidden="true"
-                                                className={classNames(
-                                                    isCurrent(item.href)
-                                                        ? "text-gray-900 dark:text-white"
-                                                        : "text-gray-700 group-hover:text-gray-400 dark:text-gray-200 dark:group-hover:text-white",
-                                                    "h-6 w-6 shrink-0"
-                                                )}
-                                            />
-                                            {item.name}
-                                        </Link>
-                                    )}
-                                </li>
+                                <li key={item.name}>{renderItem(item)}</li>
                             ))}
                         </ul>
                     </li>
                     <li>
-                        <div className="text-xs font-semibold text-gray-400 dark:text-gray-100">Services</div>
-                        <ul role="list" className="-mx-2 mt-2 space-y-1">
+                        {!collapsed && (
+                            <div className="text-xs font-semibold text-gray-400 dark:text-gray-100">Services</div>
+                        )}
+                        <ul role="list" className={classNames("-mx-2 space-y-1", !collapsed && "mt-2")}>
                             {secondaryNavigation.map((item) => (
-                                <li key={item.name}>
-                                    <Link
-                                        to={item.href}
-                                        className={classNames(
-                                            isCurrent(item.href)
-                                                ? "bg-gray-100 dark:bg-white/10 text-gray-900 dark:text-white font-medium"
-                                                : "text-gray-700 dark:text-gray-200 font-normal hover:text-gray-400 dark:hover:text-gray-100",
-                                            "group flex gap-x-3 rounded-md p-2 text-sm"
-                                        )}
-                                    >
-                                        <item.icon
-                                            aria-hidden="true"
-                                            className={classNames(
-                                                isCurrent(item.href) ? "text-gray-900 dark:text-white" : "text-gray-700 group-hover:text-gray-400 dark:text-gray-200 dark:group-hover:text-white",
-                                                "h-6 w-6 shrink-0"
-                                            )}
-                                        />
-                                        {item.name}
-                                    </Link>
-                                </li>
+                                <li key={item.name}>{renderItem(item)}</li>
                             ))}
                         </ul>
                     </li>
-                    <li className="-ml-6 -mr-4 mt-auto">
+                    <li className={classNames("mt-auto", collapsed ? "-mx-2" : "-ml-6 -mr-4")}>
                         <a
                             href="https://github.com/princeton-ddss/blackfish/issues"
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="group flex items-center gap-x-3 pl-6 pr-4 py-3 text-sm font-normal text-gray-700 dark:text-gray-200 hover:text-gray-400 dark:hover:text-white"
+                            title={collapsed ? "Feedback" : undefined}
+                            className={classNames(
+                                "group flex items-center gap-x-3 py-3 text-sm font-normal text-gray-700 dark:text-gray-200 hover:text-gray-400 dark:hover:text-white",
+                                collapsed ? "justify-center px-2" : "pl-6 pr-4"
+                            )}
                         >
-                            <ChatBubbleLeftEllipsisIcon className="h-6 w-6 text-gray-400 dark:text-gray-200 group-hover:text-gray-300 dark:group-hover:text-white" aria-hidden="true" />
-                            Feedback
+                            <ChatBubbleLeftEllipsisIcon className="h-6 w-6 shrink-0 text-gray-400 dark:text-gray-200 group-hover:text-gray-300 dark:group-hover:text-white" aria-hidden="true" />
+                            {!collapsed && "Feedback"}
                         </a>
                     </li>
                 </ul>
@@ -136,5 +148,9 @@ function Sidebar() {
         </div>
     );
 }
+
+Sidebar.propTypes = {
+    collapsed: PropTypes.bool,
+};
 
 export default Sidebar;

--- a/web/src/layouts/RootLayout.jsx
+++ b/web/src/layouts/RootLayout.jsx
@@ -13,6 +13,7 @@ import { SettingsProvider } from "@/providers/SettingsProvider";
 function RootLayoutContent() {
   const location = useLocation();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   const pathname = location.pathname;
   const isLoginPage = pathname.endsWith("login");
@@ -62,15 +63,28 @@ function RootLayoutContent() {
           </div>
         </Dialog>
 
-        <Navbar showSidebar onOpenSidebar={() => setSidebarOpen(true)} />
+        <Navbar
+          showSidebar
+          onOpenSidebar={() => setSidebarOpen(true)}
+          sidebarCollapsed={sidebarCollapsed}
+          onToggleSidebarCollapse={() => setSidebarCollapsed((v) => !v)}
+        />
 
         {/* Static sidebar for desktop - positioned below header */}
-        <div className="hidden lg:fixed lg:top-12 lg:bottom-0 lg:left-0 lg:z-40 lg:flex lg:w-72 lg:flex-col">
-          <Sidebar />
+        <div
+          className={`hidden lg:fixed lg:top-12 lg:bottom-0 lg:left-0 lg:z-40 lg:flex lg:flex-col transition-[width] duration-200 ease-in-out ${
+            sidebarCollapsed ? "lg:w-16" : "lg:w-72"
+          }`}
+        >
+          <Sidebar collapsed={sidebarCollapsed} />
         </div>
 
         {/* Main content */}
-        <main className="lg:pl-72">
+        <main
+          className={`transition-[padding] duration-200 ease-in-out ${
+            sidebarCollapsed ? "lg:pl-16" : "lg:pl-72"
+          }`}
+        >
           <div className="px-4 py-6 sm:px-6 lg:px-8 lg:pt-16">
             <Outlet />
           </div>


### PR DESCRIPTION
## Summary

- Add a collapse toggle in the desktop navbar that shrinks the left nav sidebar to an icon-only rail (`lg:w-72` → `lg:w-16`), reclaiming horizontal space for page content. State is session-only (resets to expanded on reload).
- When collapsed, nav items render icon-only with hover tooltips; the "Services" heading hides and the orca logo centers in the rail.
- Move the orca logo into the sidebar header (aligned with the nav icons) and remove it from the navbar's left slot, which now holds the collapse toggle. The dashboard navbar variant keeps its own logo unchanged.

## Test plan

- `npm run lint` — clean (one pre-existing unrelated warning)
- `npm test` — 390/390 pass
- Manual: on a service page (e.g. text-generation), click the navbar toggle and confirm the sidebar collapses/expands with the main content reflowing; verify nav tooltips appear when collapsed, active-route highlighting still works, and the mobile drawer is unaffected (always full-width with labels). Confirm the dashboard page's header/logo is unchanged.