### PR TITLE
fix(ci): make the branch-protection hook actually run

### DIFF
--- a/.claude/hooks/protect-branches.sh
+++ b/.claude/hooks/protect-branches.sh
@@ -1,16 +1,81 @@
 #!/bin/bash
+# PreToolUse(Bash) guard: refuse pushes that would land on a protected branch.
+#
+# Registered once, in .claude/settings.json, via $CLAUDE_PROJECT_DIR so it
+# resolves regardless of the working directory the tool call runs from.
+#
+# Exit 2 blocks the tool call; exit 0 allows it.
 
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // ""')
 
 PROTECTED_BRANCHES=("main" "dev" "production" "release")
 
-for branch in "${PROTECTED_BRANCHES[@]}"; do
-  # Block push to protected branches
-  if echo "$command" | grep -qE "git\s+push.*${branch}"; then
-    echo "ERROR: Cannot push to protected branch: $branch" >&2
-    exit 2
+is_protected() {
+  local branch="$1"
+  for protected in "${PROTECTED_BRANCHES[@]}"; do
+    [[ "$branch" == "$protected" ]] && return 0
+  done
+  return 1
+}
+
+# Resolve what a single `git push ...` invocation would actually write to, and
+# block only on that. Matching the branch name anywhere in the command text
+# would both over-block (`git push origin feat/fix-main-nav`) and under-block
+# (a bare `git push` while main is checked out).
+check_push() {
+  local segment="$1"
+  # shellcheck disable=SC2206
+  local tokens=($segment)
+  local seen_push=0
+  local args=()
+
+  for token in "${tokens[@]}"; do
+    if [[ $seen_push -eq 0 ]]; then
+      [[ "$token" == "push" ]] && seen_push=1
+      continue
+    fi
+    # Options never name a destination, except --delete, which makes the
+    # refspecs deletions of those very branches — still the right thing to
+    # check, so it needs no special case.
+    [[ "$token" == -* ]] && continue
+    args+=("$token")
+  done
+
+  [[ $seen_push -eq 0 ]] && return 0
+
+  # args = [remote] [refspec ...]. With no refspec, git pushes the current
+  # branch (push.default=simple/current), so that is what we must check.
+  if [[ ${#args[@]} -le 1 ]]; then
+    local current
+    current=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || return 0
+    if is_protected "$current"; then
+      echo "ERROR: Refusing to push the checked-out protected branch: $current" >&2
+      return 1
+    fi
+    return 0
   fi
-done
+
+  local refspec dest
+  for refspec in "${args[@]:1}"; do
+    # src:dst pushes to dst; a bare ref pushes to itself; ':dst' deletes dst.
+    dest="${refspec##*:}"
+    dest="${dest#+}"        # +ref forces
+    dest="${dest#refs/heads/}"
+    if is_protected "$dest"; then
+      echo "ERROR: Cannot push to protected branch: $dest" >&2
+      return 1
+    fi
+  done
+  return 0
+}
+
+# A compound command may contain several invocations; check each separately so
+# one segment's arguments aren't read as another's.
+while IFS= read -r segment; do
+  [[ "$segment" =~ git[[:space:]] ]] || continue
+  [[ "$segment" =~ [[:space:]]push([[:space:]]|$) ]] || continue
+  check_push "$segment" || exit 2
+done < <(echo "$command" | tr ';&|\n' '\n')
 
 exit 0


### PR DESCRIPTION
## Summary

- The `PreToolUse` branch-protection hook was **registered twice and fired neither time**, so pushes to protected branches were never actually checked. Both failures surface as non-blocking log noise (`PreToolUse:Bash hook error`), which is easy to scroll past:
  - `settings.json` points at `$CLAUDE_PROJECT_DIR/.claude/hooks/protect-branches.sh`, which resolves — but the script was mode `644`, so `/bin/sh` refused it (`Permission denied`).
  - `settings.local.json` pointed at the bare relative path `.claude/hooks/protect-branches.sh`, which misses whenever a tool call runs from a subdirectory such as `web/` (`No such file or directory`).
- Marks the script executable, and drops the duplicate registration so the hook runs once. That second change is not in this diff — `settings.local.json` is git-ignored — so **each machine needs the `hooks` block removed from its own `.claude/settings.local.json`**; `settings.json`'s `$CLAUDE_PROJECT_DIR` registration is the one to keep, being cwd-independent and shared.
- Resolves the push *destination* instead of substring-matching a branch name anywhere in the command. The old test both over-blocked and under-blocked: `git push origin feat/fix-main-nav` was refused, while a bare `git push` from `main` sailed through. Handles `src:dst`, `+force`, `:delete` refspecs, compound commands, and the no-refspec case (falls back to the current branch).

## Test plan

Driven the way the harness does — JSON on stdin, invoked from the `web/` subdirectory to confirm the path issue is gone:

| Command | Expected | Result |
| --- | --- | --- |
| `git push origin main` | blocked | exit 2 |
| `git push origin HEAD:main` | blocked | exit 2 |
| `git push origin :production` | blocked | exit 2 |
| `git push origin +dev` | blocked | exit 2 |
| `npm test && git push origin release` | blocked | exit 2 |
| `git push origin feat/fix-main-nav` | allowed | exit 0 |
| `git push --force-with-lease origin feat/batch-resume-web` | allowed | exit 0 |
| `git push` (on a feature branch) | allowed | exit 0 |
| `git status`, `git log --oneline -3` | allowed | exit 0 |

Not verified: a bare `git push` while a protected branch is checked out. That path reads the current branch via `git rev-parse --abbrev-ref HEAD` and was confirmed to allow the feature-branch case, but the blocking side is untested.

Known limits, unchanged from the original: a `git push` appearing inside a quoted string (a commit message, say) still counts as a push, and the protected list stays hardcoded in the script.