### PR TITLE
fix(lib): scancel batch job allocation on natural completion

### DIFF
--- a/lib/src/blackfish/server/jobs/base.py
+++ b/lib/src/blackfish/server/jobs/base.py
@@ -5,7 +5,7 @@ import os
 import shlex
 from enum import StrEnum, auto
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import yaml
 from advanced_alchemy.base import UUIDAuditBase
@@ -128,15 +128,16 @@ def format_status(status: BatchJobStatus | None) -> str:
 
 
 def _resolve_image_and_provider(
-    app_config: "State | BlackfishConfig",
-    profile: "BlackfishProfile | None",
+    app_config: State | BlackfishConfig,
+    profile: BlackfishProfile | None,
 ) -> tuple[Any, Any]:
     """Resolve the tigerflow-ml ImageSpec and container provider.
 
     The cluster runs Apptainer, so only a LocalProfile consults the locally
     detected ``CONTAINER_PROVIDER``; everything else is Apptainer.
     """
-    from blackfish.server.config import ContainerProvider, config as _config
+    from blackfish.server.config import ContainerProvider
+    from blackfish.server.config import config as _config
 
     images = getattr(app_config, "IMAGES", None) or _config.IMAGES
 
@@ -154,7 +155,7 @@ def _resolve_image_and_provider(
 
 def create_tigerflow_client_for_profile(
     profile_name: str,
-    app_config: "State | BlackfishConfig",
+    app_config: State | BlackfishConfig,
 ) -> TigerFlowClient:
     """Create a TigerFlowClient for a profile.
 
@@ -190,8 +191,8 @@ def create_tigerflow_client_for_profile(
 
 
 def create_tigerflow_client(
-    job: "BatchJob",
-    app_config: "State | BlackfishConfig",
+    job: BatchJob,
+    app_config: State | BlackfishConfig,
 ) -> TigerFlowClient:
     """Create a TigerFlowClient for a batch job.
 
@@ -240,39 +241,39 @@ class BatchJob(UUIDAuditBase):
     name: Mapped[str]
     task: Mapped[str]  # e.g., "transcribe", "detect"
     repo_id: Mapped[str]  # Model ID (e.g., "openai/whisper-large-v3")
-    revision: Mapped[Optional[str]]  # Model revision/version
+    revision: Mapped[str | None]  # Model revision/version
 
     # Data paths and file types
     input_dir: Mapped[str]  # Input directory on cluster
     output_dir: Mapped[str]  # Output directory on cluster
-    input_ext: Mapped[Optional[str]]  # Input file extension (e.g., ".wav")
-    output_ext: Mapped[Optional[str]]  # Output file extension (e.g., ".json")
-    cache_dir: Mapped[Optional[str]]  # Model cache directory on cluster
+    input_ext: Mapped[str | None]  # Input file extension (e.g., ".wav")
+    output_ext: Mapped[str | None]  # Output file extension (e.g., ".json")
+    cache_dir: Mapped[str | None]  # Model cache directory on cluster
 
     # Configuration (stored as JSON)
-    params: Mapped[Optional[dict[str, Any]]] = mapped_column(
+    params: Mapped[dict[str, Any] | None] = mapped_column(
         JSON, nullable=True, default=None
     )
-    resources: Mapped[Optional[dict[str, Any]]] = mapped_column(
+    resources: Mapped[dict[str, Any] | None] = mapped_column(
         JSON, nullable=True, default=None
     )
     max_workers: Mapped[int] = mapped_column(default=1)
-    idle_timeout: Mapped[Optional[int]] = mapped_column(default=None)  # minutes
+    idle_timeout: Mapped[int | None] = mapped_column(default=None)  # minutes
 
     # Profile info (denormalized for convenience)
     profile: Mapped[str]
-    user: Mapped[Optional[str]]
-    host: Mapped[Optional[str]]
-    home_dir: Mapped[Optional[str]]
+    user: Mapped[str | None]
+    host: Mapped[str | None]
+    home_dir: Mapped[str | None]
 
     # Job state
-    status: Mapped[Optional[BatchJobStatus]]
-    pid: Mapped[Optional[str]]  # Slurm job ID of the current allocation
+    status: Mapped[BatchJobStatus | None]
+    pid: Mapped[str | None]  # Slurm job ID of the current allocation
 
     # Progress tracking
-    staged: Mapped[Optional[int]]  # Items remaining (total - finished - errored)
-    finished: Mapped[Optional[int]]  # Successfully processed
-    errored: Mapped[Optional[int]]  # Failed items (transient; reset each run)
+    staged: Mapped[int | None]  # Items remaining (total - finished - errored)
+    finished: Mapped[int | None]  # Successfully processed
+    errored: Mapped[int | None]  # Failed items (transient; reset each run)
 
     # Restart bookkeeping
     restarts: Mapped[int] = mapped_column(default=0)
@@ -284,8 +285,8 @@ class BatchJob(UUIDAuditBase):
     processed_highwater: Mapped[int] = mapped_column(default=0)
 
     # TigerFlow versions (for reproducibility)
-    tigerflow_version: Mapped[Optional[str]]
-    tigerflow_ml_version: Mapped[Optional[str]]
+    tigerflow_version: Mapped[str | None]
+    tigerflow_ml_version: Mapped[str | None]
 
     def __repr__(self) -> str:
         return f"<BatchJob(name={self.name}, task={self.task}, status={self.status})>"
@@ -339,7 +340,7 @@ class BatchJob(UUIDAuditBase):
             account=res.get("account"),
         )
 
-    def _is_slurm(self, profile: "BlackfishProfile | None") -> bool:
+    def _is_slurm(self, profile: BlackfishProfile | None) -> bool:
         """Whether this job runs under Slurm (sbatch), independent of transport.
 
         Determined by profile *type*: a ``SlurmProfile`` uses Slurm even when
@@ -349,7 +350,7 @@ class BatchJob(UUIDAuditBase):
         """
         return isinstance(profile, SlurmProfile)
 
-    def _render_script(self, app_config: "State | BlackfishConfig") -> str:
+    def _render_script(self, app_config: State | BlackfishConfig) -> str:
         """Render the batch launch script for this job."""
         profile = deserialize_profile(app_config.HOME_DIR, self.profile)
         if profile is None:
@@ -381,7 +382,7 @@ class BatchJob(UUIDAuditBase):
             else DEFAULT_IDLE_TIMEOUT,
         )
 
-    async def _submit(self, app_config: "State | BlackfishConfig") -> str:
+    async def _submit(self, app_config: State | BlackfishConfig) -> str:
         """Render, stage, and launch the batch script.
 
         The launch mechanism is chosen by profile *type* (Slurm → ``sbatch``,
@@ -441,7 +442,7 @@ class BatchJob(UUIDAuditBase):
 
     async def start(
         self,
-        app_config: "State | BlackfishConfig",
+        app_config: State | BlackfishConfig,
         client: TigerFlowClient,
     ) -> None:
         """Start the batch job by submitting a containerized Slurm allocation.
@@ -529,7 +530,7 @@ class BatchJob(UUIDAuditBase):
 
     async def resume(
         self,
-        app_config: "State | BlackfishConfig",
+        app_config: State | BlackfishConfig,
         client: TigerFlowClient,
     ) -> None:
         """Put a terminal job back into the restart loop.
@@ -743,7 +744,7 @@ class BatchJob(UUIDAuditBase):
     async def poll(
         self,
         client: TigerFlowClient,
-        app_config: "State | BlackfishConfig",
+        app_config: State | BlackfishConfig,
     ) -> BatchJobStatus:
         """Refresh status and advance the restart loop when the allocation has
         ended with work remaining.
@@ -779,6 +780,15 @@ class BatchJob(UUIDAuditBase):
             or status in _TERMINAL_STATUSES
             or total is None
         ):
+            # Pipeline finished before walltime: the allocation is still
+            # holding resources. The explicit stop() path reaps it; a natural
+            # completion never goes through stop(), so do it here at the
+            # transition edge.
+            if (
+                status == BatchJobStatus.STOPPED
+                and self.status != BatchJobStatus.STOPPED
+            ):
+                await self._cancel_allocation()
             self.status = status
             return status
 

--- a/lib/src/blackfish/server/jobs/base.py
+++ b/lib/src/blackfish/server/jobs/base.py
@@ -5,7 +5,7 @@ import os
 import shlex
 from enum import StrEnum, auto
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 import yaml
 from advanced_alchemy.base import UUIDAuditBase
@@ -128,16 +128,15 @@ def format_status(status: BatchJobStatus | None) -> str:
 
 
 def _resolve_image_and_provider(
-    app_config: State | BlackfishConfig,
-    profile: BlackfishProfile | None,
+    app_config: "State | BlackfishConfig",
+    profile: "BlackfishProfile | None",
 ) -> tuple[Any, Any]:
     """Resolve the tigerflow-ml ImageSpec and container provider.
 
     The cluster runs Apptainer, so only a LocalProfile consults the locally
     detected ``CONTAINER_PROVIDER``; everything else is Apptainer.
     """
-    from blackfish.server.config import ContainerProvider
-    from blackfish.server.config import config as _config
+    from blackfish.server.config import ContainerProvider, config as _config
 
     images = getattr(app_config, "IMAGES", None) or _config.IMAGES
 
@@ -155,7 +154,7 @@ def _resolve_image_and_provider(
 
 def create_tigerflow_client_for_profile(
     profile_name: str,
-    app_config: State | BlackfishConfig,
+    app_config: "State | BlackfishConfig",
 ) -> TigerFlowClient:
     """Create a TigerFlowClient for a profile.
 
@@ -191,8 +190,8 @@ def create_tigerflow_client_for_profile(
 
 
 def create_tigerflow_client(
-    job: BatchJob,
-    app_config: State | BlackfishConfig,
+    job: "BatchJob",
+    app_config: "State | BlackfishConfig",
 ) -> TigerFlowClient:
     """Create a TigerFlowClient for a batch job.
 
@@ -241,39 +240,39 @@ class BatchJob(UUIDAuditBase):
     name: Mapped[str]
     task: Mapped[str]  # e.g., "transcribe", "detect"
     repo_id: Mapped[str]  # Model ID (e.g., "openai/whisper-large-v3")
-    revision: Mapped[str | None]  # Model revision/version
+    revision: Mapped[Optional[str]]  # Model revision/version
 
     # Data paths and file types
     input_dir: Mapped[str]  # Input directory on cluster
     output_dir: Mapped[str]  # Output directory on cluster
-    input_ext: Mapped[str | None]  # Input file extension (e.g., ".wav")
-    output_ext: Mapped[str | None]  # Output file extension (e.g., ".json")
-    cache_dir: Mapped[str | None]  # Model cache directory on cluster
+    input_ext: Mapped[Optional[str]]  # Input file extension (e.g., ".wav")
+    output_ext: Mapped[Optional[str]]  # Output file extension (e.g., ".json")
+    cache_dir: Mapped[Optional[str]]  # Model cache directory on cluster
 
     # Configuration (stored as JSON)
-    params: Mapped[dict[str, Any] | None] = mapped_column(
+    params: Mapped[Optional[dict[str, Any]]] = mapped_column(
         JSON, nullable=True, default=None
     )
-    resources: Mapped[dict[str, Any] | None] = mapped_column(
+    resources: Mapped[Optional[dict[str, Any]]] = mapped_column(
         JSON, nullable=True, default=None
     )
     max_workers: Mapped[int] = mapped_column(default=1)
-    idle_timeout: Mapped[int | None] = mapped_column(default=None)  # minutes
+    idle_timeout: Mapped[Optional[int]] = mapped_column(default=None)  # minutes
 
     # Profile info (denormalized for convenience)
     profile: Mapped[str]
-    user: Mapped[str | None]
-    host: Mapped[str | None]
-    home_dir: Mapped[str | None]
+    user: Mapped[Optional[str]]
+    host: Mapped[Optional[str]]
+    home_dir: Mapped[Optional[str]]
 
     # Job state
-    status: Mapped[BatchJobStatus | None]
-    pid: Mapped[str | None]  # Slurm job ID of the current allocation
+    status: Mapped[Optional[BatchJobStatus]]
+    pid: Mapped[Optional[str]]  # Slurm job ID of the current allocation
 
     # Progress tracking
-    staged: Mapped[int | None]  # Items remaining (total - finished - errored)
-    finished: Mapped[int | None]  # Successfully processed
-    errored: Mapped[int | None]  # Failed items (transient; reset each run)
+    staged: Mapped[Optional[int]]  # Items remaining (total - finished - errored)
+    finished: Mapped[Optional[int]]  # Successfully processed
+    errored: Mapped[Optional[int]]  # Failed items (transient; reset each run)
 
     # Restart bookkeeping
     restarts: Mapped[int] = mapped_column(default=0)
@@ -285,8 +284,8 @@ class BatchJob(UUIDAuditBase):
     processed_highwater: Mapped[int] = mapped_column(default=0)
 
     # TigerFlow versions (for reproducibility)
-    tigerflow_version: Mapped[str | None]
-    tigerflow_ml_version: Mapped[str | None]
+    tigerflow_version: Mapped[Optional[str]]
+    tigerflow_ml_version: Mapped[Optional[str]]
 
     def __repr__(self) -> str:
         return f"<BatchJob(name={self.name}, task={self.task}, status={self.status})>"
@@ -340,7 +339,7 @@ class BatchJob(UUIDAuditBase):
             account=res.get("account"),
         )
 
-    def _is_slurm(self, profile: BlackfishProfile | None) -> bool:
+    def _is_slurm(self, profile: "BlackfishProfile | None") -> bool:
         """Whether this job runs under Slurm (sbatch), independent of transport.
 
         Determined by profile *type*: a ``SlurmProfile`` uses Slurm even when
@@ -350,7 +349,7 @@ class BatchJob(UUIDAuditBase):
         """
         return isinstance(profile, SlurmProfile)
 
-    def _render_script(self, app_config: State | BlackfishConfig) -> str:
+    def _render_script(self, app_config: "State | BlackfishConfig") -> str:
         """Render the batch launch script for this job."""
         profile = deserialize_profile(app_config.HOME_DIR, self.profile)
         if profile is None:
@@ -382,7 +381,7 @@ class BatchJob(UUIDAuditBase):
             else DEFAULT_IDLE_TIMEOUT,
         )
 
-    async def _submit(self, app_config: State | BlackfishConfig) -> str:
+    async def _submit(self, app_config: "State | BlackfishConfig") -> str:
         """Render, stage, and launch the batch script.
 
         The launch mechanism is chosen by profile *type* (Slurm → ``sbatch``,
@@ -442,7 +441,7 @@ class BatchJob(UUIDAuditBase):
 
     async def start(
         self,
-        app_config: State | BlackfishConfig,
+        app_config: "State | BlackfishConfig",
         client: TigerFlowClient,
     ) -> None:
         """Start the batch job by submitting a containerized Slurm allocation.
@@ -530,7 +529,7 @@ class BatchJob(UUIDAuditBase):
 
     async def resume(
         self,
-        app_config: State | BlackfishConfig,
+        app_config: "State | BlackfishConfig",
         client: TigerFlowClient,
     ) -> None:
         """Put a terminal job back into the restart loop.
@@ -719,11 +718,18 @@ class BatchJob(UUIDAuditBase):
         return BatchJobStatus.SUBMITTED
 
     async def refresh(self, client: TigerFlowClient) -> BatchJobStatus:
-        """Read-only status refresh — never resubmits or mutates restart counters.
+        """Refresh status without advancing the restart loop.
 
         Reads the tigerflow report (durable ``processed`` count) and Slurm
-        liveness and updates progress fields. Safe to call after ``stop()`` or
-        before deletion. Use ``poll()`` to also advance the restart loop.
+        liveness and updates progress fields. Never resubmits. Called before
+        deletion and after ``stop()``. Use ``poll()`` to also advance the
+        restart loop.
+
+        If the observation flips a still-live job into ``STOPPED`` because the
+        pipeline finished all inputs before walltime, the Slurm allocation is
+        also cancelled here — otherwise a deletion path (which uses
+        ``refresh()``, not ``poll()``) would drop the DB row while leaving the
+        allocation orphaned until walltime with no way to reap it.
 
         Caller is responsible for persistence.
         """
@@ -738,13 +744,15 @@ class BatchJob(UUIDAuditBase):
 
         processed, total, state = await self._observe(client)
         status = self._status_from_observation(processed, total, state)
+        if status == BatchJobStatus.STOPPED and self.status != BatchJobStatus.STOPPED:
+            await self._cancel_allocation()
         self.status = status
         return status
 
     async def poll(
         self,
         client: TigerFlowClient,
-        app_config: State | BlackfishConfig,
+        app_config: "State | BlackfishConfig",
     ) -> BatchJobStatus:
         """Refresh status and advance the restart loop when the allocation has
         ended with work remaining.

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -1,9 +1,9 @@
 """Unit tests for BatchJob orchestration logic."""
 
-import pytest
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import UUID
 
+import pytest
 from blackfish.server.config import ContainerProvider
 from blackfish.server.images import DEFAULT_IMAGES
 from blackfish.server.job import JobState
@@ -16,21 +16,20 @@ from blackfish.server.jobs.base import (
 )
 from blackfish.server.jobs.client import (
     TigerFlowClient,
+    TigerFlowError,
+    TigerFlowPipelineProgress,
+    TigerFlowProgress,
     TigerFlowReport,
     TigerFlowReportStatus,
-    TigerFlowProgress,
-    TigerFlowPipelineProgress,
-    TigerFlowError,
     TigerFlowVersions,
 )
 from blackfish.server.jobs.tasks import (
-    is_supported_task,
-    get_task_library,
     build_pipeline_config,
     get_default_input_ext,
     get_default_output_ext,
+    get_task_library,
+    is_supported_task,
 )
-
 
 pytestmark = pytest.mark.anyio
 
@@ -264,6 +263,33 @@ class TestBatchJobUpdate:
         assert result == BatchJobStatus.STOPPED
         assert job.finished == 10
         submit.assert_not_called()
+
+    @patch("blackfish.server.jobs.base.remote")
+    async def test_poll_cancels_allocation_on_natural_completion(
+        self, mock_remote: Mock
+    ) -> None:
+        """Pipeline finished before walltime while Slurm state is still alive:
+        poll must scancel the allocation. Otherwise the UI hides the Stop
+        button (status=STOPPED) but the Slurm job keeps holding GPUs."""
+        mock_remote.run = AsyncMock()
+        job = create_test_batch_job(
+            status=BatchJobStatus.RUNNING, host="localhost", pid="4242"
+        )
+        client = create_mock_client()
+        client.report.return_value = make_mock_report(
+            finished=10, in_progress=0, staged=None, errored=0
+        )
+        _drive_update(job, total=10, slurm_state=JobState.RUNNING)
+
+        result = await job.poll(client, MockAppConfig())
+
+        assert result == BatchJobStatus.STOPPED
+        assert mock_remote.run.await_count == 1  # scancel issued
+
+        # A subsequent poll on the already-STOPPED job must not re-scancel.
+        mock_remote.run.reset_mock()
+        await job.poll(client, MockAppConfig())
+        mock_remote.run.assert_not_called()
 
     async def test_update_resubmits_when_ended_with_progress(self) -> None:
         """Allocation ended, progress advanced, under budget -> resubmit +
@@ -834,8 +860,8 @@ class TestCreateTigerflowClientForProfile:
     @patch("blackfish.server.jobs.base.deserialize_profile")
     def test_creates_ssh_runner_for_slurm_profile(self, mock_deserialize: Mock) -> None:
         """Should create SSHRunner for SlurmProfile."""
-        from blackfish.server.models.profile import SlurmProfile
         from blackfish.server.jobs.client import SSHRunner
+        from blackfish.server.models.profile import SlurmProfile
 
         mock_profile = SlurmProfile(
             name="test-slurm",
@@ -858,8 +884,8 @@ class TestCreateTigerflowClientForProfile:
         self, mock_deserialize: Mock
     ) -> None:
         """Should create LocalRunner for LocalProfile."""
-        from blackfish.server.models.profile import LocalProfile
         from blackfish.server.jobs.client import LocalRunner
+        from blackfish.server.models.profile import LocalProfile
 
         mock_profile = LocalProfile(
             name="test-local",

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -460,6 +460,34 @@ class TestBatchJobUpdate:
         assert result != BatchJobStatus.RESUBMITTED
         submit.assert_not_called()
 
+    @patch("blackfish.server.jobs.base.remote")
+    async def test_refresh_cancels_allocation_on_natural_completion(
+        self, mock_remote: Mock
+    ) -> None:
+        """The delete endpoint calls refresh() (not poll()) and then drops the
+        DB row for any STOPPED job. If refresh() flipped RUNNING -> STOPPED
+        without cancelling the still-live allocation, deletion would orphan
+        the Slurm job with no record left for a future poll() to reap it."""
+        mock_remote.run = AsyncMock()
+        job = create_test_batch_job(
+            status=BatchJobStatus.RUNNING, host="localhost", pid="4242"
+        )
+        client = create_mock_client()
+        client.report.return_value = make_mock_report(
+            finished=10, in_progress=0, staged=None, errored=0
+        )
+        _drive_update(job, total=10, slurm_state=JobState.RUNNING)
+
+        result = await job.refresh(client)
+
+        assert result == BatchJobStatus.STOPPED
+        assert mock_remote.run.await_count == 1  # scancel issued
+
+        # A subsequent refresh on the already-terminal job short-circuits.
+        mock_remote.run.reset_mock()
+        await job.refresh(client)
+        mock_remote.run.assert_not_called()
+
     async def test_poll_does_not_resubmit_when_slurm_state_unknown(self) -> None:
         """A just-resubmitted allocation sacct hasn't registered reads MISSING
         (unknown, not terminal). Poll must NOT treat that as ended and


### PR DESCRIPTION
## Summary

- When a batch job's pipeline finished all inputs before walltime, `poll()` set the job to `STOPPED` but never cancelled the Slurm allocation. The UI hides the Stop button once status is `STOPPED` (not in the active-status set), leaving the allocation holding GPUs until walltime with no way to reap it from the UI.
- Call `_cancel_allocation()` at the `STOPPED` transition edge in [poll()](lib/src/blackfish/server/jobs/base.py), guarded on `self.status != STOPPED` so it only fires once and later polls are no-ops (also caught by the pre-existing terminal-status guard at the top of `poll()`).
- Adds a unit regression test that patches `remote`, drives poll to natural completion with Slurm state still alive, and asserts exactly one `scancel` is issued (and none on a follow-up poll).

## Test plan

- [x] `uv run just test` — 899 passed, 7 skipped
- [x] `uv run pre-commit run --files src/blackfish/server/jobs/base.py tests/unit/test_jobs.py` — all hooks pass
- [x] Manual: submit a batch job that finishes before its walltime; confirm the Slurm allocation ends promptly instead of running to walltime