### PR TITLE
fix(web): re-seed batch job param defaults on modal reopen

### DIFF
--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -870,6 +870,8 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
   // Seed task param defaults on every open, not just when `task` changes: the
   // reset effect above clears taskParams to {} on open, and `task` is a stable
   // reference, so reopening the same task would otherwise leave defaults unset.
+  // Both effects run on open, but this one is a full overwrite (not a merge),
+  // so their order does not matter — this always produces the complete defaults.
   useEffect(() => {
     if (!open || !task) return;
     setTaskParams(getDefaultTaskParams(task));

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -544,6 +544,25 @@ export function coerceParamValue(task, paramName, value) {
   return value;
 }
 
+// The initial taskParams for a task: each param's declared default, plus the
+// default prompt for tasks that require a prompt but have no server-side one.
+// A dropped default here (e.g. OCR's output_format="text") submits a null
+// output_ext and makes tigerflow fall back to its ".out" default, which the
+// task rejects — so the modal must always re-seed these when it opens.
+export function getDefaultTaskParams(task) {
+  if (!task) return {};
+  const defaults = {};
+  task.params.forEach((param) => {
+    if (param.default !== undefined) {
+      defaults[param.name] = param.default;
+    }
+  });
+  if (task.promptRequired && task.defaultPrompt) {
+    defaults.prompt = task.defaultPrompt;
+  }
+  return defaults;
+}
+
 // Translate exposes a single "Source Language" dropdown, but the image has two
 // params: an optional explicit source_lang and an auto_lang_detect boolean.
 // "auto" (not a valid language code) means "detect per file"; a real code is
@@ -848,23 +867,13 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
     }
   }, [open]);
 
-  // Initialize task params when task changes
+  // Seed task param defaults on every open, not just when `task` changes: the
+  // reset effect above clears taskParams to {} on open, and `task` is a stable
+  // reference, so reopening the same task would otherwise leave defaults unset.
   useEffect(() => {
-    if (!task) return;
-    const defaults = {};
-    task.params.forEach((param) => {
-      if (param.default !== undefined) {
-        defaults[param.name] = param.default;
-      }
-    });
-    // A required prompt has no server-side default, so seed the field with the
-    // task's default prompt rather than leaving it blank (which would submit an
-    // empty required param).
-    if (task.promptRequired && task.defaultPrompt) {
-      defaults.prompt = task.defaultPrompt;
-    }
-    setTaskParams(defaults);
-  }, [task]);
+    if (!open || !task) return;
+    setTaskParams(getDefaultTaskParams(task));
+  }, [open, task]);
 
   // Auto-detect language pair from model name for translation task
   useEffect(() => {

--- a/web/src/routes/jobs/components/NewJobModal.test.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.test.jsx
@@ -3,6 +3,7 @@ import { describe, test, expect } from "vitest";
 import {
   TASKS,
   coerceParamValue,
+  getDefaultTaskParams,
   isParamVisible,
   applyTranslateSourceLang,
   buildJobResources,
@@ -40,6 +41,34 @@ describe("coerceParamValue", () => {
 
   test("returns the raw value for an unknown param", () => {
     expect(coerceParamValue(detect, "not_a_param", "x")).toBe("x");
+  });
+});
+
+describe("getDefaultTaskParams", () => {
+  const ocr = TASKS.find((t) => t.id === "ocr");
+
+  test("seeds every param that declares a default", () => {
+    // The modal re-seeds these on each open. A dropped default (the bug: OCR's
+    // output_format="text") submits output_ext=null, so tigerflow falls back to
+    // ".out" and errors every file.
+    const defaults = getDefaultTaskParams(ocr);
+    for (const param of ocr.params) {
+      if (param.default !== undefined) {
+        expect(defaults[param.name]).toBe(param.default);
+      }
+    }
+  });
+
+  test("seeds output_format for OCR (regression for the .out default)", () => {
+    expect(getDefaultTaskParams(ocr).output_format).toBe("text");
+  });
+
+  test("seeds the default prompt for prompt-required tasks", () => {
+    expect(getDefaultTaskParams(ocr).prompt).toBe(ocr.defaultPrompt);
+  });
+
+  test("returns an empty object for a null task", () => {
+    expect(getDefaultTaskParams(null)).toEqual({});
   });
 });
 


### PR DESCRIPTION
## Summary

- Reopening the batch-job launch modal for the **same task** cleared `taskParams` (reset effect keyed on `open`) but did **not** re-seed defaults (seed effect keyed on the stable `task` reference), so a default `output_format` was silently dropped and `output_ext` went `null`.
- For OCR that meant the pipeline YAML omitted `output_ext`, so tigerflow fell back to its `.out` default — which the task rejects, erroring every file. `.md` appeared to work only because selecting Markdown requires actively changing the dropdown, which sets `output_format` regardless of seeding.
- Extracted the seeding logic into a pure, exported `getDefaultTaskParams(task)` and made the seed effect run on `[open, task]` so defaults are re-applied on every open. Added unit tests, including an OCR regression assertion.

## Test plan

Automated:
- `cd web && npm test` — 510 tests pass, including 4 new `getDefaultTaskParams` tests (default seeding, OCR `output_format` regression, prompt-required seeding, null task).
- `cd web && npm run lint` — 0 errors (one pre-existing warning in an unrelated file).

Manual (reproduces the original bug without the fix):
1. Open the batch jobs page and launch a **new OCR job**; leave Output Format at the default (Plain text / `.txt`). Submit.
2. **Without reloading the page**, open a new OCR job again, leave Output Format at the default, and submit.
3. Inspect the generated pipeline YAML on the cluster (`~/.blackfish/jobs/<id>/pipeline-*.yaml`).
   - **Before:** the second job's YAML has no `output_ext` line → files error with `.out` not a supported output format.
   - **After:** both jobs include `output_ext: .txt` and process successfully.
4. Repeat selecting Markdown (`.md`) to confirm non-default selections still work.