### PR TITLE
fix(lib): include any-to-any models in text-generation launch modal

### DIFF
--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -565,6 +565,7 @@ COMPATIBLE_PIPELINES: dict[str, list[str]] = {
         "audio-text-to-text",
         "video-text-to-text",
         "image-to-text",
+        "any-to-any",
     ],
     "object-detection": [
         "object-detection",


### PR DESCRIPTION
## Summary

- Add `any-to-any` to `COMPATIBLE_PIPELINES["text-generation"]` in `asgi.py`.
- Any-to-any models (e.g. Qwen2.5-Omni) generate text and run on the text-generation runtime, but were absent from the launch modal because the server-side model filter didn't treat `any-to-any` as text-generation-compatible.
- Backend-only, one-line change; mirrors how the other multimodal→text pipeline tags are already handled.

## Test plan

- `pre-commit run --files src/blackfish/server/asgi.py` — all hooks pass.
- `uv run pytest` — 898 passed, 7 skipped.
- Manual: launch the text generation service modal with an any-to-any model registered for the profile and confirm it now appears in the model list.