### PR TITLE
fix(infra): remove autoupdate from just lint

### DIFF
--- a/lib/justfile
+++ b/lib/justfile
@@ -1,6 +1,8 @@
 lint:
-  uv run pre-commit autoupdate
   uv run pre-commit run --all-files
+
+lint-update:
+  uv run pre-commit autoupdate
 
 test:
   uv run pytest --cache-clear --verbose --cov=blackfish


### PR DESCRIPTION
Split the lint auto-update step into its own `just` command so updates are intentional: they should have their own PRs.

Closes #454 