### PR TITLE
fix(web): drop stale batch job resource options

### DIFF
--- a/web/src/routes/jobs/components/JobDetailsPanel.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.jsx
@@ -269,7 +269,7 @@ function JobDetailsPanel({ job, onStopJob, onResumeJob, onDeleteJob, jobActions 
             )}
 
             {/* Resource Config Section */}
-            {(job.resources || job.max_workers) && (
+            {job.resources && (
                 <div className="border-t border-gray-200 dark:border-gray-700 pt-4 mb-4">
                     <div className="flex items-center gap-2 mb-3">
                         <ServerIcon className="h-4 w-4 text-gray-500 dark:text-gray-400" />
@@ -298,16 +298,8 @@ function JobDetailsPanel({ job, onStopJob, onResumeJob, onDeleteJob, jobActions 
                         )}
                         {job.resources?.time && (
                             <div className="flex justify-between">
-                                {/* Per-allocation walltime; batch jobs resubmit across
-                                    allocations, so this is not the total job runtime. */}
-                                <span className="text-gray-500 dark:text-gray-400">Walltime (per allocation):</span>
+                                <span className="text-gray-500 dark:text-gray-400">Time Limit:</span>
                                 <span className="text-gray-900 dark:text-gray-100">{job.resources.time}</span>
-                            </div>
-                        )}
-                        {job.max_workers != null && (
-                            <div className="flex justify-between">
-                                <span className="text-gray-500 dark:text-gray-400">Max Workers:</span>
-                                <span className="text-gray-900 dark:text-gray-100">{job.max_workers}</span>
                             </div>
                         )}
                     </div>
@@ -390,7 +382,6 @@ JobDetailsPanel.propTypes = {
         revision: PropTypes.string,
         input_dir: PropTypes.string,
         output_dir: PropTypes.string,
-        max_workers: PropTypes.number,
         resources: PropTypes.shape({
             mem: PropTypes.number,
             cpus: PropTypes.number,

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -34,6 +34,8 @@ import { fetchProfileResources, fetchModelSizeFromHub, createJob } from "@/lib/r
 import { selectTierByModelSize, isRemoteProfile } from "@/lib/util";
 import PropTypes from "prop-types";
 
+const DEFAULT_WORKER_TIMEOUT = '01:00';
+
 // Task definitions - each task maps to a TigerFlow task type
 // id must match backend SUPPORTED_TASKS keys (detect, ocr, transcribe, translate, chat)
 // service can be a string or array of strings for tasks that support multiple model types
@@ -588,7 +590,11 @@ export function buildJobResources(tier, { account, workerTimeout } = {}) {
   if (tier?.memory_gb != null) resources.mem = tier.memory_gb;
   if (tier?.gpu_count != null) resources.gpus = tier.gpu_count;
   if (account) resources.account = account;
-  if (workerTimeout) resources.time = `${workerTimeout}:00`;
+  if (workerTimeout) {
+    resources.time = `${workerTimeout}:00`
+  } else {
+    resources.time = DEFAULT_WORKER_TIMEOUT
+  };
   return resources;
 }
 

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -34,7 +34,7 @@ import { fetchProfileResources, fetchModelSizeFromHub, createJob } from "@/lib/r
 import { selectTierByModelSize, isRemoteProfile } from "@/lib/util";
 import PropTypes from "prop-types";
 
-const DEFAULT_WORKER_TIMEOUT = '01:00';
+const DEFAULT_WORKER_TIMEOUT = '01:00:00';
 
 // Task definitions - each task maps to a TigerFlow task type
 // id must match backend SUPPORTED_TASKS keys (detect, ocr, transcribe, translate, chat)

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -746,7 +746,6 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
   const [selectedPartition, setSelectedPartition] = useState(null);
   const [selectedTier, setSelectedTier] = useState(null);
   const [recommendedTier, setRecommendedTier] = useState(null);
-  const [maxWorkers, setMaxWorkers] = useState(1);
 
   // Advanced options
   const [showAdvanced, setShowAdvanced] = useState(false);
@@ -856,7 +855,6 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
       setSelectedPartition(null);
       setSelectedTier(null);
       setRecommendedTier(null);
-      setMaxWorkers(1);
       setShowAdvanced(false);
       setAccount("");
       setWorkerTimeout("");
@@ -1085,7 +1083,6 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
         cache_dir: cacheDir,
         params: Object.keys(pipelineParams).length > 0 ? pipelineParams : null,
         resources: Object.keys(jobResources).length > 0 ? jobResources : null,
-        max_workers: maxWorkers,
         idle_timeout: idleTimeout ? parseTimeToMinutes(idleTimeout) : undefined,
       };
 
@@ -1512,24 +1509,6 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
               />
             </div>
 
-            <fieldset>
-              <label className="block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100 mb-1">
-                Max Workers
-              </label>
-              <input
-                type="number"
-                min={1}
-                max={10}
-                value={maxWorkers}
-                onChange={(e) => setMaxWorkers(parseInt(e.target.value) || 1)}
-                disabled={isSubmitting}
-                className="block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 focus:ring-2 focus:ring-inset focus:ring-blue-500 sm:text-sm sm:leading-6 disabled:bg-gray-100 dark:disabled:bg-gray-800"
-              />
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                Maximum number of concurrent Slurm jobs. TigerFlow scales automatically.
-              </p>
-            </fieldset>
-
             {/* Advanced Options */}
             <fieldset>
               <button
@@ -1561,9 +1540,9 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
                   <ServiceModalValidatedInput
                     type="text"
                     htmlFor="worker-timeout"
-                    label="Worker Timeout"
+                    label="Time Limit"
                     placeholder="01:00"
-                    help="Time limit for each worker job in HH:MM format (max 168:00)."
+                    help="Slurm job time limit in HH:MM format (max 168:00)."
                     value={workerTimeout}
                     setValue={setWorkerTimeout}
                     validate={validateWorkerTimeout}

--- a/web/src/routes/jobs/components/NewJobModal.test.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.test.jsx
@@ -276,13 +276,13 @@ describe("buildJobResources", () => {
     expect(res.time).toBe("02:00:00");
   });
 
-  test("account and time are omitted when absent", () => {
+  test("account omitted when absent", () => {
     const res = buildJobResources(gpuTier);
     expect(res).not.toHaveProperty("account");
-    expect(res).not.toHaveProperty("time");
+    expect(res.time).toBe("01:00:00");
   });
 
-  test("an undefined tier yields an empty resources object", () => {
-    expect(buildJobResources(undefined)).toEqual({});
+  test("an undefined tier yields only default time", () => {
+    expect(buildJobResources(undefined)).toEqual({"time": "01:00:00"});
   });
 });


### PR DESCRIPTION
## Summary
- TigerFlow now runs as a single Slurm allocation (no auto-scaling), so remove the "Max Workers" input from the Compute step and stop sending `max_workers` in the job request (backend still defaults it to 1).
- Rename "Worker Timeout" → "Time Limit" so the label matches what it actually sets (the Slurm job time limit via `resources.time`).
- Update the job details panel: drop the "Max Workers" row, rename "Walltime (per allocation)" → "Time Limit", remove the stale PropType.

## Test plan
- [x] `npm run lint` (no new warnings)
- [x] `npm test` (510/510 pass)
- [ ] Manually launch a batch job from the UI; confirm Compute step shows Tier + Advanced Options only, and job details panel shows "Time Limit" instead of "Max Workers"/"Walltime"