### PR TITLE
fix(web): track in-flight job actions per job

### DIFF
--- a/web/src/routes/jobs/components/JobDetailsPanel.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.jsx
@@ -115,7 +115,7 @@ ProgressBar.propTypes = {
     total: PropTypes.number,
 };
 
-function JobDetailsPanel({ job, onStopJob, onResumeJob, onDeleteJob, jobActionInProgress }) {
+function JobDetailsPanel({ job, onStopJob, onResumeJob, onDeleteJob, jobActions = {} }) {
     if (!job) {
         return (
             <div className="bg-white dark:bg-gray-800 p-6 h-full flex flex-col justify-center">
@@ -136,6 +136,9 @@ function JobDetailsPanel({ job, onStopJob, onResumeJob, onDeleteJob, jobActionIn
     // total is null before the job's first observation: no denominator to show.
     const pending = total === null ? 0 : total - done - failed;
     const reason = terminalReason(job);
+    // Any action in flight for this job blocks its other actions and marks the
+    // status unsettled — regardless of which action it is.
+    const actionInFlight = Boolean(jobActions[job.id]);
     const restarts = Number(job.restarts) || 0;
 
     return (
@@ -154,41 +157,41 @@ function JobDetailsPanel({ job, onStopJob, onResumeJob, onDeleteJob, jobActionIn
                     <StatusBadge
                         status={job.status}
                         errored={job.errored}
-                        pulse={jobActionInProgress === job.id}
+                        pulse={actionInFlight}
                     />
                     <div className="flex items-center gap-0.5">
                         {isBatchJobActive(job.status) && onStopJob && (
                             <button
                                 type="button"
                                 onClick={() => onStopJob(job)}
-                                disabled={jobActionInProgress === job.id}
+                                disabled={actionInFlight}
                                 aria-label="Stop job"
                                 className="p-1.5 rounded-md text-gray-500 hover:text-red-600 hover:bg-red-50 dark:text-gray-400 dark:hover:text-red-400 dark:hover:bg-red-900/20 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none"
                             >
-                                <StopIcon className={`h-5 w-5 ${jobActionInProgress === job.id ? "animate-pulse" : ""}`} />
+                                <StopIcon className={`h-5 w-5 ${actionInFlight ? "animate-pulse" : ""}`} />
                             </button>
                         )}
                         {isBatchJobResumable(job.status) && onResumeJob && (
                             <button
                                 type="button"
                                 onClick={() => onResumeJob(job)}
-                                disabled={jobActionInProgress === job.id}
+                                disabled={actionInFlight}
                                 aria-label="Resume job"
                                 title="Resume job"
                                 className="p-1.5 rounded-md text-gray-500 hover:text-green-600 hover:bg-green-50 dark:text-gray-400 dark:hover:text-green-400 dark:hover:bg-green-900/20 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none"
                             >
-                                <PlayIcon className={`h-5 w-5 ${jobActionInProgress === job.id ? "animate-pulse" : ""}`} />
+                                <PlayIcon className={`h-5 w-5 ${actionInFlight ? "animate-pulse" : ""}`} />
                             </button>
                         )}
                         {!isBatchJobActive(job.status) && onDeleteJob && (
                             <button
                                 type="button"
                                 onClick={() => onDeleteJob(job)}
-                                disabled={jobActionInProgress === job.id}
+                                disabled={actionInFlight}
                                 aria-label="Delete job"
                                 className="p-1.5 rounded-md text-gray-500 hover:text-red-600 hover:bg-red-50 dark:text-gray-400 dark:hover:text-red-400 dark:hover:bg-red-900/20 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none"
                             >
-                                <TrashIcon className={`h-5 w-5 ${jobActionInProgress === job.id ? "animate-pulse" : ""}`} />
+                                <TrashIcon className={`h-5 w-5 ${actionInFlight ? "animate-pulse" : ""}`} />
                             </button>
                         )}
                     </div>
@@ -399,7 +402,8 @@ JobDetailsPanel.propTypes = {
     onStopJob: PropTypes.func,
     onResumeJob: PropTypes.func,
     onDeleteJob: PropTypes.func,
-    jobActionInProgress: PropTypes.string,
+    // job id -> action in flight for it ("stop" | "resume" | "delete").
+    jobActions: PropTypes.objectOf(PropTypes.string),
 };
 
 export default JobDetailsPanel;

--- a/web/src/routes/jobs/components/JobDetailsPanel.test.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.test.jsx
@@ -168,8 +168,13 @@ describe("JobDetailsPanel resume action", () => {
   });
 
   test("disables Resume while an action is in flight for that job", () => {
-    renderPanel("stopped", { jobActionInProgress: "job-001" });
+    renderPanel("stopped", { jobActions: { "job-001": "resume" } });
     expect(screen.getByLabelText("Resume job")).toBeDisabled();
+  });
+
+  test("stays enabled while a different job's action is in flight", () => {
+    renderPanel("stopped", { jobActions: { "job-002": "stop" } });
+    expect(screen.getByLabelText("Resume job")).toBeEnabled();
   });
 
   test("omits Resume when no handler is supplied", () => {

--- a/web/src/routes/jobs/components/JobsContainer.jsx
+++ b/web/src/routes/jobs/components/JobsContainer.jsx
@@ -243,9 +243,29 @@ function JobsContainer() {
     const [viewingResults, setViewingResults] = useState(false);
     const [isNewPipelineModalOpen, setIsNewPipelineModalOpen] = useState(false);
     const [selectedTask, setSelectedTask] = useState(null);
-    const [jobActionInProgress, setJobActionInProgress] = useState(null); // job id being stopped/deleted
+    // job id -> the action in flight for it ("stop" | "resume" | "delete").
+    // Keyed by job because actions on different jobs run concurrently: a single
+    // scalar let the second action clear the first one's in-flight state, which
+    // re-enabled its buttons mid-request.
+    const [jobActions, setJobActions] = useState({});
     const [operationSuccess, setOperationSuccess] = useState(null);
     const [operationError, setOperationError] = useState(null);
+
+    const beginJobAction = (jobId, action) => {
+        setJobActions((prev) => ({ ...prev, [jobId]: action }));
+        // Clear both: a stale success from a previous action would otherwise
+        // sit alongside this one's error, each describing a different job.
+        setOperationSuccess(null);
+        setOperationError(null);
+    };
+
+    const endJobAction = (jobId) => {
+        setJobActions((prev) => {
+            // eslint-disable-next-line no-unused-vars
+            const { [jobId]: _finished, ...rest } = prev;
+            return rest;
+        });
+    };
 
     // Gate mock data on import.meta.env.DEV so Vite can tree-shake MOCK_JOBS
     // out of production builds. In prod this expression simplifies to `apiJobs`.
@@ -293,11 +313,7 @@ function JobsContainer() {
     };
 
     const handleStopJob = async (job) => {
-        setJobActionInProgress(job.id);
-        // Clear both: a stale success from a previous action would otherwise
-        // sit alongside this one's error, each describing a different job.
-        setOperationSuccess(null);
-        setOperationError(null);
+        beginJobAction(job.id, "stop");
         try {
             const updated = await stopJob(job.id);
             // Like resume, a failed stop can answer 200 with the job marked
@@ -320,16 +336,12 @@ function JobsContainer() {
             console.error("Failed to stop job:", err);
             setOperationError(`Could not stop ${job.name}. ${err.message}`);
         } finally {
-            setJobActionInProgress(null);
+            endJobAction(job.id);
         }
     };
 
     const handleResumeJob = async (job) => {
-        setJobActionInProgress(job.id);
-        // Clear both: a stale success from a previous action would otherwise
-        // sit alongside this one's error, each describing a different job.
-        setOperationSuccess(null);
-        setOperationError(null);
+        beginJobAction(job.id, "resume");
         try {
             const updated = await resumeJob(job.id);
             // A failed resubmit still answers 200: the route catches the
@@ -357,16 +369,12 @@ function JobsContainer() {
             console.error("Failed to resume job:", err);
             setOperationError(`Could not resume ${job.name}. ${err.message}`);
         } finally {
-            setJobActionInProgress(null);
+            endJobAction(job.id);
         }
     };
 
     const handleDeleteJob = async (job) => {
-        setJobActionInProgress(job.id);
-        // Clear both: a stale success from a previous action would otherwise
-        // sit alongside this one's error, each describing a different job.
-        setOperationSuccess(null);
-        setOperationError(null);
+        beginJobAction(job.id, "delete");
         try {
             await deleteJob(job.id);
             // Unlike stop/resume this waits for the response before touching
@@ -384,7 +392,7 @@ function JobsContainer() {
             console.error("Failed to delete job:", err);
             setOperationError(`Could not delete ${job.name}. ${err.message}`);
         } finally {
-            setJobActionInProgress(null);
+            endJobAction(job.id);
         }
     };
 
@@ -433,7 +441,7 @@ function JobsContainer() {
                         onRefresh={() => mutate()}
                         useMockData={useMockData}
                         setUseMockData={setUseMockData}
-                        jobActionInProgress={jobActionInProgress}
+                        jobActions={jobActions}
                     />
                 )}
             </div>
@@ -456,7 +464,7 @@ function JobsContainer() {
                             onStopJob={handleStopJob}
                             onResumeJob={handleResumeJob}
                             onDeleteJob={handleDeleteJob}
-                            jobActionInProgress={jobActionInProgress}
+                            jobActions={jobActions}
                         />
                     )}
                 </div>

--- a/web/src/routes/jobs/components/JobsContainer.test.jsx
+++ b/web/src/routes/jobs/components/JobsContainer.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, test, expect, vi, beforeEach } from "vitest";
 
@@ -125,6 +125,52 @@ describe("JobsContainer resume outcomes", () => {
       expect(
         screen.queryByText("Resumed Batch Translation."),
       ).not.toBeInTheDocument(),
+    );
+  });
+});
+
+describe("JobsContainer concurrent actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Regression test for #443: in-flight state used to be a single job id, so
+  // starting an action on a second job cleared the first job's, un-pulsing its
+  // badge and re-enabling its buttons while its request was still outstanding.
+  test("keeps a job's in-flight state when another job's action starts", async () => {
+    const jobA = { ...STOPPED_JOB, id: "job-A", name: "Job A" };
+    const jobB = { ...STOPPED_JOB, id: "job-B", name: "Job B" };
+
+    let finishA;
+    resumeJob
+      .mockImplementationOnce(() => new Promise((resolve) => { finishA = resolve; }))
+      .mockResolvedValueOnce({ id: "job-B", status: "resubmitted" });
+
+    const user = userEvent.setup();
+    renderContainer([jobA, jobB]);
+
+    // The selected job's name also appears in the details panel, so scope row
+    // lookups to the table.
+    const rowFor = (name) =>
+      within(screen.getByRole("table")).getByText(name).closest("tr");
+    const badgeFor = (name) => within(rowFor(name)).getByText("Stopped");
+
+    // Start A's resume; it stays pending.
+    await user.click(rowFor("Job A"));
+    await user.click(await screen.findByLabelText("Resume job"));
+    expect(badgeFor("Job A")).toHaveClass("animate-pulse");
+
+    // Start B's resume and let it finish.
+    await user.click(rowFor("Job B"));
+    await user.click(await screen.findByLabelText("Resume job"));
+    expect(await screen.findByText("Resumed Job B.")).toBeInTheDocument();
+
+    // A is still waiting, so its badge must still say so.
+    expect(badgeFor("Job A")).toHaveClass("animate-pulse");
+
+    finishA({ id: "job-A", status: "resubmitted" });
+    await waitFor(() =>
+      expect(badgeFor("Job A")).not.toHaveClass("animate-pulse"),
     );
   });
 });

--- a/web/src/routes/jobs/components/JobsTable.jsx
+++ b/web/src/routes/jobs/components/JobsTable.jsx
@@ -133,7 +133,7 @@ ProgressDisplay.propTypes = {
     errored: PropTypes.number,
 };
 
-function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = false, isRefreshing = false, onRefresh, onNewClick, profile, useMockData, setUseMockData, jobActionInProgress = null }) {
+function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = false, isRefreshing = false, onRefresh, onNewClick, profile, useMockData, setUseMockData, jobActions = {} }) {
     const isSlurm = profile?.schema === "slurm";
     const [currentPage, setCurrentPage] = useState(1);
     // See JobResultsTable: a page short enough to fit without scrolling makes
@@ -344,7 +344,7 @@ function JobsTable({ jobs, onJobClick, onJobDrillIn, selectedJob, isLoading = fa
                                         <StatusBadge
                                             status={job.status}
                                             errored={job.errored}
-                                            pulse={jobActionInProgress === job.id}
+                                            pulse={Boolean(jobActions[job.id])}
                                         />
                                     </td>
                                     <td className="whitespace-nowrap py-3 px-3 text-left text-sm text-gray-900 dark:text-gray-100">
@@ -399,7 +399,8 @@ JobsTable.propTypes = {
     profile: PropTypes.object,
     useMockData: PropTypes.bool,
     setUseMockData: PropTypes.func,
-    jobActionInProgress: PropTypes.string,
+    // job id -> action in flight for it ("stop" | "resume" | "delete").
+    jobActions: PropTypes.objectOf(PropTypes.string),
 };
 
 export default JobsTable;


### PR DESCRIPTION
## Summary

- `jobActionInProgress` held a **single job id**, but actions on different jobs run concurrently — each button only disabled itself via `jobActionInProgress === job.id`, leaving other rows live. Starting Stop on job A and then Resume on job B overwrote the scalar, so A's badge stopped pulsing and A's buttons re-enabled while A's request was still outstanding, opening the door to a duplicate request on A. Whichever request finished first also nulled the state for both, stripping the survivor's indicator.
- Replaced with a **map of job id → action** (`"stop" | "resume" | "delete"`), added in `beginJobAction` and removed in each handler's `finally` via `endJobAction`. `JobDetailsPanel` and `JobsTable` test membership rather than equality, so a job's controls respond only to its own action.
- Kept the action *type* rather than a bare `Set`: it costs nothing and leaves room to name the running action in the UI later (e.g. a "Stopping…" tooltip).

## Test plan

- `cd web && npm test` — **506 passed across 52 files**. New coverage:
  - `JobsContainer`: a regression test for this bug — job A's resume is left pending, job B's runs to completion, and A's row badge must still be pulsing; it settles only once A's own request resolves. Confirmed the test fails when `beginJobAction` is reverted to replacing the map instead of extending it.
  - `JobDetailsPanel`: a job's button stays enabled while a *different* job's action is in flight.
  - The existing panel test moves from the `jobActionInProgress` string to the `jobActions` map.
- `npm run lint` — clean apart from the pre-existing `ImageAttachment.jsx` `exhaustive-deps` warning.
- `npm run build` — succeeds.

Not covered: the duplicate-request path itself (clicking a re-enabled button mid-request). The fix removes the state that made it reachable, and the pulse assertion stands in for it.

Closes #443