### PR TITLE
feat(lib): persist and honor a pinned container image

### DIFF
--- a/lib/docs/assets/img/coverage.svg
+++ b/lib/docs/assets/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">70%</text>
-        <text x="80" y="14">70%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">71%</text>
+        <text x="80" y="14">71%</text>
     </g>
 </svg>

--- a/lib/docs/assets/img/coverage.svg
+++ b/lib/docs/assets/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">71%</text>
-        <text x="80" y="14">71%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">70%</text>
+        <text x="80" y="14">70%</text>
     </g>
 </svg>

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -1028,9 +1028,15 @@ async def get_ports(request: Request) -> int:  # type: ignore
     return find_port()
 
 
-def is_valid_image_ref(ref: str) -> str:
-    """Validate an optional pinned container image reference ("repo:tag")."""
-    ImageSpec.parse(ref)  # raises ValueError if malformed
+def is_valid_image_ref(ref: str | None) -> str | None:
+    """Validate an optional pinned container image reference ("repo:tag").
+
+    An explicit ``null`` is equivalent to omitting the field ("no pin"), so it
+    passes through rather than reaching ``ImageSpec.parse`` — which would raise
+    TypeError on None and surface as a 400 with an unhelpful message.
+    """
+    if ref is not None:
+        ImageSpec.parse(ref)  # raises ValueError if malformed
     return ref
 
 

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -119,6 +119,7 @@ from blackfish.server.setup import (
     ProfileSetupError,
     repair_slurm_profile,
 )
+from blackfish.server.images import ImageSpec
 from blackfish.server.models.model import (
     Model,
     PIPELINE_IMAGES,
@@ -1027,9 +1028,21 @@ async def get_ports(request: Request) -> int:  # type: ignore
     return find_port()
 
 
+def is_valid_image_ref(ref: str) -> str:
+    """Validate an optional pinned container image reference ("repo:tag")."""
+    ImageSpec.parse(ref)  # raises ValueError if malformed
+    return ref
+
+
+# A pinned container image, e.g. "ghcr.io/princeton-ddss/tigerflow-ml:0.1.1".
+# None means "use the configured default", which is then recorded on the row.
+ImageRef = Annotated[Optional[str], AfterValidator(is_valid_image_ref)]
+
+
 class ServiceRequest(BaseModel):
     name: str
     image: str
+    image_ref: ImageRef = None
     repo_id: str
     profile: Profile
     container_config: ContainerConfig
@@ -1060,6 +1073,7 @@ def build_service(data: ServiceRequest) -> Service:
     flattened = {
         "name": data.name,
         "model": data.repo_id,
+        "image_ref": data.image_ref,
         "profile": data.profile.name,
         "home_dir": data.profile.home_dir,
         "cache_dir": data.profile.cache_dir,
@@ -1338,6 +1352,7 @@ class BatchJobRequest(BaseModel):
     task: str  # e.g., "transcribe", "summarize"
     repo_id: str  # Model ID (e.g., "openai/whisper-large-v3")
     revision: Optional[str] = None  # Model revision
+    image_ref: ImageRef = None  # Pinned container image; None uses the default
     profile: Profile
     input_dir: str  # Input directory on cluster
     output_dir: str  # Output directory on cluster
@@ -1358,6 +1373,7 @@ def build_batch_job(data: BatchJobRequest) -> BatchJob:
         "task": data.task,
         "repo_id": data.repo_id,
         "revision": data.revision,
+        "image_ref": data.image_ref,
         "profile": data.profile.name,
         "home_dir": data.profile.home_dir,
         "input_dir": data.input_dir,

--- a/lib/src/blackfish/server/db/migrations/versions/2026-08-21_add_image_ref_columns_87981ca2ed42.py
+++ b/lib/src/blackfish/server/db/migrations/versions/2026-08-21_add_image_ref_columns_87981ca2ed42.py
@@ -1,0 +1,94 @@
+# type: ignore
+"""add image_ref columns
+
+Records the container image ("repo:tag") a service or batch job launched with,
+so restarts reuse it instead of picking up whatever the configured default
+points at. NULL for rows created before this migration.
+
+Revision ID: 87981ca2ed42
+Revises: d7e8f9a0b1c2
+Create Date: 2026-08-21 10:29:16.425386+00:00
+
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import sqlalchemy as sa
+from alembic import op
+from advanced_alchemy.types import (
+    EncryptedString,
+    EncryptedText,
+    GUID,
+    ORA_JSONB,
+    DateTimeUTC,
+)
+from sqlalchemy import Text  # noqa: F401
+
+__all__ = [
+    "downgrade",
+    "upgrade",
+    "schema_upgrades",
+    "schema_downgrades",
+    "data_upgrades",
+    "data_downgrades",
+]
+
+sa.GUID = GUID
+sa.DateTimeUTC = DateTimeUTC
+sa.ORA_JSONB = ORA_JSONB
+sa.EncryptedString = EncryptedString
+sa.EncryptedText = EncryptedText
+
+# revision identifiers, used by Alembic.
+revision = "87981ca2ed42"
+down_revision = "d7e8f9a0b1c2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        with op.get_context().autocommit_block():
+            schema_upgrades()
+            data_upgrades()
+
+
+def downgrade() -> None:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        with op.get_context().autocommit_block():
+            data_downgrades()
+            schema_downgrades()
+
+
+def schema_upgrades() -> None:
+    """schema upgrade migrations go here."""
+
+    # Nullable with no server_default: existing rows legitimately have no
+    # recorded image, and NULL means "resolve the configured default".
+    with op.batch_alter_table("service", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("image_ref", sa.String(), nullable=True))
+
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("image_ref", sa.String(), nullable=True))
+
+
+def schema_downgrades() -> None:
+    """schema downgrade migrations go here."""
+
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.drop_column("image_ref")
+
+    with op.batch_alter_table("service", schema=None) as batch_op:
+        batch_op.drop_column("image_ref")
+
+
+def data_upgrades() -> None:
+    """Add any optional data upgrade migrations here!"""
+
+
+def data_downgrades() -> None:
+    """Add any optional data downgrade migrations here!"""

--- a/lib/src/blackfish/server/images.py
+++ b/lib/src/blackfish/server/images.py
@@ -43,6 +43,23 @@ class ImageSpec:
         return cls(repo=repo, tag=tag)
 
 
+def resolve_image(image_ref: str | None, default: ImageSpec) -> ImageSpec:
+    """The pinned image if one was recorded, else the configured default.
+
+    Services and batch jobs persist the image they launched with (``image_ref``)
+    so that restarts reuse it rather than picking up whatever the config
+    currently points at.
+
+    Args:
+        image_ref: A persisted ``repo:tag`` reference, or None to use the default.
+        default: The configured image for this service/task.
+
+    Raises:
+        ValueError: If ``image_ref`` is set but malformed.
+    """
+    return ImageSpec.parse(image_ref) if image_ref else default
+
+
 DEFAULT_IMAGES: dict[str, ImageSpec] = {
     "text_generation": ImageSpec(repo="vllm/vllm-openai", tag="v0.20.0"),
     "speech_recognition": ImageSpec(

--- a/lib/src/blackfish/server/jobs/base.py
+++ b/lib/src/blackfish/server/jobs/base.py
@@ -130,13 +130,24 @@ def format_status(status: BatchJobStatus | None) -> str:
 def _resolve_image_and_provider(
     app_config: "State | BlackfishConfig",
     profile: "BlackfishProfile | None",
+    image_ref: str | None = None,
 ) -> tuple[Any, Any]:
     """Resolve the tigerflow-ml ImageSpec and container provider.
 
     The cluster runs Apptainer, so only a LocalProfile consults the locally
     detected ``CONTAINER_PROVIDER``; everything else is Apptainer.
+
+    Args:
+        app_config: Application configuration (IMAGES, CONTAINER_PROVIDER).
+        profile: The job's profile, which decides the container provider.
+        image_ref: A job's pinned ``repo:tag``, if it recorded one. Callers
+            holding a job MUST pass ``job.image_ref``: the launch script and
+            the health-check client each resolve an image independently, and
+            if they disagree the pre-flight validates a different SIF than the
+            job actually runs.
     """
     from blackfish.server.config import ContainerProvider, config as _config
+    from blackfish.server.images import resolve_image
 
     images = getattr(app_config, "IMAGES", None) or _config.IMAGES
 
@@ -149,7 +160,7 @@ def _resolve_image_and_provider(
             or ContainerProvider.Apptainer
         )
 
-    return images["tigerflow_ml"], provider
+    return resolve_image(image_ref, images["tigerflow_ml"]), provider
 
 
 def create_tigerflow_client_for_profile(
@@ -215,7 +226,10 @@ def create_tigerflow_client(
     # SIF location uses the profile cache_dir, not job.cache_dir (the HF cache).
     cache_dir = profile.cache_dir if profile else home_dir
 
-    image, provider = _resolve_image_and_provider(app_config, profile)
+    # Pass the job's pin: this client's SIF path is what check_health probes,
+    # and it must be the same image _render_script launches. Resolving the
+    # default here would validate one image while the job ran another.
+    image, provider = _resolve_image_and_provider(app_config, profile, job.image_ref)
     return TigerFlowClient(
         runner=runner,
         home_dir=home_dir,
@@ -283,7 +297,16 @@ class BatchJob(UUIDAuditBase):
     )
     processed_highwater: Mapped[int] = mapped_column(default=0)
 
-    # TigerFlow versions (for reproducibility)
+    # The container image this job actually ran, as "repo:tag". Set at launch
+    # (from the request, else the configured default) and reused on every
+    # resubmission, so a long job that restarts keeps the same image even if
+    # the configured default changes. NULL for jobs started before this was
+    # recorded.
+    image_ref: Mapped[Optional[str]]
+
+    # TigerFlow versions (for reproducibility). Read from *inside* the image
+    # at launch, so they describe its contents; `image_ref` above is the
+    # image that was chosen.
     tigerflow_version: Mapped[Optional[str]]
     tigerflow_ml_version: Mapped[Optional[str]]
 
@@ -361,7 +384,9 @@ class BatchJob(UUIDAuditBase):
             home_dir, "jobs", self.id.hex, f"pipeline-{self.id}.yaml"
         )
 
-        image, provider = _resolve_image_and_provider(app_config, profile)
+        image, provider = _resolve_image_and_provider(
+            app_config, profile, self.image_ref
+        )
         env = Environment(loader=PackageLoader("blackfish.server", "templates"))
         template = env.get_template(f"batch_{scheduler}.sh")
         return template.render(
@@ -464,6 +489,13 @@ class BatchJob(UUIDAuditBase):
         versions = await client.check_health()
         self.tigerflow_version = versions.tigerflow
         self.tigerflow_ml_version = versions.tigerflow_ml
+
+        # Record the image actually launched, so resubmissions reuse it even if
+        # the configured default changes. Taken from the client, which resolved
+        # (and just health-checked) the same spec _render_script will use.
+        # Only on first start: resume/restart must keep the existing pin.
+        if self.image_ref is None:
+            self.image_ref = client.image.docker_ref
 
         await self._ensure_directories(client)
 

--- a/lib/src/blackfish/server/services/base.py
+++ b/lib/src/blackfish/server/services/base.py
@@ -134,7 +134,7 @@ class Service(UUIDAuditBase):
     }
 
     def __repr__(self) -> str:
-        return f"Service(id={self.id}, name={self.name}, image={self.image}, model={self.model}, profile={self.profile}, host={self.host}, user={self.user}, home_dir={self.home_dir}, cache_dir={self.cache_dir}, job_id={self.job_id}, port={self.port}, status={self.status}, scheduler={self.scheduler}, provider={self.provider}, grace_period={self.grace_period}, mount={self.mount})"
+        return f"Service(id={self.id}, name={self.name}, image={self.image}, image_ref={self.image_ref}, model={self.model}, profile={self.profile}, host={self.host}, user={self.user}, home_dir={self.home_dir}, cache_dir={self.cache_dir}, job_id={self.job_id}, port={self.port}, status={self.status}, scheduler={self.scheduler}, provider={self.provider}, grace_period={self.grace_period}, mount={self.mount})"
 
     def get_profile(self) -> Optional[BlackfishProfile]:
         if self.scheduler == JobScheduler.Slurm:

--- a/lib/src/blackfish/server/services/base.py
+++ b/lib/src/blackfish/server/services/base.py
@@ -32,6 +32,7 @@ from blackfish.server.logger import logger
 from blackfish.server.utils import find_port
 from blackfish.server.http_client import HEALTH_CHECK_TIMEOUT
 from blackfish.server.config import ContainerProvider, config as blackfish_config
+from blackfish.server.images import resolve_image
 from blackfish.server.models.profile import BlackfishProfile, LocalProfile, SlurmProfile
 
 
@@ -95,7 +96,14 @@ class Service(UUIDAuditBase):
     __tablename__ = "service"
 
     name: Mapped[str]
+    # The service *type* (e.g. "text_generation"). Doubles as the polymorphic
+    # discriminator and the IMAGES/template key — not a container reference.
     image: Mapped[str]
+    # The container image this service actually ran, as "repo:tag". Set at
+    # launch (from the request, else the configured default) and reused on
+    # restart, so a config change can't silently swap the image underneath a
+    # running service. NULL for services started before this was recorded.
+    image_ref: Mapped[Optional[str]]
     model: Mapped[str]
 
     profile: Mapped[str]
@@ -679,6 +687,14 @@ class Service(UUIDAuditBase):
     ) -> str:
         env = Environment(loader=PackageLoader("blackfish.server", "templates"))
         template = env.get_template(f"{self.image}_{self.scheduler or 'local'}.sh")
+        image = resolve_image(self.image_ref, blackfish_config.IMAGES[self.image])
+
+        # Record the image actually rendered, so a restart reuses it even if the
+        # configured default changes. Backfilled here (rather than in start())
+        # because the Slurm and local branches each render separately.
+        if self.image_ref is None:
+            self.image_ref = image.docker_ref
+
         job_script = template.render(
             uuid=self.id.hex,
             name=self.name,
@@ -688,7 +704,7 @@ class Service(UUIDAuditBase):
             container_config=container_config,
             job_config=job_config,
             mount=self.mount,
-            image=blackfish_config.IMAGES[self.image],
+            image=image,
         )
 
         return job_script

--- a/lib/tests/api/test_jobs.py
+++ b/lib/tests/api/test_jobs.py
@@ -1119,7 +1119,11 @@ class TestCreateBatchJobAPI:
         with patch.object(BatchJob, "start", new_callable=AsyncMock):
             response = await client.post("/api/jobs", json=data)
 
+        # The point of this test: the request is accepted, not 400'd.
         assert response.status_code == 201
+        # start() is mocked, so this observes the row before the backfill —
+        # it shows the request path didn't invent a pin, not what a real
+        # launch returns (which is the resolved default).
         assert response.json()["image_ref"] is None
 
     async def test_create_job_without_image_ref_is_unpinned(

--- a/lib/tests/api/test_jobs.py
+++ b/lib/tests/api/test_jobs.py
@@ -1119,40 +1119,7 @@ class TestCreateBatchJobAPI:
         with patch.object(BatchJob, "start", new_callable=AsyncMock):
             response = await client.post("/api/jobs", json=data)
 
-        # The point of this test: the request is accepted, not 400'd.
         assert response.status_code == 201
-        # start() is mocked, so this observes the row before the backfill —
-        # it shows the request path didn't invent a pin, not what a real
-        # launch returns (which is the resolved default).
-        assert response.json()["image_ref"] is None
-
-    async def test_create_job_without_image_ref_is_unpinned(
-        self, client: AsyncTestClient
-    ):
-        """Omitting image_ref leaves it unset through build_batch_job.
-
-        start() is mocked here, so this observes the row before the backfill
-        runs; a real unpinned launch records the resolved default.
-        """
-
-        data = {
-            "name": "unpinned-job",
-            "task": "transcribe",
-            "repo_id": "openai/whisper-large-v3",
-            "profile": {
-                "name": "test",
-                "home_dir": "/home/test",
-                "cache_dir": "/cache",
-            },
-            "input_dir": "/data/input",
-            "output_dir": "/data/output",
-        }
-
-        with patch.object(BatchJob, "start", new_callable=AsyncMock):
-            response = await client.post("/api/jobs", json=data)
-
-        assert response.status_code == 201
-        assert response.json()["image_ref"] is None
 
     async def test_create_job_missing_request_body(self, client: AsyncTestClient):
         """Test creating a job with missing request body."""

--- a/lib/tests/api/test_jobs.py
+++ b/lib/tests/api/test_jobs.py
@@ -1090,10 +1090,46 @@ class TestCreateBatchJobAPI:
 
         assert response.status_code == 400
 
+    async def test_create_job_accepts_explicit_null_image_ref(
+        self, client: AsyncTestClient
+    ):
+        """An explicit null means "no pin", same as omitting the field.
+
+        The validator must short-circuit on None: passing it to
+        ImageSpec.parse raises TypeError, which surfaced as a 400 with
+        "argument of type 'NoneType' is not iterable" — rejecting a request
+        that is perfectly valid. A frontend serializing an empty selector is
+        the likely source of an explicit null.
+        """
+
+        data = {
+            "name": "null-pin-job",
+            "task": "transcribe",
+            "repo_id": "openai/whisper-large-v3",
+            "image_ref": None,
+            "profile": {
+                "name": "test",
+                "home_dir": "/home/test",
+                "cache_dir": "/cache",
+            },
+            "input_dir": "/data/input",
+            "output_dir": "/data/output",
+        }
+
+        with patch.object(BatchJob, "start", new_callable=AsyncMock):
+            response = await client.post("/api/jobs", json=data)
+
+        assert response.status_code == 201
+        assert response.json()["image_ref"] is None
+
     async def test_create_job_without_image_ref_is_unpinned(
         self, client: AsyncTestClient
     ):
-        """Omitting image_ref leaves it NULL; start() backfills the default."""
+        """Omitting image_ref leaves it unset through build_batch_job.
+
+        start() is mocked here, so this observes the row before the backfill
+        runs; a real unpinned launch records the resolved default.
+        """
 
         data = {
             "name": "unpinned-job",

--- a/lib/tests/api/test_jobs.py
+++ b/lib/tests/api/test_jobs.py
@@ -1042,6 +1042,78 @@ class TestCreateBatchJobAPI:
             assert job["repo_id"] == "openai/whisper-large-v3"
             assert job["profile"] == "test"  # only returns the name
 
+    async def test_create_job_with_pinned_image(self, client: AsyncTestClient):
+        """A pinned image_ref is persisted on the job."""
+
+        data = {
+            "name": "pinned-job",
+            "task": "transcribe",
+            "repo_id": "openai/whisper-large-v3",
+            "image_ref": "ghcr.io/princeton-ddss/tigerflow-ml:9.9.9",
+            "profile": {
+                "name": "test",
+                "home_dir": "/home/test",
+                "cache_dir": "/cache",
+            },
+            "input_dir": "/data/input",
+            "output_dir": "/data/output",
+        }
+
+        with patch.object(BatchJob, "start", new_callable=AsyncMock):
+            response = await client.post("/api/jobs", json=data)
+
+        assert response.status_code == 201
+        assert (
+            response.json()["image_ref"] == "ghcr.io/princeton-ddss/tigerflow-ml:9.9.9"
+        )
+
+    async def test_create_job_rejects_malformed_image_ref(
+        self, client: AsyncTestClient
+    ):
+        """A malformed ref is a 400, not a job that fails later at render."""
+
+        data = {
+            "name": "bad-pin",
+            "task": "transcribe",
+            "repo_id": "openai/whisper-large-v3",
+            "image_ref": "missing-the-tag",
+            "profile": {
+                "name": "test",
+                "home_dir": "/home/test",
+                "cache_dir": "/cache",
+            },
+            "input_dir": "/data/input",
+            "output_dir": "/data/output",
+        }
+
+        response = await client.post("/api/jobs", json=data)
+
+        assert response.status_code == 400
+
+    async def test_create_job_without_image_ref_is_unpinned(
+        self, client: AsyncTestClient
+    ):
+        """Omitting image_ref leaves it NULL; start() backfills the default."""
+
+        data = {
+            "name": "unpinned-job",
+            "task": "transcribe",
+            "repo_id": "openai/whisper-large-v3",
+            "profile": {
+                "name": "test",
+                "home_dir": "/home/test",
+                "cache_dir": "/cache",
+            },
+            "input_dir": "/data/input",
+            "output_dir": "/data/output",
+        }
+
+        with patch.object(BatchJob, "start", new_callable=AsyncMock):
+            response = await client.post("/api/jobs", json=data)
+
+        assert response.status_code == 201
+        assert response.json()["image_ref"] is None
+
     async def test_create_job_missing_request_body(self, client: AsyncTestClient):
         """Test creating a job with missing request body."""
         response = await client.post("/api/jobs")

--- a/lib/tests/unit/test_images.py
+++ b/lib/tests/unit/test_images.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from blackfish.server.images import DEFAULT_IMAGES, ImageSpec
+from blackfish.server.images import DEFAULT_IMAGES, ImageSpec, resolve_image
 
 
 def test_image_spec_docker_ref():
@@ -68,3 +68,46 @@ def test_default_images_covers_all_concrete_services():
         f"Service identities {identities} do not match "
         f"DEFAULT_IMAGES service keys {service_image_keys}"
     )
+
+
+class TestResolveImage:
+    """Tests for resolve_image, the pin-or-default helper.
+
+    Services and batch jobs persist the image they launched with so that
+    restarts reuse it rather than following a changed config default.
+    """
+
+    DEFAULT = ImageSpec(repo="ghcr.io/princeton-ddss/tigerflow-ml", tag="0.1.1")
+
+    def test_returns_default_when_no_pin(self):
+        assert resolve_image(None, self.DEFAULT) is self.DEFAULT
+
+    def test_pin_wins_over_default(self):
+        """A recorded pin must beat the configured default — this is the whole
+        point: a config change must not silently swap a running job's image."""
+        spec = resolve_image("ghcr.io/princeton-ddss/tigerflow-ml:0.1.2", self.DEFAULT)
+        assert spec.tag == "0.1.2"
+        assert spec.repo == "ghcr.io/princeton-ddss/tigerflow-ml"
+
+    def test_pin_may_change_repo_not_just_tag(self):
+        """image_ref stores the full repo:tag, so a pin can move repos too."""
+        spec = resolve_image("vllm/vllm-openai:v0.20.0", self.DEFAULT)
+        assert spec.repo == "vllm/vllm-openai"
+        assert spec.tag == "v0.20.0"
+
+    def test_resolved_pin_round_trips_through_sif_and_docker_ref(self):
+        """The pin must survive into both launch forms (apptainer and docker)."""
+        spec = resolve_image("ghcr.io/princeton-ddss/tigerflow-ml:0.1.2", self.DEFAULT)
+        assert spec.sif == "tigerflow-ml_0.1.2.sif"
+        assert spec.docker_ref == "ghcr.io/princeton-ddss/tigerflow-ml:0.1.2"
+
+    @pytest.mark.parametrize("bad", ["no-tag", "repo:", ":tag", ""])
+    def test_malformed_pin_raises(self, bad):
+        """Malformed refs raise so the API can reject them as a 400 rather
+        than rendering a broken launch script."""
+        if bad == "":
+            # Empty string is falsy -> treated as "no pin", not an error.
+            assert resolve_image(bad, self.DEFAULT) is self.DEFAULT
+        else:
+            with pytest.raises(ValueError):
+                resolve_image(bad, self.DEFAULT)

--- a/lib/tests/unit/test_images.py
+++ b/lib/tests/unit/test_images.py
@@ -89,25 +89,14 @@ class TestResolveImage:
         assert spec.tag == "0.1.2"
         assert spec.repo == "ghcr.io/princeton-ddss/tigerflow-ml"
 
-    def test_pin_may_change_repo_not_just_tag(self):
-        """image_ref stores the full repo:tag, so a pin can move repos too."""
-        spec = resolve_image("vllm/vllm-openai:v0.20.0", self.DEFAULT)
-        assert spec.repo == "vllm/vllm-openai"
-        assert spec.tag == "v0.20.0"
+    def test_malformed_pin_raises(self):
+        """A malformed pin propagates ValueError, so the API rejects it as a
+        400 rather than rendering a broken launch script."""
+        with pytest.raises(ValueError):
+            resolve_image("no-tag", self.DEFAULT)
 
-    def test_resolved_pin_round_trips_through_sif_and_docker_ref(self):
-        """The pin must survive into both launch forms (apptainer and docker)."""
-        spec = resolve_image("ghcr.io/princeton-ddss/tigerflow-ml:0.1.2", self.DEFAULT)
-        assert spec.sif == "tigerflow-ml_0.1.2.sif"
-        assert spec.docker_ref == "ghcr.io/princeton-ddss/tigerflow-ml:0.1.2"
-
-    @pytest.mark.parametrize("bad", ["no-tag", "repo:", ":tag", ""])
-    def test_malformed_pin_raises(self, bad):
-        """Malformed refs raise so the API can reject them as a 400 rather
-        than rendering a broken launch script."""
-        if bad == "":
-            # Empty string is falsy -> treated as "no pin", not an error.
-            assert resolve_image(bad, self.DEFAULT) is self.DEFAULT
-        else:
-            with pytest.raises(ValueError):
-                resolve_image(bad, self.DEFAULT)
+    def test_empty_pin_is_treated_as_no_pin(self):
+        """An empty string is falsy, so it falls through to the default rather
+        than raising — worth pinning down since "" is a plausible value from a
+        form field that was rendered but never filled in."""
+        assert resolve_image("", self.DEFAULT) is self.DEFAULT

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -77,6 +77,9 @@ def create_mock_client() -> AsyncMock:
     client.host = "localhost"
     client.runner = AsyncMock()
     client.runner.run = AsyncMock(return_value=(0, b"", b""))
+    # Set on the real client in __init__, so `spec` doesn't provide it. start()
+    # reads it to record the image the job actually launched with.
+    client.image = DEFAULT_IMAGES["tigerflow_ml"]
     return client
 
 
@@ -1098,3 +1101,131 @@ class TestTasks:
         )
         rendered = job._pipeline_yaml()
         assert "output_ext: .txt" in rendered
+
+
+class TestBatchJobImagePinning:
+    """Tests for the persisted container image (``image_ref``).
+
+    A job records the image it launched with so that resubmissions reuse it
+    rather than following a changed configuration default.
+    """
+
+    def _slurm_localhost(self):
+        from blackfish.server.models.profile import SlurmProfile
+
+        return SlurmProfile(
+            name="onburst",
+            host="localhost",
+            user="alice",
+            home_dir="/home/alice/.blackfish",
+            cache_dir="/scratch/cache",
+        )
+
+    @patch("blackfish.server.jobs.base.deserialize_profile")
+    def test_render_uses_configured_default_when_unpinned(
+        self, mock_deserialize: Mock
+    ) -> None:
+        """No pin -> the configured default SIF, i.e. today's behavior."""
+        mock_deserialize.return_value = self._slurm_localhost()
+        job = create_test_batch_job(host="localhost", image_ref=None)
+
+        script = job._render_script(MockAppConfig())
+
+        assert DEFAULT_IMAGES["tigerflow_ml"].sif in script
+
+    @patch("blackfish.server.jobs.base.deserialize_profile")
+    def test_render_uses_the_pin_when_set(self, mock_deserialize: Mock) -> None:
+        """A pin overrides the configured default in the launch script."""
+        mock_deserialize.return_value = self._slurm_localhost()
+        job = create_test_batch_job(
+            host="localhost",
+            image_ref="ghcr.io/princeton-ddss/tigerflow-ml:9.9.9",
+        )
+
+        script = job._render_script(MockAppConfig())
+
+        assert "tigerflow-ml_9.9.9.sif" in script
+        assert DEFAULT_IMAGES["tigerflow_ml"].sif not in script
+
+    @patch("blackfish.server.jobs.base.deserialize_profile")
+    def test_resubmission_still_renders_the_pin(self, mock_deserialize: Mock) -> None:
+        """The regression this feature exists to prevent.
+
+        Batch jobs re-render on every resubmission (the restart loop calls
+        _submit -> _render_script), so a long job must not drift onto a new
+        image just because the configured default moved.
+        """
+        mock_deserialize.return_value = self._slurm_localhost()
+        job = create_test_batch_job(
+            host="localhost",
+            image_ref="ghcr.io/princeton-ddss/tigerflow-ml:9.9.9",
+            restarts=3,
+        )
+
+        for _ in range(2):
+            assert "tigerflow-ml_9.9.9.sif" in job._render_script(MockAppConfig())
+
+    async def test_start_backfills_image_ref_from_the_client(self) -> None:
+        """An unpinned launch records what actually ran.
+
+        The value comes from the client, which resolved and health-checked the
+        same spec the script uses, so the record can't disagree with reality.
+        """
+        job = create_test_batch_job(image_ref=None)
+        client = create_mock_client()
+        client.image = DEFAULT_IMAGES["tigerflow_ml"]
+        client.check_health.return_value = TigerFlowVersions(
+            tigerflow="0.1.0", tigerflow_ml="0.1.0"
+        )
+
+        with patch.object(job, "_submit", new=AsyncMock(return_value="99")):
+            await job.start(MockAppConfig(), client)
+
+        assert job.image_ref == DEFAULT_IMAGES["tigerflow_ml"].docker_ref
+
+    async def test_start_does_not_overwrite_an_existing_pin(self) -> None:
+        """A user-supplied pin survives start(); backfill only fills a blank."""
+        pinned = "ghcr.io/princeton-ddss/tigerflow-ml:9.9.9"
+        job = create_test_batch_job(image_ref=pinned)
+        client = create_mock_client()
+        client.image = DEFAULT_IMAGES["tigerflow_ml"]
+        client.check_health.return_value = TigerFlowVersions(
+            tigerflow="0.1.0", tigerflow_ml="0.1.0"
+        )
+
+        with patch.object(job, "_submit", new=AsyncMock(return_value="99")):
+            await job.start(MockAppConfig(), client)
+
+        assert job.image_ref == pinned
+
+    @patch("blackfish.server.jobs.base.deserialize_profile")
+    def test_client_is_built_from_the_jobs_pin(self, mock_deserialize: Mock) -> None:
+        """The health-check client must probe the SIF the script will run.
+
+        create_tigerflow_client resolves an image independently of
+        _render_script. If it ignored the pin, check_health would verify one
+        image (and record its versions) while the job ran another.
+        """
+        mock_deserialize.return_value = self._slurm_localhost()
+        job = create_test_batch_job(
+            host="localhost",
+            image_ref="ghcr.io/princeton-ddss/tigerflow-ml:9.9.9",
+        )
+
+        client = create_tigerflow_client(job, MockAppConfig())
+
+        assert client.image.tag == "9.9.9"
+        assert "tigerflow-ml_9.9.9.sif" in client.sif_path
+        # And it matches what the launch script actually references.
+        assert client.image.sif in job._render_script(MockAppConfig())
+
+    @patch("blackfish.server.jobs.base.deserialize_profile")
+    def test_client_falls_back_to_default_when_unpinned(
+        self, mock_deserialize: Mock
+    ) -> None:
+        mock_deserialize.return_value = self._slurm_localhost()
+        job = create_test_batch_job(host="localhost", image_ref=None)
+
+        client = create_tigerflow_client(job, MockAppConfig())
+
+        assert client.image == DEFAULT_IMAGES["tigerflow_ml"]

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 import pytest
 from blackfish.server.config import ContainerProvider
-from blackfish.server.images import DEFAULT_IMAGES
+from blackfish.server.images import DEFAULT_IMAGES, ImageSpec
 from blackfish.server.job import JobState
 from blackfish.server.jobs.base import (
     DEFAULT_JOB_RESOURCES,
@@ -1148,22 +1148,43 @@ class TestBatchJobImagePinning:
         assert DEFAULT_IMAGES["tigerflow_ml"].sif not in script
 
     @patch("blackfish.server.jobs.base.deserialize_profile")
-    def test_resubmission_still_renders_the_pin(self, mock_deserialize: Mock) -> None:
+    def test_pin_survives_a_changed_configured_default(
+        self, mock_deserialize: Mock
+    ) -> None:
         """The regression this feature exists to prevent.
 
         Batch jobs re-render on every resubmission (the restart loop calls
-        _submit -> _render_script), so a long job must not drift onto a new
-        image just because the configured default moved.
+        _submit -> _render_script). If the configured default moves mid-flight
+        — a redeploy with a new DEFAULT_IMAGES pin, or a changed
+        BLACKFISH_TIGERFLOW_ML_IMAGE — a job holding a pin must keep rendering
+        *its* image, not the new default.
         """
         mock_deserialize.return_value = self._slurm_localhost()
         job = create_test_batch_job(
             host="localhost",
             image_ref="ghcr.io/princeton-ddss/tigerflow-ml:9.9.9",
-            restarts=3,
         )
 
-        for _ in range(2):
-            assert "tigerflow-ml_9.9.9.sif" in job._render_script(MockAppConfig())
+        # First allocation, under the original default.
+        assert "tigerflow-ml_9.9.9.sif" in job._render_script(MockAppConfig())
+
+        # The deployment's default moves out from under the running job.
+        class MovedDefaultConfig(MockAppConfig):
+            IMAGES = {
+                **DEFAULT_IMAGES,
+                "tigerflow_ml": ImageSpec(
+                    repo="ghcr.io/princeton-ddss/tigerflow-ml", tag="5.5.5"
+                ),
+            }
+
+        # Sanity-check the new default is live: an *unpinned* job follows it.
+        unpinned = create_test_batch_job(host="localhost", image_ref=None)
+        assert "tigerflow-ml_5.5.5.sif" in unpinned._render_script(MovedDefaultConfig())
+
+        # The pinned job does not drift onto it.
+        resubmitted = job._render_script(MovedDefaultConfig())
+        assert "tigerflow-ml_9.9.9.sif" in resubmitted
+        assert "tigerflow-ml_5.5.5.sif" not in resubmitted
 
     async def test_start_backfills_image_ref_from_the_client(self) -> None:
         """An unpinned launch records what actually ran.

--- a/lib/tests/unit/test_migrations.py
+++ b/lib/tests/unit/test_migrations.py
@@ -408,3 +408,104 @@ class TestNormalizeModelDirMigration:
             ).scalar_one()
 
         assert result == fixed
+
+
+def _create_minimal_service_table(conn: sa.Connection) -> None:
+    """Create a minimal `service` table for exercising the image_ref migration."""
+    conn.execute(
+        text(
+            """
+            CREATE TABLE service (
+                id BLOB NOT NULL,
+                name VARCHAR NOT NULL,
+                image VARCHAR NOT NULL,
+                model VARCHAR NOT NULL,
+                CONSTRAINT pk_service PRIMARY KEY (id)
+            )
+            """
+        )
+    )
+
+
+class TestAddImageRefColumns:
+    """Tests for 2026-08-21_add_image_ref_columns (revision 87981ca2ed42).
+
+    Adds a nullable `image_ref` to both `service` and `jobs`, recording the
+    container image a launch used so restarts can reuse it.
+    """
+
+    FILENAME = "2026-08-21_add_image_ref_columns_87981ca2ed42.py"
+
+    def test_schema_upgrade_adds_image_ref_to_both_tables(self, engine: Engine) -> None:
+        """Both tables gain a nullable image_ref column."""
+        with engine.connect() as conn:
+            _create_minimal_service_table(conn)
+            _create_v05_jobs_table(conn)
+            conn.commit()
+
+            migration = load_migration(self.FILENAME)
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.schema_upgrades()
+            conn.commit()
+
+            for table in ("service", "jobs"):
+                cols = _get_columns(conn, table)
+                assert "image_ref" in cols, f"missing image_ref on {table!r}"
+                # PRAGMA reports notnull=1 for NOT NULL columns.
+                assert not cols["image_ref"]["notnull"], (
+                    f"image_ref on {table!r} must be nullable: pre-existing rows "
+                    "have no recorded image, and NULL means 'use the default'"
+                )
+
+    def test_existing_rows_survive_with_null_image_ref(self, engine: Engine) -> None:
+        """Rows created before the migration keep their data, with image_ref NULL."""
+        with engine.connect() as conn:
+            _create_minimal_service_table(conn)
+            _create_v05_jobs_table(conn)
+            conn.execute(
+                text(
+                    "INSERT INTO service (id, name, image, model) "
+                    "VALUES (:id, :n, :i, :m)"
+                ),
+                {
+                    "id": b"svc",
+                    "n": "existing",
+                    "i": "text_generation",
+                    "m": "meta-llama/Llama-3.1-8B",
+                },
+            )
+            conn.commit()
+
+            migration = load_migration(self.FILENAME)
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.schema_upgrades()
+            conn.commit()
+
+            row = conn.execute(text("SELECT name, image, image_ref FROM service")).one()
+
+        assert row.name == "existing"
+        assert row.image == "text_generation"
+        assert row.image_ref is None
+
+    def test_schema_downgrade_removes_image_ref(self, engine: Engine) -> None:
+        """Downgrade drops the column from both tables."""
+        with engine.connect() as conn:
+            _create_minimal_service_table(conn)
+            _create_v05_jobs_table(conn)
+            conn.commit()
+
+            migration = load_migration(self.FILENAME)
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.schema_upgrades()
+            conn.commit()
+
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.schema_downgrades()
+            conn.commit()
+
+            for table in ("service", "jobs"):
+                assert "image_ref" not in _get_columns(conn, table)

--- a/lib/tests/unit/test_services.py
+++ b/lib/tests/unit/test_services.py
@@ -224,3 +224,75 @@ class TestServiceLaunchError:
         error = ServiceLaunchError("submit", "hpc.princeton.edu")
         assert error.error_type == "submit"
         assert error.host == "hpc.princeton.edu"
+
+
+class TestServiceImagePinning:
+    """Tests for the persisted container image (``image_ref``) on services.
+
+    A service records the image it launched with so that a restart reuses it
+    rather than following a changed configuration default.
+    """
+
+    def _service(self, **kwargs):
+        from uuid import UUID
+
+        from blackfish.server.job import JobScheduler
+        from blackfish.server.services.text_generation import TextGeneration
+
+        defaults = {
+            "id": UUID("2a7a8e62-40cc-4240-a825-463e5b11a81f"),
+            "name": "test-service",
+            "model": "meta-llama/Llama-3.1-8B-Instruct",
+            "profile": "default",
+            "host": "localhost",
+            "user": "alice",
+            "home_dir": "/home/alice/.blackfish",
+            "cache_dir": "/scratch/cache",
+            "scheduler": JobScheduler.Slurm,
+            "grace_period": 180,
+        }
+        defaults.update(kwargs)
+        return TextGeneration(**defaults)
+
+    def _render(self, service):
+        from blackfish.server.job import SlurmJobConfig
+        from blackfish.server.services.text_generation import TextGenerationConfig
+
+        return service.render_job_script(
+            TextGenerationConfig(port=8080),
+            SlurmJobConfig(name="test-service"),
+        )
+
+    def test_render_uses_configured_default_when_unpinned(self):
+        """No pin -> the configured default SIF, i.e. today's behavior."""
+        from blackfish.server.images import DEFAULT_IMAGES
+
+        script = self._render(self._service(image_ref=None))
+
+        assert DEFAULT_IMAGES["text_generation"].sif in script
+
+    def test_render_uses_the_pin_when_set(self):
+        """A pin overrides the configured default in the launch script."""
+        from blackfish.server.images import DEFAULT_IMAGES
+
+        script = self._render(self._service(image_ref="vllm/vllm-openai:v9.9.9"))
+
+        assert "vllm-openai_v9.9.9.sif" in script
+        assert DEFAULT_IMAGES["text_generation"].sif not in script
+
+    def test_render_backfills_image_ref_when_unpinned(self):
+        """An unpinned render records what it actually used, so a later
+        restart reuses that image instead of a changed default."""
+        from blackfish.server.images import DEFAULT_IMAGES
+
+        service = self._service(image_ref=None)
+        self._render(service)
+
+        assert service.image_ref == DEFAULT_IMAGES["text_generation"].docker_ref
+
+    def test_render_does_not_overwrite_an_existing_pin(self):
+        """Backfill only fills a blank; a user-supplied pin survives."""
+        service = self._service(image_ref="vllm/vllm-openai:v9.9.9")
+        self._render(service)
+
+        assert service.image_ref == "vllm/vllm-openai:v9.9.9"


### PR DESCRIPTION
## Summary

- Records the container image a service or batch job launched with in a new nullable `image_ref` column (`repo:tag`), and prefers it over the configured default when rendering the launch script. Restarts reuse the stored pin, so changing `DEFAULT_IMAGES` or a `BLACKFISH_*_IMAGE` override can no longer swap the image underneath a running job. This matters for batch jobs in particular: `_submit` → `_render_script` runs on *every* resubmission, so a long job could previously drift onto a new image mid-life.
- Resolves the pin in `create_tigerflow_client` as well as `_render_script`. A job resolves its image twice — once for the health-check client (which derives the SIF path it probes) and once for the launch script. Honoring the pin in only one place would validate one image while running another, and would record the *wrong* image's `tigerflow_ml_version`.
- Accepts an optional `image_ref` on `ServiceRequest` and `BatchJobRequest`, validated via `ImageSpec.parse` (400 on a malformed ref). Launching with no pin backfills the resolved default onto the row, so every launch from now on records what actually ran. `resume`/restart never overwrite an existing pin.

Field naming note: it cannot be called `image` — `Service.image` is the SQLAlchemy polymorphic discriminator holding the service *type*, and `Model.image` is a Hugging Face pipeline tag.

No template changes: all six service/batch templates already receive an `image` object and use `.sif` / `.docker_ref`. Only *which* `ImageSpec` is passed changes.

This is the first of four sub-issues under #212. Follow-ups: read-only surfacing in the CLI and details views (#481), a `GET /api/images` discovery route (#482), and launcher selectors (#483). Pinning is reachable via the API only until #483 lands.

## Test plan

- [x] `uv run just lint` — clean, including MyPy strict.
- [x] `uv run just test` — 927 passed, 7 skipped (20 new tests; coverage 70% → 71%).
- [x] **Migration verified against real alembic**, not just the unit harness: `alembic heads` reports a single head correctly chained off `d7e8f9a0b1c2`; a real `upgrade head` from an empty DB adds `image_ref` to both `service` and `jobs` as nullable `VARCHAR`; a real `downgrade` removes it from both.
- [x] **Pin honored on resubmission** — the regression this exists to prevent. `test_resubmission_still_renders_the_pin` asserts a pinned job re-renders the pinned SIF across repeated `_render_script` calls.
- [x] **Two-resolution consistency** — `test_client_is_built_from_the_jobs_pin` asserts the health-check client's SIF path matches the launch script's. Sanity-checked by reverting just the `create_tigerflow_client` change: the test fails with `9.9.9` vs `0.1.1`, confirming it catches the real bug rather than passing vacuously.
- [x] **Backfill semantics** — `start()` fills a blank `image_ref` from the client's resolved spec; an existing pin survives untouched.
- [x] API: a valid `image_ref` persists on the created job; a malformed one returns 400; omitting it leaves the column NULL.
- [x] Existing rows are unaffected — the column is nullable with no server default, and NULL means "resolve the configured default" (verified on a local DB with 12 services and 5 jobs).

Closes #480.
