### PR TITLE
feat(web): resume a terminal batch job from the details panel

### DIFF
--- a/web/src/lib/requests.js
+++ b/web/src/lib/requests.js
@@ -664,6 +664,28 @@ export async function stopJob(jobId) {
   return res.json();
 }
 
+/** Resume a terminal batch job (stopped, stalled, or exhausted). */
+export async function resumeJob(jobId) {
+  const res = await fetch(`${blackfishApiURL}/api/jobs/${jobId}/resume`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  if (!res.ok) {
+    let message = "Failed to resume job";
+    try {
+      const body = await res.json();
+      if (body.detail) message = body.detail;
+    } catch {
+      // Ignore JSON parse errors
+    }
+    const error = new Error(message);
+    error.status = res.status;
+    throw error;
+  }
+  return res.json();
+}
+
 /** Create a new batch job. */
 export async function createJob(jobData) {
   const res = await fetch(`${blackfishApiURL}/api/jobs`, {

--- a/web/src/lib/requests.test.js
+++ b/web/src/lib/requests.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { buildContainerConfig, setDefaultProfile } from "@/lib/requests";
+import { buildContainerConfig, setDefaultProfile, resumeJob } from "@/lib/requests";
 
 describe("buildContainerConfig", () => {
   it("strips disable_thinking when false and adds no launch_kwargs", () => {
@@ -82,5 +82,58 @@ describe("setDefaultProfile", () => {
       message: "Failed to set default profile.",
       status: 500,
     });
+  });
+});
+
+describe("resumeJob", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("PUTs to the job's resume endpoint and returns the updated job", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "job-001", status: "resubmitted" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await resumeJob("job-001");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toContain("/api/jobs/job-001/resume");
+    expect(options.method).toBe("PUT");
+    expect(result).toEqual({ id: "job-001", status: "resubmitted" });
+  });
+
+  it("throws the server detail so the caller can show why a resume was refused", async () => {
+    // e.g. a job whose input_dir was deleted since it ran, or a BROKEN job.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({ detail: "Input directory does not exist" }),
+      })
+    );
+
+    await expect(resumeJob("job-001")).rejects.toThrow(
+      "Input directory does not exist"
+    );
+  });
+
+  it("falls back to a generic message when the body has no detail", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => {
+          throw new Error("not json");
+        },
+      })
+    );
+
+    await expect(resumeJob("job-001")).rejects.toThrow("Failed to resume job");
   });
 });

--- a/web/src/lib/util.js
+++ b/web/src/lib/util.js
@@ -64,6 +64,19 @@ const BATCH_JOB_ACTIVE_STATUSES = new Set([
 export const isBatchJobActive = (status) =>
   BATCH_JOB_ACTIVE_STATUSES.has(status);
 
+// Terminal statuses a job can be resumed from — mirrors the backend's
+// _RESUMABLE_STATUSES. Resubmitting continues against the same output dir
+// (finished files are skipped). BROKEN is excluded: a metadata/config error a
+// resubmit can't fix.
+const BATCH_JOB_RESUMABLE_STATUSES = new Set([
+  BatchJobStatus.STOPPED,
+  BatchJobStatus.STALLED,
+  BatchJobStatus.EXHAUSTED,
+]);
+
+export const isBatchJobResumable = (status) =>
+  BATCH_JOB_RESUMABLE_STATUSES.has(status);
+
 /**
  * Compute batch-job progress for display.
  *

--- a/web/src/lib/util.test.js
+++ b/web/src/lib/util.test.js
@@ -14,6 +14,7 @@ import {
   isServiceRunning,
   selectTierByModelSize,
   isBatchJobActive,
+  isBatchJobResumable,
   batchProgress,
   elapsedMs,
   formatElapsed,
@@ -419,6 +420,20 @@ describe("Utils", () => {
     it("is false for terminal statuses", () => {
       for (const s of ["stopped", "stalled", "exhausted", "broken"]) {
         expect(isBatchJobActive(s)).toBe(false);
+      }
+    });
+  });
+
+  describe("isBatchJobResumable", () => {
+    it("is true for resumable terminal statuses", () => {
+      for (const s of ["stopped", "stalled", "exhausted"]) {
+        expect(isBatchJobResumable(s)).toBe(true);
+      }
+    });
+
+    it("is false for broken (not resumable) and active statuses", () => {
+      for (const s of ["broken", "submitted", "resubmitted", "pending", "running"]) {
+        expect(isBatchJobResumable(s)).toBe(false);
       }
     });
   });

--- a/web/src/routes/jobs/components/JobDetailsPanel.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.jsx
@@ -151,7 +151,11 @@ function JobDetailsPanel({ job, onStopJob, onResumeJob, onDeleteJob, jobActionIn
                     </p>
                 </div>
                 <div className="flex items-center gap-2.5">
-                    <StatusBadge status={job.status} errored={job.errored} />
+                    <StatusBadge
+                        status={job.status}
+                        errored={job.errored}
+                        pulse={jobActionInProgress === job.id}
+                    />
                     <div className="flex items-center gap-0.5">
                         {isBatchJobActive(job.status) && onStopJob && (
                             <button

--- a/web/src/routes/jobs/components/JobDetailsPanel.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.jsx
@@ -6,9 +6,10 @@ import {
     StopIcon,
     TrashIcon,
     ExclamationTriangleIcon,
+    PlayIcon,
 } from "@heroicons/react/24/outline";
 import StatusBadge from "./StatusBadge";
-import { isBatchJobActive, batchProgress } from "@/lib/util";
+import { isBatchJobActive, isBatchJobResumable, batchProgress } from "@/lib/util";
 import PropTypes from "prop-types";
 
 // A batch job resubmits its Slurm allocation until the input dir is fully
@@ -46,7 +47,8 @@ export function terminalReason(job) {
                 detail:
                     `No files were processed across ${n} restart${n === 1 ? "" : "s"}` +
                     (total != null ? `; stopped at ${highwater}/${total}.` : ".") +
-                    " A file may be failing repeatedly.",
+                    " A file is likely failing repeatedly — remove or fix it before" +
+                    " resuming, or the job will stall again.",
             };
         }
         default:
@@ -113,7 +115,7 @@ ProgressBar.propTypes = {
     total: PropTypes.number,
 };
 
-function JobDetailsPanel({ job, onStopJob, onDeleteJob, jobActionInProgress }) {
+function JobDetailsPanel({ job, onStopJob, onResumeJob, onDeleteJob, jobActionInProgress }) {
     if (!job) {
         return (
             <div className="bg-white dark:bg-gray-800 p-6 h-full flex flex-col justify-center">
@@ -148,30 +150,44 @@ function JobDetailsPanel({ job, onStopJob, onDeleteJob, jobActionInProgress }) {
                         {job.id}
                     </p>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2.5">
                     <StatusBadge status={job.status} errored={job.errored} />
-                    {isBatchJobActive(job.status) && onStopJob && (
-                        <button
-                            type="button"
-                            onClick={() => onStopJob(job)}
-                            disabled={jobActionInProgress === job.id}
-                            aria-label="Stop job"
-                            className="p-1.5 rounded-md text-gray-500 hover:text-red-600 hover:bg-red-50 dark:text-gray-400 dark:hover:text-red-400 dark:hover:bg-red-900/20 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none"
-                        >
-                            <StopIcon className={`h-5 w-5 ${jobActionInProgress === job.id ? "animate-pulse" : ""}`} />
-                        </button>
-                    )}
-                    {!isBatchJobActive(job.status) && onDeleteJob && (
-                        <button
-                            type="button"
-                            onClick={() => onDeleteJob(job)}
-                            disabled={jobActionInProgress === job.id}
-                            aria-label="Delete job"
-                            className="p-1.5 rounded-md text-gray-500 hover:text-red-600 hover:bg-red-50 dark:text-gray-400 dark:hover:text-red-400 dark:hover:bg-red-900/20 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none"
-                        >
-                            <TrashIcon className={`h-5 w-5 ${jobActionInProgress === job.id ? "animate-pulse" : ""}`} />
-                        </button>
-                    )}
+                    <div className="flex items-center gap-0.5">
+                        {isBatchJobActive(job.status) && onStopJob && (
+                            <button
+                                type="button"
+                                onClick={() => onStopJob(job)}
+                                disabled={jobActionInProgress === job.id}
+                                aria-label="Stop job"
+                                className="p-1.5 rounded-md text-gray-500 hover:text-red-600 hover:bg-red-50 dark:text-gray-400 dark:hover:text-red-400 dark:hover:bg-red-900/20 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none"
+                            >
+                                <StopIcon className={`h-5 w-5 ${jobActionInProgress === job.id ? "animate-pulse" : ""}`} />
+                            </button>
+                        )}
+                        {isBatchJobResumable(job.status) && onResumeJob && (
+                            <button
+                                type="button"
+                                onClick={() => onResumeJob(job)}
+                                disabled={jobActionInProgress === job.id}
+                                aria-label="Resume job"
+                                title="Resume job"
+                                className="p-1.5 rounded-md text-gray-500 hover:text-green-600 hover:bg-green-50 dark:text-gray-400 dark:hover:text-green-400 dark:hover:bg-green-900/20 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none"
+                            >
+                                <PlayIcon className={`h-5 w-5 ${jobActionInProgress === job.id ? "animate-pulse" : ""}`} />
+                            </button>
+                        )}
+                        {!isBatchJobActive(job.status) && onDeleteJob && (
+                            <button
+                                type="button"
+                                onClick={() => onDeleteJob(job)}
+                                disabled={jobActionInProgress === job.id}
+                                aria-label="Delete job"
+                                className="p-1.5 rounded-md text-gray-500 hover:text-red-600 hover:bg-red-50 dark:text-gray-400 dark:hover:text-red-400 dark:hover:bg-red-900/20 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none"
+                            >
+                                <TrashIcon className={`h-5 w-5 ${jobActionInProgress === job.id ? "animate-pulse" : ""}`} />
+                            </button>
+                        )}
+                    </div>
                 </div>
             </div>
 
@@ -377,6 +393,7 @@ JobDetailsPanel.propTypes = {
         params: PropTypes.object,
     }),
     onStopJob: PropTypes.func,
+    onResumeJob: PropTypes.func,
     onDeleteJob: PropTypes.func,
     jobActionInProgress: PropTypes.string,
 };

--- a/web/src/routes/jobs/components/JobDetailsPanel.test.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.test.jsx
@@ -94,6 +94,9 @@ describe("terminalReason", () => {
     expect(r.detail).toContain("across 1 restart");
     expect(r.detail).toContain("stopped at 41/44");
     expect(r.detail).toContain("failing repeatedly");
+    // Warns the user to fix the input before resuming (else it re-stalls).
+    expect(r.detail).toContain("before");
+    expect(r.detail).toContain("resuming");
   });
 
   test("omits the total when staged is unknown (between allocations)", () => {

--- a/web/src/routes/jobs/components/JobDetailsPanel.test.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.test.jsx
@@ -1,6 +1,12 @@
-import { describe, test, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, test, expect, vi } from "vitest";
 
-import { formatParamLabel, formatParamValue, terminalReason } from "./JobDetailsPanel";
+import JobDetailsPanel, {
+  formatParamLabel,
+  formatParamValue,
+  terminalReason,
+} from "./JobDetailsPanel";
 
 describe("formatParamLabel", () => {
   test("uses friendly labels for known params", () => {
@@ -110,5 +116,64 @@ describe("terminalReason", () => {
     });
     expect(r.detail).toContain("across 2 restarts");
     expect(r.detail).not.toContain("stopped at");
+  });
+});
+
+describe("JobDetailsPanel resume action", () => {
+  const job = (status) => ({
+    id: "job-001",
+    name: "Batch Translation",
+    status,
+    finished: 10,
+    staged: 5,
+    errored: 0,
+  });
+
+  function renderPanel(status, props = {}) {
+    return render(
+      <JobDetailsPanel
+        job={job(status)}
+        onResumeJob={vi.fn()}
+        onStopJob={vi.fn()}
+        onDeleteJob={vi.fn()}
+        {...props}
+      />,
+    );
+  }
+
+  test.each(["stopped", "stalled", "exhausted"])(
+    "offers Resume for a %s job",
+    (status) => {
+      renderPanel(status);
+      expect(screen.getByLabelText("Resume job")).toBeInTheDocument();
+    },
+  );
+
+  test.each(["broken", "running", "pending", "submitted", "resubmitted"])(
+    "does not offer Resume for a %s job",
+    (status) => {
+      renderPanel(status);
+      expect(screen.queryByLabelText("Resume job")).not.toBeInTheDocument();
+    },
+  );
+
+  test("calls onResumeJob with the job", async () => {
+    const onResumeJob = vi.fn();
+    renderPanel("exhausted", { onResumeJob });
+
+    await userEvent.click(screen.getByLabelText("Resume job"));
+
+    expect(onResumeJob).toHaveBeenCalledTimes(1);
+    expect(onResumeJob.mock.calls[0][0].id).toBe("job-001");
+  });
+
+  test("disables Resume while an action is in flight for that job", () => {
+    renderPanel("stopped", { jobActionInProgress: "job-001" });
+    expect(screen.getByLabelText("Resume job")).toBeDisabled();
+  });
+
+  test("omits Resume when no handler is supplied", () => {
+    render(<JobDetailsPanel job={job("stopped")} />);
+    expect(screen.queryByLabelText("Resume job")).not.toBeInTheDocument();
   });
 });

--- a/web/src/routes/jobs/components/JobsContainer.jsx
+++ b/web/src/routes/jobs/components/JobsContainer.jsx
@@ -294,6 +294,9 @@ function JobsContainer() {
 
     const handleStopJob = async (job) => {
         setJobActionInProgress(job.id);
+        // Clear both: a stale success from a previous action would otherwise
+        // sit alongside this one's error, each describing a different job.
+        setOperationSuccess(null);
         setOperationError(null);
         try {
             const updated = await stopJob(job.id);
@@ -323,6 +326,9 @@ function JobsContainer() {
 
     const handleResumeJob = async (job) => {
         setJobActionInProgress(job.id);
+        // Clear both: a stale success from a previous action would otherwise
+        // sit alongside this one's error, each describing a different job.
+        setOperationSuccess(null);
         setOperationError(null);
         try {
             const updated = await resumeJob(job.id);
@@ -357,6 +363,9 @@ function JobsContainer() {
 
     const handleDeleteJob = async (job) => {
         setJobActionInProgress(job.id);
+        // Clear both: a stale success from a previous action would otherwise
+        // sit alongside this one's error, each describing a different job.
+        setOperationSuccess(null);
         setOperationError(null);
         try {
             await deleteJob(job.id);

--- a/web/src/routes/jobs/components/JobsContainer.jsx
+++ b/web/src/routes/jobs/components/JobsContainer.jsx
@@ -7,6 +7,7 @@ import JobResultsTable from "./JobResultsTable";
 import JobDetailsPanel from "./JobDetailsPanel";
 import ResultPreview from "./ResultPreview";
 import NewJobModal from "./NewJobModal";
+import Notification from "@/components/Notification";
 import { COLUMN_HEIGHT } from "./layout";
 
 // Mock data for development - matches API BatchJob structure
@@ -243,6 +244,8 @@ function JobsContainer() {
     const [isNewPipelineModalOpen, setIsNewPipelineModalOpen] = useState(false);
     const [selectedTask, setSelectedTask] = useState(null);
     const [jobActionInProgress, setJobActionInProgress] = useState(null); // job id being stopped/deleted
+    const [operationSuccess, setOperationSuccess] = useState(null);
+    const [operationError, setOperationError] = useState(null);
 
     // Gate mock data on import.meta.env.DEV so Vite can tree-shake MOCK_JOBS
     // out of production builds. In prod this expression simplifies to `apiJobs`.
@@ -291,17 +294,28 @@ function JobsContainer() {
 
     const handleStopJob = async (job) => {
         setJobActionInProgress(job.id);
+        setOperationError(null);
         try {
-            await stopJob(job.id);
-            // Optimistic update: mark job as stopped immediately
+            const updated = await stopJob(job.id);
+            // Like resume, a failed stop can answer 200 with the job marked
+            // BROKEN (the route maps both a failed scancel and a failed
+            // post-stop refresh to BROKEN), so take the status from the body.
             mutate(
                 (currentJobs) => currentJobs?.map((j) =>
-                    j.id === job.id ? { ...j, status: "stopped" } : j
+                    j.id === job.id ? { ...j, ...updated } : j
                 ),
                 { revalidate: true }
             );
+            if (updated?.status === "broken") {
+                setOperationError(
+                    `Could not stop ${job.name}. The job is now marked broken.`
+                );
+            } else {
+                setOperationSuccess(`Stopped ${job.name}.`);
+            }
         } catch (err) {
             console.error("Failed to stop job:", err);
+            setOperationError(`Could not stop ${job.name}. ${err.message}`);
         } finally {
             setJobActionInProgress(null);
         }
@@ -309,17 +323,33 @@ function JobsContainer() {
 
     const handleResumeJob = async (job) => {
         setJobActionInProgress(job.id);
+        setOperationError(null);
         try {
-            await resumeJob(job.id);
-            // Optimistic update: the backend resubmits and sets RESUBMITTED.
+            const updated = await resumeJob(job.id);
+            // A failed resubmit still answers 200: the route catches the
+            // TigerFlowError and returns the job marked BROKEN. Take the status
+            // from the response rather than assuming RESUBMITTED, or the UI
+            // reports success for a resume that didn't happen.
             mutate(
                 (currentJobs) => currentJobs?.map((j) =>
-                    j.id === job.id ? { ...j, status: "resubmitted" } : j
+                    j.id === job.id ? { ...j, ...updated } : j
                 ),
                 { revalidate: true }
             );
+            if (updated?.status === "broken") {
+                setOperationError(
+                    `Could not resume ${job.name}. The job could not be resubmitted and is now marked broken.`
+                );
+            } else {
+                setOperationSuccess(`Resumed ${job.name}.`);
+            }
         } catch (err) {
+            // No rollback needed: the badge still shows the job's real status,
+            // since nothing is written until the server answers.
+            // The server says why it refused (not resumable, input_dir gone,
+            // image unstaged); surface that instead of failing silently.
             console.error("Failed to resume job:", err);
+            setOperationError(`Could not resume ${job.name}. ${err.message}`);
         } finally {
             setJobActionInProgress(null);
         }
@@ -327,19 +357,23 @@ function JobsContainer() {
 
     const handleDeleteJob = async (job) => {
         setJobActionInProgress(job.id);
+        setOperationError(null);
         try {
             await deleteJob(job.id);
-            // Clear selection if deleted job was selected
+            // Unlike stop/resume this waits for the response before touching
+            // the list: a row that vanishes and then comes back on failure is
+            // worse than one that lingers for the length of the request.
             if (selectedJobId === job.id) {
                 setSelectedJobId(null);
             }
-            // Optimistic update: remove job from list immediately
             mutate(
                 (currentJobs) => currentJobs?.filter((j) => j.id !== job.id),
                 { revalidate: true }
             );
+            setOperationSuccess(`Deleted ${job.name}.`);
         } catch (err) {
             console.error("Failed to delete job:", err);
+            setOperationError(`Could not delete ${job.name}. ${err.message}`);
         } finally {
             setJobActionInProgress(null);
         }
@@ -390,6 +424,7 @@ function JobsContainer() {
                         onRefresh={() => mutate()}
                         useMockData={useMockData}
                         setUseMockData={setUseMockData}
+                        jobActionInProgress={jobActionInProgress}
                     />
                 )}
             </div>
@@ -424,6 +459,19 @@ function JobsContainer() {
                 profile={profile}
                 task={selectedTask}
                 onJobCreated={handleJobCreated}
+            />
+
+            <Notification
+                show={!!operationSuccess}
+                variant="success"
+                message={operationSuccess}
+                onDismiss={() => setOperationSuccess(null)}
+            />
+            <Notification
+                show={!!operationError}
+                variant="error"
+                message={operationError}
+                onDismiss={() => setOperationError(null)}
             />
         </div>
     );

--- a/web/src/routes/jobs/components/JobsContainer.jsx
+++ b/web/src/routes/jobs/components/JobsContainer.jsx
@@ -1,7 +1,7 @@
 import { useContext, useState } from "react";
 import { ProfileContext } from "@/components/ProfileSelect";
 import { useJobs, useJobResults } from "@/lib/loaders";
-import { stopJob, deleteJob } from "@/lib/requests";
+import { stopJob, resumeJob, deleteJob } from "@/lib/requests";
 import JobsTable from "./JobsTable";
 import JobResultsTable from "./JobResultsTable";
 import JobDetailsPanel from "./JobDetailsPanel";
@@ -307,6 +307,24 @@ function JobsContainer() {
         }
     };
 
+    const handleResumeJob = async (job) => {
+        setJobActionInProgress(job.id);
+        try {
+            await resumeJob(job.id);
+            // Optimistic update: the backend resubmits and sets RESUBMITTED.
+            mutate(
+                (currentJobs) => currentJobs?.map((j) =>
+                    j.id === job.id ? { ...j, status: "resubmitted" } : j
+                ),
+                { revalidate: true }
+            );
+        } catch (err) {
+            console.error("Failed to resume job:", err);
+        } finally {
+            setJobActionInProgress(null);
+        }
+    };
+
     const handleDeleteJob = async (job) => {
         setJobActionInProgress(job.id);
         try {
@@ -392,6 +410,7 @@ function JobsContainer() {
                         <JobDetailsPanel
                             job={selectedJob}
                             onStopJob={handleStopJob}
+                            onResumeJob={handleResumeJob}
                             onDeleteJob={handleDeleteJob}
                             jobActionInProgress={jobActionInProgress}
                         />

--- a/web/src/routes/jobs/components/JobsContainer.test.jsx
+++ b/web/src/routes/jobs/components/JobsContainer.test.jsx
@@ -1,0 +1,163 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+import { ProfileContext } from "@/components/ProfileSelect";
+import { useJobs, useJobResults } from "@/lib/loaders";
+import { stopJob, resumeJob, deleteJob } from "@/lib/requests";
+import JobsContainer from "./JobsContainer";
+
+vi.mock("@/lib/loaders");
+vi.mock("@/lib/requests");
+// The modal needs RemoteFileSystemProvider, which is irrelevant here. JobsTable
+// imports TASKS from the same module, so the stub has to keep exporting it.
+vi.mock("./NewJobModal", () => ({
+  default: () => null,
+  TASKS: [
+    { id: "transcribe", name: "Transcribe", description: "Speech to text" },
+    { id: "translate", name: "Translate", description: "Translate text" },
+  ],
+}));
+
+const STOPPED_JOB = {
+  id: "job-001",
+  name: "Batch Translation",
+  status: "stopped",
+  created_at: "2024-01-15T10:30:00Z",
+  finished: 50,
+  staged: 10,
+  errored: 0,
+  restarts: 3,
+  stalled_restarts: 0,
+  task: "translate",
+};
+
+const mutate = vi.fn();
+
+function renderContainer(jobs = [STOPPED_JOB]) {
+  useJobs.mockReturnValue({
+    jobs,
+    error: null,
+    isLoading: false,
+    isRefreshing: false,
+    mutate,
+  });
+  useJobResults.mockReturnValue({
+    results: [],
+    error: null,
+    isLoading: false,
+    isRefreshing: false,
+    mutate: vi.fn(),
+  });
+  return render(
+    <ProfileContext.Provider value={{ profile: { name: "adroit", schema: "slurm" } }}>
+      <JobsContainer />
+    </ProfileContext.Provider>,
+  );
+}
+
+// Select the job so JobDetailsPanel (which owns the action buttons) renders it.
+async function selectJobAndResume(user) {
+  await user.click(screen.getByText("Batch Translation"));
+  await user.click(await screen.findByLabelText("Resume job"));
+}
+
+describe("JobsContainer resume outcomes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("reports a 200 that comes back BROKEN as a failure, not a success", async () => {
+    // The route catches a failed resubmit and answers 200 with the job marked
+    // BROKEN — the case this feature is built around. Resolving is not success.
+    resumeJob.mockResolvedValue({ id: "job-001", status: "broken" });
+    const user = userEvent.setup();
+    renderContainer();
+
+    await selectJobAndResume(user);
+
+    expect(await screen.findByText(/marked broken/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Resumed/)).not.toBeInTheDocument();
+  });
+
+  test("reports a genuine resume as a success", async () => {
+    resumeJob.mockResolvedValue({ id: "job-001", status: "resubmitted" });
+    const user = userEvent.setup();
+    renderContainer();
+
+    await selectJobAndResume(user);
+
+    expect(
+      await screen.findByText("Resumed Batch Translation."),
+    ).toBeInTheDocument();
+  });
+
+  test("surfaces the server's reason when the request is refused", async () => {
+    resumeJob.mockRejectedValue(
+      new Error("Input directory does not exist on adroit: /scratch/gone"),
+    );
+    const user = userEvent.setup();
+    renderContainer();
+
+    await selectJobAndResume(user);
+
+    expect(
+      await screen.findByText(/Input directory does not exist/),
+    ).toBeInTheDocument();
+  });
+
+  test("does not leave a previous success showing when a later action fails", async () => {
+    resumeJob
+      .mockResolvedValueOnce({ id: "job-001", status: "resubmitted" })
+      .mockRejectedValueOnce(new Error("Job job-001 is not resumable"));
+    const user = userEvent.setup();
+    renderContainer();
+
+    await selectJobAndResume(user);
+    expect(
+      await screen.findByText("Resumed Batch Translation."),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Resume job"));
+
+    expect(await screen.findByText(/is not resumable/)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Resumed Batch Translation."),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});
+
+describe("JobsContainer stop and delete outcomes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("reports a stop that comes back BROKEN as a failure", async () => {
+    // stop_job maps a failed scancel and a failed post-stop refresh to BROKEN,
+    // so it has the same 200-with-BROKEN shape as resume.
+    stopJob.mockResolvedValue({ id: "job-002", status: "broken" });
+    const user = userEvent.setup();
+    renderContainer([{ ...STOPPED_JOB, id: "job-002", status: "running" }]);
+
+    await user.click(screen.getByText("Batch Translation"));
+    await user.click(await screen.findByLabelText("Stop job"));
+
+    expect(await screen.findByText(/marked broken/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Stopped/)).not.toBeInTheDocument();
+  });
+
+  test("reports a successful delete", async () => {
+    deleteJob.mockResolvedValue({});
+    const user = userEvent.setup();
+    renderContainer();
+
+    await user.click(screen.getByText("Batch Translation"));
+    await user.click(await screen.findByLabelText("Delete job"));
+
+    expect(
+      await screen.findByText("Deleted Batch Translation."),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/routes/jobs/components/JobsTable.jsx
+++ b/web/src/routes/jobs/components/JobsTable.jsx
@@ -133,7 +133,7 @@ ProgressDisplay.propTypes = {
     errored: PropTypes.number,
 };
 
-function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = false, isRefreshing = false, onRefresh, onNewClick, profile, useMockData, setUseMockData }) {
+function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = false, isRefreshing = false, onRefresh, onNewClick, profile, useMockData, setUseMockData, jobActionInProgress = null }) {
     const isSlurm = profile?.schema === "slurm";
     const [currentPage, setCurrentPage] = useState(1);
     // See JobResultsTable: a page short enough to fit without scrolling makes
@@ -341,7 +341,11 @@ function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = fa
                                         {lastModified(job.created_at)}
                                     </td>
                                     <td className="whitespace-nowrap py-3 px-3 text-left text-sm">
-                                        <StatusBadge status={job.status} errored={job.errored} />
+                                        <StatusBadge
+                                            status={job.status}
+                                            errored={job.errored}
+                                            pulse={jobActionInProgress === job.id}
+                                        />
                                     </td>
                                     <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-900 dark:text-gray-100">
                                         <ProgressDisplay
@@ -395,6 +399,7 @@ JobsTable.propTypes = {
     profile: PropTypes.object,
     useMockData: PropTypes.bool,
     setUseMockData: PropTypes.func,
+    jobActionInProgress: PropTypes.string,
 };
 
 export default JobsTable;

--- a/web/src/routes/jobs/components/StatusBadge.jsx
+++ b/web/src/routes/jobs/components/StatusBadge.jsx
@@ -1,6 +1,8 @@
 import PropTypes from "prop-types";
 
-function StatusBadge({ status, errored = 0 }) {
+// `pulse` marks a status that isn't settled yet — the badge is showing where
+// the job is headed while a request for it is still in flight.
+function StatusBadge({ status, errored = 0, pulse = false }) {
     const YELLOW = {
         bg: "bg-yellow-50 dark:bg-yellow-900/30",
         text: "text-yellow-700 dark:text-yellow-400",
@@ -54,7 +56,7 @@ function StatusBadge({ status, errored = 0 }) {
     const config = getStatusConfig();
 
     return (
-        <span className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${config.bg} ${config.text} ${config.ring}`}>
+        <span className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${config.bg} ${config.text} ${config.ring} ${pulse ? "animate-pulse" : ""}`}>
             {config.label}
         </span>
     );
@@ -63,6 +65,7 @@ function StatusBadge({ status, errored = 0 }) {
 StatusBadge.propTypes = {
     status: PropTypes.string.isRequired,
     errored: PropTypes.number,
+    pulse: PropTypes.bool,
 };
 
 export default StatusBadge;


### PR DESCRIPTION
## Summary

- Adds a **Resume** action to `JobDetailsPanel`'s header for the terminal statuses the server accepts — stopped, stalled, exhausted. BROKEN is excluded to match `_RESUMABLE_STATUSES`: that status marks a config error a resubmit can't fix, so offering the button would only produce a 400. Extends the STALLED callout to say the failing input must be removed or fixed first, since `max_stalled_restarts` defaults to 1 and resuming as-is re-stalls on the same file.
- **Reports what happened.** All three job actions (stop, resume, delete) previously failed to the console only, so a refused action looked like nothing happened. Each now reports through the existing `Notification` component, as `ModelsContainer` does. Note success and failure are not simply 2xx and 4xx here: stop and resume both answer **200 with the job marked BROKEN** when the underlying operation fails (the routes map a failed `scancel`, a failed post-stop refresh, and a failed resubmit to that), so the cache update takes the status from the response body rather than assuming, and a broken result reports as an error.
- **Pulses the status badge** while an action is in flight, in both the details panel and the job's row — the row being what the user watches during a delete. Nothing is written to the cache before the server answers, so the badge keeps showing the job's real status until there is something true to replace it.

## Test plan

- `cd web && npm test` — **498 passed across 51 files**. New coverage:
  - `JobDetailsPanel`: which statuses offer Resume (stopped/stalled/exhausted) and which don't (broken + the four active ones), the handler call, the disabled in-flight state, and the button's absence when no handler is passed.
  - `resumeJob`: PUTs the right endpoint, propagates the server's `detail` so a refusal can be shown, and falls back to a generic message on an unparseable body.
  - `isBatchJobResumable`: mirrors the backend's resumable set.
  - `terminalReason`: STALLED copy tells the user to fix the input before resuming.
- `npm run lint` — clean apart from a pre-existing `ImageAttachment.jsx` `exhaustive-deps` warning, untouched by this branch.
- `npm run build` — succeeds.

Manual passes were done against the dev server for the success path and the badge/pulse behaviour. The two failure paths (a refused request, and the 200-with-BROKEN response) were exercised by stubbing `fetch`, not against a genuinely failing cluster.

Closes #434