### PR TITLE
fix: model revisions duplicate — race in refresh + unique-key UI list

### DIFF
--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -1880,6 +1880,57 @@ async def proxy_service(
         return res
 
 
+_MODEL_UNIQUE_CONSTRAINT = "uq_model_repo_profile_revision"
+
+
+def _is_model_unique_violation(exc: IntegrityError) -> bool:
+    """True if ``exc`` is the (repo, profile, revision) uniqueness violation.
+
+    Narrower than a bare ``except IntegrityError`` so a future NOT NULL or FK
+    constraint won't be silently misdiagnosed as a raced insert.
+    """
+    orig = getattr(exc, "orig", None)
+    return orig is not None and _MODEL_UNIQUE_CONSTRAINT in str(orig)
+
+
+async def _insert_or_return_existing_model(
+    session: AsyncSession, model: Model
+) -> Model:
+    """Insert ``model`` inside a savepoint, or return the row a concurrent
+    caller inserted first.
+
+    Both call sites that create ``Model`` rows outside of ``get_models`` are
+    check-then-insert against ``(repo, profile, revision)``. Before the
+    ``uq_model_repo_profile_revision`` constraint existed the loser of a race
+    silently added a duplicate row; now the loser gets an ``IntegrityError``
+    that would otherwise surface as a 500 or a spurious download failure.
+    Re-query on the constraint violation so those call sites keep the
+    idempotent behavior their callers expect.
+    """
+    try:
+        async with session.begin_nested():
+            session.add(model)
+            await session.flush()
+        return model
+    except IntegrityError as e:
+        if not _is_model_unique_violation(e):
+            raise
+        existing = (
+            await session.execute(
+                sa.select(Model).where(
+                    Model.repo == model.repo,
+                    Model.profile == model.profile,
+                    Model.revision == model.revision,
+                )
+            )
+        ).scalar_one()
+        logger.warning(
+            f"Concurrent write already added {model.repo}@{model.revision} "
+            f"for profile {model.profile}; returning the winning row."
+        )
+        return existing
+
+
 @get("/api/models", guards=ENDPOINT_GUARDS)
 async def get_models(
     session: AsyncSession,
@@ -1958,22 +2009,10 @@ async def get_models(
                 m.image = hub_image
                 m.metadata_ = metadata_dict
 
-                # Insert inside a savepoint. A concurrent refresh may have
-                # inserted the same (repo, profile, revision) between our DB
-                # read and this write; the UNIQUE constraint turns that into
-                # an IntegrityError on the losing insert. Rolling back only
-                # the savepoint (not the outer transaction) lets us skip the
-                # duplicate and continue with the rest. Adding inside the
-                # savepoint keeps the session's identity map clean on rollback.
-                try:
-                    async with session.begin_nested():
-                        session.add(m)
-                        await session.flush()
-                except IntegrityError:
-                    logger.warning(
-                        f"Concurrent refresh already added {m.repo}@{m.revision} "
-                        f"for profile {m.profile}; skipping duplicate insert."
-                    )
+                # A concurrent refresh may have inserted the same
+                # (repo, profile, revision) between our DB read and this
+                # write; treat the winning row as authoritative and continue.
+                await _insert_or_return_existing_model(session, m)
 
         # 5. Update existing models with missing metadata
         to_update = [
@@ -2087,9 +2126,11 @@ async def create_model(data: CreateModelRequest, session: AsyncSession) -> Model
         model_dir=data.model_dir,
         metadata_=data.metadata_,
     )
-    session.add(model)
-    await session.flush()  # Populate ID before returning
-    return model
+    # A concurrent create_model (e.g. two CLI re-runs, or a create_model
+    # racing a refresh scan) may have inserted the same row between the
+    # check above and this write. The helper turns the resulting
+    # IntegrityError into the winning row so the endpoint stays idempotent.
+    return await _insert_or_return_existing_model(session, model)
 
 
 @delete("/api/models/{model_id:str}", guards=ENDPOINT_GUARDS)
@@ -2552,9 +2593,11 @@ async def _run_download_task(
             add_model, repo_id, profile, revision, use_cache
         )
 
-        # Add model to database
+        # Add model to database. A concurrent refresh or download of the
+        # same (repo, profile, revision) may race with our check-then-insert;
+        # the helper catches the IntegrityError and returns the winning row
+        # so the download isn't marked FAILED just because someone else won.
         async with async_session_factory() as session:
-            # Check if model already exists
             query = sa.select(Model).where(
                 Model.repo == repo_id,
                 Model.profile == profile.name,
@@ -2565,9 +2608,9 @@ async def _run_download_task(
             if existing:
                 completed_model_id = existing.id
             else:
-                session.add(new_model)
+                persisted = await _insert_or_return_existing_model(session, new_model)
                 await session.commit()
-                completed_model_id = new_model.id
+                completed_model_id = persisted.id
 
         await update_task_status(DownloadStatus.COMPLETED, model_id=completed_model_id)
 

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -1958,11 +1958,22 @@ async def get_models(
                 m.image = hub_image
                 m.metadata_ = metadata_dict
 
-            session.add_all(to_add)
-            try:
-                await session.flush()
-            except Exception as e:
-                logger.error(f"Failed to add new models: {e}")
+                # Insert inside a savepoint. A concurrent refresh may have
+                # inserted the same (repo, profile, revision) between our DB
+                # read and this write; the UNIQUE constraint turns that into
+                # an IntegrityError on the losing insert. Rolling back only
+                # the savepoint (not the outer transaction) lets us skip the
+                # duplicate and continue with the rest. Adding inside the
+                # savepoint keeps the session's identity map clean on rollback.
+                try:
+                    async with session.begin_nested():
+                        session.add(m)
+                        await session.flush()
+                except IntegrityError:
+                    logger.warning(
+                        f"Concurrent refresh already added {m.repo}@{m.revision} "
+                        f"for profile {m.profile}; skipping duplicate insert."
+                    )
 
         # 5. Update existing models with missing metadata
         to_update = [

--- a/lib/src/blackfish/server/db/migrations/versions/2026-08-13_dedup_and_uniq_model_repo_profile_revision_d7e8f9a0b1c2.py
+++ b/lib/src/blackfish/server/db/migrations/versions/2026-08-13_dedup_and_uniq_model_repo_profile_revision_d7e8f9a0b1c2.py
@@ -1,0 +1,122 @@
+# type: ignore
+"""dedup model rows and add uniq(repo, profile, revision)
+
+Concurrent ``GET /api/models?refresh=true`` calls both read the DB, both
+compute the same "missing" diff against the filesystem scan, and both INSERT
+the same rows with different UUIDs. The window is wide enough to hit on Open
+OnDemand (login-node FS latency stretches the HF Hub fetches to seconds).
+
+Duplicate rows share the same on-disk ``model_dir``, so the cleanup can drop
+all but one per ``(repo, profile, revision)`` without touching the filesystem.
+Keep the oldest ``created_at`` because that's the row referenced by any
+external URL that was captured before the race.
+
+Once cleaned, install a UNIQUE constraint so future concurrent inserts get an
+IntegrityError on the loser (handled in ``get_models``) instead of quietly
+adding a duplicate.
+
+Revision ID: d7e8f9a0b1c2
+Revises: 565bd6201d2a
+Create Date: 2026-08-13 00:00:00.000000+00:00
+
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import sqlalchemy as sa
+from alembic import op
+from advanced_alchemy.types import (
+    EncryptedString,
+    EncryptedText,
+    GUID,
+    ORA_JSONB,
+    DateTimeUTC,
+)
+from sqlalchemy import Text  # noqa: F401
+
+__all__ = [
+    "downgrade",
+    "upgrade",
+    "schema_upgrades",
+    "schema_downgrades",
+    "data_upgrades",
+    "data_downgrades",
+]
+
+sa.GUID = GUID
+sa.DateTimeUTC = DateTimeUTC
+sa.ORA_JSONB = ORA_JSONB
+sa.EncryptedString = EncryptedString
+sa.EncryptedText = EncryptedText
+
+# revision identifiers, used by Alembic.
+revision = "d7e8f9a0b1c2"
+down_revision = "565bd6201d2a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        with op.get_context().autocommit_block():
+            data_upgrades()
+            schema_upgrades()
+
+
+def downgrade() -> None:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        with op.get_context().autocommit_block():
+            schema_downgrades()
+            data_downgrades()
+
+
+def schema_upgrades() -> None:
+    """Add UNIQUE(repo, profile, revision) on the model table."""
+    with op.batch_alter_table("model") as batch_op:
+        batch_op.create_unique_constraint(
+            "uq_model_repo_profile_revision",
+            ["repo", "profile", "revision"],
+        )
+
+
+def schema_downgrades() -> None:
+    """Drop the uniqueness constraint added in the upgrade."""
+    with op.batch_alter_table("model") as batch_op:
+        batch_op.drop_constraint("uq_model_repo_profile_revision", type_="unique")
+
+
+def data_upgrades() -> None:
+    """Delete duplicate model rows, keeping the oldest per key.
+
+    Duplicates share ``model_dir``, so this only removes DB rows — no files are
+    touched. Ordering by ``created_at`` (with ``id`` as a stable tiebreaker for
+    rows created in the same microsecond) keeps the row a caller with an
+    already-issued ID would expect to find.
+    """
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            """
+            DELETE FROM model
+            WHERE id NOT IN (
+                SELECT id FROM (
+                    SELECT id,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY repo, profile, revision
+                               ORDER BY created_at ASC, id ASC
+                           ) AS rn
+                    FROM model
+                ) ranked
+                WHERE rn = 1
+            )
+            """
+        )
+    )
+
+
+def data_downgrades() -> None:
+    """No-op: the deleted duplicates were spurious and cannot be reconstructed."""

--- a/lib/src/blackfish/server/models/model.py
+++ b/lib/src/blackfish/server/models/model.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from log_symbols.symbols import LogSymbols
 from huggingface_hub import snapshot_download, model_info, scan_cache_dir, ModelInfo
 from advanced_alchemy.base import UUIDAuditBase
-from sqlalchemy import JSON
+from sqlalchemy import JSON, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 from blackfish.server.models.profile import BlackfishProfile as Profile
 from blackfish.server.models.metadata import fetch_model_metadata
@@ -36,6 +36,17 @@ PIPELINE_IMAGES = {
 
 class Model(UUIDAuditBase):
     __tablename__ = "model"
+    # A given profile has exactly one on-disk snapshot per (repo, revision).
+    # Enforced at the DB level so concurrent refreshes can't create duplicate
+    # rows — see get_models(refresh=True): two overlapping calls both compute
+    # the same "missing" diff and race to INSERT, and without this constraint
+    # both succeed with different UUIDs.
+    __table_args__ = (
+        UniqueConstraint(
+            "repo", "profile", "revision", name="uq_model_repo_profile_revision"
+        ),
+    )
+
     repo: Mapped[str]  # e.g., bigscience/bloom-560m
     profile: Mapped[str]  # e.g.,  hpc
     revision: Mapped[str]

--- a/lib/tests/api/test_models.py
+++ b/lib/tests/api/test_models.py
@@ -216,6 +216,58 @@ class TestFetchModelsAPI:
             for model in result:
                 assert model.get("profile") == "default"
 
+    async def test_concurrent_refresh_does_not_create_duplicates(
+        self, client: AsyncTestClient
+    ):
+        """Two overlapping refresh calls both diff DB vs. filesystem and both
+        try to INSERT the same rows. The UNIQUE constraint on
+        (repo, profile, revision) plus the per-row savepoint in get_models
+        must collapse this to a single row, not two rows with different UUIDs
+        (the OoD-only bug that made the UI show ghost revisions)."""
+
+        # Return fresh Model instances on each call — production find_models
+        # builds new objects per scan, and sharing SQLAlchemy instances across
+        # sessions would trigger DetachedInstanceError unrelated to the race.
+        def make_fs_models():
+            return [
+                Model(
+                    repo="racy-org/racy-model",
+                    profile="default",
+                    revision="deadbeef",
+                    image="unknown",
+                    model_dir="/home/test/.blackfish/models/models--racy-org--racy-model",
+                    metadata_=None,
+                ),
+            ]
+
+        mock_find_models = AsyncMock(side_effect=lambda *_a, **_kw: make_fs_models())
+        mock_fetch = MagicMock(return_value=("text-generation", {"model_size_gb": 1.0}))
+
+        with patch("blackfish.server.asgi.find_models", mock_find_models):
+            with patch("blackfish.server.asgi.fetch_model_info_from_hub", mock_fetch):
+                r1, r2 = await asyncio.gather(
+                    client.get(
+                        "/api/models", params={"profile": "default", "refresh": True}
+                    ),
+                    client.get(
+                        "/api/models", params={"profile": "default", "refresh": True}
+                    ),
+                )
+
+        assert r1.status_code == 200, r1.text
+        assert r2.status_code == 200, r2.text
+
+        # Post-race: exactly one row for the raced key. Without the constraint
+        # and savepoint, this returns two rows with distinct UUIDs.
+        response = await client.get("/api/models", params={"profile": "default"})
+        result = response.json()
+        matching = [
+            m
+            for m in result
+            if m["repo"] == "racy-org/racy-model" and m["revision"] == "deadbeef"
+        ]
+        assert len(matching) == 1
+
     async def test_refresh_without_profile_is_rejected(self, client: AsyncTestClient):
         """Refresh without ?profile= should 400 — the CLI fans out per-profile."""
         response = await client.get("/api/models", params={"refresh": True})

--- a/lib/tests/api/test_models.py
+++ b/lib/tests/api/test_models.py
@@ -715,6 +715,26 @@ class TestCreateModelAPI:
         # Same model ID returned
         assert model1["id"] == model2["id"]
 
+    async def test_create_model_concurrent_idempotent(self, client: AsyncTestClient):
+        """Two concurrent POSTs with the same (repo, profile, revision) must
+        both succeed with the same id. Under the pre-fix behaviour both
+        requests passed the check-then-insert guard and the loser surfaced
+        an IntegrityError (500) after the UNIQUE constraint landed."""
+        data = {
+            "repo": "concurrent-org/concurrent-model",
+            "profile": "default",
+            "revision": "v1.0",
+            "image": "text-generation",
+            "model_dir": "/tmp/models/concurrent-org--concurrent-model",
+        }
+        r1, r2 = await asyncio.gather(
+            client.post("/api/models", json=data),
+            client.post("/api/models", json=data),
+        )
+        assert r1.status_code == 201, r1.text
+        assert r2.status_code == 201, r2.text
+        assert r1.json()["id"] == r2.json()["id"]
+
 
 class TestDownloadModelAPI:
     """Test cases for the POST /api/models/download endpoint."""

--- a/web/src/routes/models/components/ModelsTable.jsx
+++ b/web/src/routes/models/components/ModelsTable.jsx
@@ -342,10 +342,13 @@ function RevisionRows({ revisions, activeDownload, cacheDir, homeDir, isRemote, 
         );
     }
 
-    // Revision rows
+    // Revision rows. Key on the DB row id (unique per Model row) rather than
+    // the revision hash: duplicate hashes have historically leaked in through
+    // a race in the refresh endpoint, and duplicate React keys break diffing —
+    // switching to a different model then reconciles against stale nodes.
     for (const revision of revisions) {
         rows.push(
-            <tr key={revision.revision} className="xl:hidden bg-gray-50 dark:bg-gray-900">
+            <tr key={revision.id} className="xl:hidden bg-gray-50 dark:bg-gray-900">
                 <td className="py-2 pl-4 pr-1 w-8"></td>
                 <td className="py-2 pl-2 pr-3 text-sm">
                     <div className="flex items-center gap-2 pl-4">
@@ -897,7 +900,7 @@ function ModelsTable({
                                                 );
                                             })()}
                                             {selectedModel.revisions.map((revision) => (
-                                                <tr key={revision.revision} className="bg-white dark:bg-gray-800">
+                                                <tr key={revision.id} className="bg-white dark:bg-gray-800">
                                                     <td className="py-3 pl-6 pr-4 text-left text-sm w-full">
                                                         <div className="flex items-center gap-1.5">
                                                             <span


### PR DESCRIPTION
## Summary

- Root cause of the "revisions accumulate as I cycle through models" symptom is a race in [\`GET /api/models?refresh=true\`](lib/src/blackfish/server/asgi.py): two overlapping calls both diff DB vs. filesystem and both INSERT the same \`(repo, profile, revision)\` with different UUIDs. Only reproduces on Open OnDemand — login-node FS latency widens the window; Hub metadata fetches take seconds instead of milliseconds. Confirmed against live JSON where duplicate rows share \`model_dir\` and \`created_at\` matches within microseconds while HF \`fetched_at\` differs by ~2s.
- Backend: add \`UniqueConstraint(repo, profile, revision)\` on the \`Model\` table; \`get_models(refresh=True)\` inserts each new row inside a nested savepoint so a raced \`IntegrityError\` rolls back only that row and the endpoint continues with the rest. Alembic migration first deduplicates existing rows (keeps the oldest per key — duplicates share \`model_dir\` so no files are touched), then installs the constraint.
- Frontend: the desktop revisions panel and mobile expand-row keyed on \`revision.revision\`. Duplicate rows in the DB collide on that key, which corrupts React's list diff and produces visual accumulation as \`selectedModel\` changes. Switch to the DB row id (\`revision.id\`), which is always unique.

## Test plan

- [x] \`uv run pytest\` — 899 passed, 7 skipped
- [x] \`uv run pre-commit run --files ...\` on touched Python files — all hooks pass
- [x] \`npm test\` — 510 passed
- [x] \`npm run lint\` — clean (one pre-existing unrelated warning)
- [x] New regression test \`test_concurrent_refresh_does_not_create_duplicates\` — two concurrent \`refresh=true\` calls land exactly one row for the raced key
- [ ] Manual on OoD: cycle between models with the model view open, verify revisions list length is stable and matches actual on-disk state
- [x] Manual: run migration against a DB containing known-duplicate rows, verify duplicates collapse to one row per \`(repo, profile, revision)\`

## Follow-ups (not in this PR)

Tracked in #467:
- \`DELETE /api/models/{id}\` unlinks the shared \`model_dir\` on disk. If a user pressed delete on a duplicate before this PR lands, both rows lose their files. Worth teaching the endpoint to check for sibling rows before touching disk.
- \`useModels\` sends \`refresh=true\` unconditionally on every mount, from three call sites with different SWR keys. This is the fuel for the race and independently slow on high-latency filesystems. Consider making \`refresh=true\` opt-in.