### PR TITLE
feat: surface the pinned container image in the CLI and UI

### DIFF
--- a/lib/docs/assets/img/coverage.svg
+++ b/lib/docs/assets/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">70%</text>
-        <text x="80" y="14">70%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">71%</text>
+        <text x="80" y="14">71%</text>
     </g>
 </svg>

--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -629,6 +629,9 @@ def details(service_id: str) -> None:  # pragma: no cover
     data = {
         "name": service.name,
         "image": service.image,
+        # The full "repo:tag" this service launched with (null if it predates
+        # image_ref or was never launched). `ls` shows only the tag.
+        "image_ref": service.image_ref,
         "model": service.model,
         "profile": asdict(profile) if profile is not None else None,
         "status": {
@@ -697,13 +700,14 @@ def ls(filters: Optional[str], all: bool = False) -> None:  # pragma: no cover
     from typing import Any
     from prettytable import PrettyTable, TableStyle
     from datetime import datetime
-    from blackfish.server.utils import format_datetime
+    from blackfish.server.utils import format_datetime, format_image_version
     from blackfish.server.services.base import ServiceStatus
 
     tab = PrettyTable(
         field_names=[
             "SERVICE ID",
             "IMAGE",
+            "VERSION",
             "MODEL",
             "CREATED",
             "UPDATED",
@@ -756,6 +760,7 @@ def ls(filters: Optional[str], all: bool = False) -> None:  # pragma: no cover
                 [
                     service["id"][:DISPLAY_ID_LENGTH],
                     service["image"],
+                    format_image_version(service.get("image_ref")),
                     service["model"],
                     format_datetime(datetime.fromisoformat(service["created_at"])),
                     format_datetime(datetime.fromisoformat(service["updated_at"])),

--- a/lib/src/blackfish/cli/batch.py
+++ b/lib/src/blackfish/cli/batch.py
@@ -31,6 +31,7 @@ from blackfish.cli.profile import resolve_profile_or_exit
 from blackfish.server.models.profile import deserialize_profile
 from blackfish.server.utils import (
     format_datetime,
+    format_image_version,
     get_latest_commit,
     get_model_dir,
     get_models,
@@ -136,6 +137,7 @@ def list_batch_jobs(
         field_names=[
             "JOB ID",
             "TASK",
+            "VERSION",
             "MODEL",
             "CREATED",
             "UPDATED",
@@ -207,6 +209,7 @@ def list_batch_jobs(
                 [
                     job["id"][:DISPLAY_ID_LENGTH],
                     job.get("task", ""),
+                    format_image_version(job.get("image_ref")),
                     job.get("repo_id", ""),
                     format_datetime(datetime.fromisoformat(job["created_at"])),
                     format_datetime(datetime.fromisoformat(job["updated_at"])),

--- a/lib/src/blackfish/server/utils.py
+++ b/lib/src/blackfish/server/utils.py
@@ -5,6 +5,7 @@ from typing import Optional
 from huggingface_hub import ModelCard, list_repo_commits
 from huggingface_hub.errors import RepositoryNotFoundError
 from blackfish.server import remote
+from blackfish.server.images import ImageSpec
 from blackfish.server.models.profile import BlackfishProfile, SlurmProfile
 from blackfish.server.logger import logger
 from yaspin import yaspin
@@ -270,6 +271,25 @@ def find_port(
                         f"Failed to bind port {port} on host {host}. Trying next port."
                     )
     raise OSError(f"OSError: no ports available in range {lower}-{upper}")
+
+
+def format_image_version(image_ref: Optional[str]) -> str:
+    """Format an ``image_ref`` as a short tag for a list table.
+
+    List tables are already near the width of a standard terminal, so they show
+    only the tag ("0.1.1") rather than the full ``repo:tag``; the complete
+    reference is available in the details views.
+
+    Returns "-" when no image was recorded — the column is NULL for anything
+    created before the image_ref migration or never launched — and falls back to
+    the raw value if it isn't a well-formed reference.
+    """
+    if not image_ref:
+        return "-"
+    try:
+        return ImageSpec.parse(image_ref).tag
+    except ValueError:
+        return image_ref
 
 
 def format_datetime(t0: datetime.datetime, t1: datetime.datetime | None = None) -> str:

--- a/lib/tests/unit/test_utils.py
+++ b/lib/tests/unit/test_utils.py
@@ -131,6 +131,25 @@ def test_find_port_none():
     pass
 
 
+def test_format_image_version():
+    """The list tables show a tag, or a dash when nothing was recorded."""
+    # Well-formed refs render as the tag alone — the tables are already near
+    # terminal width, so the full repo:tag goes in the details views instead.
+    assert (
+        utils.format_image_version("ghcr.io/princeton-ddss/tigerflow-ml:0.1.1")
+        == "0.1.1"
+    )
+    assert utils.format_image_version("vllm/vllm-openai:v0.20.0") == "v0.20.0"
+
+    # NULL for rows created before image_ref existed, or never launched.
+    assert utils.format_image_version(None) == "-"
+    assert utils.format_image_version("") == "-"
+
+    # An unparsable value falls back to itself rather than raising, so a bad
+    # row can never break the whole table.
+    assert utils.format_image_version("garbage") == "garbage"
+
+
 def test_format_datetime():
     t1 = datetime.datetime(
         2025, 1, 12, 14, 58, 29, 646404, tzinfo=datetime.timezone.utc

--- a/web/src/components/ServiceSummary.jsx
+++ b/web/src/components/ServiceSummary.jsx
@@ -7,6 +7,7 @@ import {
   CpuChipIcon,
   FireIcon,
   CubeTransparentIcon,
+  CircleStackIcon,
 } from "@heroicons/react/24/outline";
 import PropTypes from "prop-types";
 import { formattedTimeInterval, isServiceRunning } from "@/lib/util";
@@ -59,6 +60,11 @@ function ServiceSummary({
               <div className="grow font-regular text-sm mr-1">Model </div>
               <span className="mr-2">-</span>
             </div>
+            <div className="mb-1 ml-0 inline-flex justify-start items-center">
+              <CubeTransparentIcon className="h-6 w-6 text-gray-300 dark:text-gray-600 mr-1" />
+              <div className="grow font-regular text-sm mr-1">Image </div>
+              <span className="mr-2">-</span>
+            </div>
             <div className="mb-1 ml-0 inline-flex justify-start items-center capitalize">
               <HeartIcon className="h-6 w-6 text-gray-300 dark:text-gray-600 mr-1" />
               <div className="grow font-regular text-sm mr-1">Status </div>
@@ -80,7 +86,7 @@ function ServiceSummary({
               <span className="mr-2">-</span>
             </div>
             <div className="mb-1 ml-0 inline-flex items-center">
-              <CubeTransparentIcon className="h-6 w-6 text-gray-300 dark:text-gray-600 mr-1" />
+              <CircleStackIcon className="h-6 w-6 text-gray-300 dark:text-gray-600 mr-1" />
               <div className="grow font-regular text-sm mr-1">Memory </div>
               <span className="mr-2">-</span>
             </div>
@@ -109,6 +115,15 @@ function ServiceSummary({
             {service?.model
               ? service.model.split("/")[1] || service.model
               : "-"}
+          </div>
+          <div className="mb-1 ml-0 inline-flex justify-start items-center">
+            <CubeTransparentIcon className="h-6 w-6 text-gray-600 dark:text-gray-400 mr-1" />
+            <div className="grow font-medium text-sm mr-1">Image </div>
+            {/* Show the tag only — a full "repo:tag" overflows this column.
+                The complete reference is in the title attribute. */}
+            <span className="service-summary__image" title={service?.image_ref || undefined}>
+              {service?.image_ref ? service.image_ref.split(":").pop() : "-"}
+            </span>
           </div>
           <div className="mb-1 ml-0 inline-flex justify-start items-center capitalize">
             <HeartIcon className="h-6 w-6 text-gray-600 dark:text-gray-400 mr-1" />
@@ -141,7 +156,7 @@ function ServiceSummary({
             {service?.ntasks_per_node || "-"}
           </div>
           <div className="mb-1 ml-0 inline-flex items-center">
-            <CubeTransparentIcon className="h-6 w-6 text-gray-600 dark:text-gray-400 mr-1" />
+            <CircleStackIcon className="h-6 w-6 text-gray-600 dark:text-gray-400 mr-1" />
             <div className="grow font-medium text-sm mr-1">Memory </div>
             {service?.mem || "-"}
           </div>

--- a/web/src/components/ServiceSummary.test.jsx
+++ b/web/src/components/ServiceSummary.test.jsx
@@ -129,7 +129,27 @@ describe("ServiceSummary", () => {
       container.querySelectorAll('.gpus-indicator')
     ).filter((el) => el.textContent.trim() === "-");
     expect(gpus).toHaveLength(1);
+    // image_ref is null for services created before it was recorded, or
+    // never launched, so the row must degrade to a dash rather than blank.
+    expect(
+      container.querySelector('.service-summary__image').textContent.trim()
+    ).toBe("-");
     expect(baseElement).toMatchSnapshot();
+  });
+
+  it("renders the image tag, with the full reference as a title", () => {
+    // The column is narrow, so only the tag is shown; the full repo:tag is
+    // preserved in the title attribute for hover.
+    const { container } = render(
+      <ServiceSummary
+        service={{ ...mockService, image_ref: "vllm/vllm-openai:v0.20.0" }}
+        profile={mockProfile}
+        task="test-task"
+      />
+    );
+    const image = container.querySelector('.service-summary__image');
+    expect(image.textContent.trim()).toBe("v0.20.0");
+    expect(image.getAttribute("title")).toBe("vllm/vllm-openai:v0.20.0");
   });
 
   describe("Timer component", () => {

--- a/web/src/components/__snapshots__/ServiceSummary.test.jsx.snap
+++ b/web/src/components/__snapshots__/ServiceSummary.test.jsx.snap
@@ -39,6 +39,36 @@ exports[`ServiceSummary > Timer component > renders Timer for running service cr
             model-name
           </div>
           <div
+            class="mb-1 ml-0 inline-flex justify-start items-center"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-6 w-6 text-gray-600 dark:text-gray-400 mr-1"
+              data-slot="icon"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <div
+              class="grow font-medium text-sm mr-1"
+            >
+              Image 
+            </div>
+            <span
+              class="service-summary__image"
+            >
+              -
+            </span>
+          </div>
+          <div
             class="mb-1 ml-0 inline-flex justify-start items-center capitalize"
           >
             <svg
@@ -162,7 +192,7 @@ exports[`ServiceSummary > Timer component > renders Timer for running service cr
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
                 stroke-linecap="round"
                 stroke-linejoin="round"
               />
@@ -263,6 +293,36 @@ exports[`ServiceSummary > Timer component > renders Timer for updated_at when it
             model-name
           </div>
           <div
+            class="mb-1 ml-0 inline-flex justify-start items-center"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-6 w-6 text-gray-600 dark:text-gray-400 mr-1"
+              data-slot="icon"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <div
+              class="grow font-medium text-sm mr-1"
+            >
+              Image 
+            </div>
+            <span
+              class="service-summary__image"
+            >
+              -
+            </span>
+          </div>
+          <div
             class="mb-1 ml-0 inline-flex justify-start items-center capitalize"
           >
             <svg
@@ -386,7 +446,7 @@ exports[`ServiceSummary > Timer component > renders Timer for updated_at when it
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
                 stroke-linecap="round"
                 stroke-linejoin="round"
               />
@@ -485,6 +545,36 @@ exports[`ServiceSummary > Timer component > renders dash for non-running service
               Model 
             </div>
             model-name
+          </div>
+          <div
+            class="mb-1 ml-0 inline-flex justify-start items-center"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-6 w-6 text-gray-600 dark:text-gray-400 mr-1"
+              data-slot="icon"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <div
+              class="grow font-medium text-sm mr-1"
+            >
+              Image 
+            </div>
+            <span
+              class="service-summary__image"
+            >
+              -
+            </span>
           </div>
           <div
             class="mb-1 ml-0 inline-flex justify-start items-center capitalize"
@@ -608,7 +698,7 @@ exports[`ServiceSummary > Timer component > renders dash for non-running service
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
                 stroke-linecap="round"
                 stroke-linejoin="round"
               />
@@ -709,6 +799,36 @@ exports[`ServiceSummary > Timer component > renders empty div when service doesn
             model-name
           </div>
           <div
+            class="mb-1 ml-0 inline-flex justify-start items-center"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-6 w-6 text-gray-600 dark:text-gray-400 mr-1"
+              data-slot="icon"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <div
+              class="grow font-medium text-sm mr-1"
+            >
+              Image 
+            </div>
+            <span
+              class="service-summary__image"
+            >
+              -
+            </span>
+          </div>
+          <div
             class="mb-1 ml-0 inline-flex justify-start items-center capitalize"
           >
             <svg
@@ -832,7 +952,7 @@ exports[`ServiceSummary > Timer component > renders empty div when service doesn
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
                 stroke-linecap="round"
                 stroke-linejoin="round"
               />
@@ -930,6 +1050,36 @@ exports[`ServiceSummary > renders GPU as ice cube when gres is 0 1`] = `
             model-name
           </div>
           <div
+            class="mb-1 ml-0 inline-flex justify-start items-center"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-6 w-6 text-gray-600 dark:text-gray-400 mr-1"
+              data-slot="icon"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <div
+              class="grow font-medium text-sm mr-1"
+            >
+              Image 
+            </div>
+            <span
+              class="service-summary__image"
+            >
+              -
+            </span>
+          </div>
+          <div
             class="mb-1 ml-0 inline-flex justify-start items-center capitalize"
           >
             <svg
@@ -1053,7 +1203,7 @@ exports[`ServiceSummary > renders GPU as ice cube when gres is 0 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
                 stroke-linecap="round"
                 stroke-linejoin="round"
               />
@@ -1154,6 +1304,36 @@ exports[`ServiceSummary > renders dashes for missing service properties 1`] = `
             -
           </div>
           <div
+            class="mb-1 ml-0 inline-flex justify-start items-center"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-6 w-6 text-gray-600 dark:text-gray-400 mr-1"
+              data-slot="icon"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <div
+              class="grow font-medium text-sm mr-1"
+            >
+              Image 
+            </div>
+            <span
+              class="service-summary__image"
+            >
+              -
+            </span>
+          </div>
+          <div
             class="mb-1 ml-0 inline-flex justify-start items-center capitalize"
           >
             <svg
@@ -1275,7 +1455,7 @@ exports[`ServiceSummary > renders dashes for missing service properties 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
                 stroke-linecap="round"
                 stroke-linejoin="round"
               />
@@ -1377,6 +1557,36 @@ exports[`ServiceSummary > renders host without port when port is not provided 1`
               Model 
             </div>
             model-name
+          </div>
+          <div
+            class="mb-1 ml-0 inline-flex justify-start items-center"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-6 w-6 text-gray-600 dark:text-gray-400 mr-1"
+              data-slot="icon"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <div
+              class="grow font-medium text-sm mr-1"
+            >
+              Image 
+            </div>
+            <span
+              class="service-summary__image"
+            >
+              -
+            </span>
           </div>
           <div
             class="mb-1 ml-0 inline-flex justify-start items-center capitalize"
@@ -1502,7 +1712,7 @@ exports[`ServiceSummary > renders host without port when port is not provided 1`
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
                 stroke-linecap="round"
                 stroke-linejoin="round"
               />
@@ -1603,6 +1813,36 @@ exports[`ServiceSummary > renders service information when service and profile a
             model-name
           </div>
           <div
+            class="mb-1 ml-0 inline-flex justify-start items-center"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-6 w-6 text-gray-600 dark:text-gray-400 mr-1"
+              data-slot="icon"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <div
+              class="grow font-medium text-sm mr-1"
+            >
+              Image 
+            </div>
+            <span
+              class="service-summary__image"
+            >
+              -
+            </span>
+          </div>
+          <div
             class="mb-1 ml-0 inline-flex justify-start items-center capitalize"
           >
             <svg
@@ -1726,7 +1966,7 @@ exports[`ServiceSummary > renders service information when service and profile a
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
                 stroke-linecap="round"
                 stroke-linejoin="round"
               />
@@ -1827,6 +2067,36 @@ exports[`ServiceSummary > renders service with model without slash 1`] = `
             simple-model
           </div>
           <div
+            class="mb-1 ml-0 inline-flex justify-start items-center"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-6 w-6 text-gray-600 dark:text-gray-400 mr-1"
+              data-slot="icon"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <div
+              class="grow font-medium text-sm mr-1"
+            >
+              Image 
+            </div>
+            <span
+              class="service-summary__image"
+            >
+              -
+            </span>
+          </div>
+          <div
             class="mb-1 ml-0 inline-flex justify-start items-center capitalize"
           >
             <svg
@@ -1950,7 +2220,7 @@ exports[`ServiceSummary > renders service with model without slash 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
                 stroke-linecap="round"
                 stroke-linejoin="round"
               />
@@ -2055,6 +2325,36 @@ exports[`ServiceSummary > renders without a profile 1`] = `
             </span>
           </div>
           <div
+            class="mb-1 ml-0 inline-flex justify-start items-center"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-6 w-6 text-gray-300 dark:text-gray-600 mr-1"
+              data-slot="icon"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <div
+              class="grow font-regular text-sm mr-1"
+            >
+              Image 
+            </div>
+            <span
+              class="mr-2"
+            >
+              -
+            </span>
+          </div>
+          <div
             class="mb-1 ml-0 inline-flex justify-start items-center capitalize"
           >
             <svg
@@ -2188,7 +2488,7 @@ exports[`ServiceSummary > renders without a profile 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
                 stroke-linecap="round"
                 stroke-linejoin="round"
               />
@@ -2297,6 +2597,36 @@ exports[`ServiceSummary > renders without a profile and a service 1`] = `
             </span>
           </div>
           <div
+            class="mb-1 ml-0 inline-flex justify-start items-center"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-6 w-6 text-gray-300 dark:text-gray-600 mr-1"
+              data-slot="icon"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <div
+              class="grow font-regular text-sm mr-1"
+            >
+              Image 
+            </div>
+            <span
+              class="mr-2"
+            >
+              -
+            </span>
+          </div>
+          <div
             class="mb-1 ml-0 inline-flex justify-start items-center capitalize"
           >
             <svg
@@ -2430,7 +2760,7 @@ exports[`ServiceSummary > renders without a profile and a service 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="m21 7.5-2.25-1.313M21 7.5v2.25m0-2.25-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3 2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75 2.25-1.313M12 21.75V19.5m0 2.25-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
+                d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"
                 stroke-linecap="round"
                 stroke-linejoin="round"
               />

--- a/web/src/routes/jobs/components/JobDetailsPanel.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.jsx
@@ -325,7 +325,7 @@ function JobDetailsPanel({ job, onStopJob, onResumeJob, onDeleteJob, jobActions 
                         {job.repo_id && (
                             <div className="flex justify-between">
                                 <span className="text-gray-500 dark:text-gray-400">Model:</span>
-                                <span className="text-gray-900 dark:text-gray-100 text-xs font-mono truncate ml-2 max-w-[200px]" title={job.repo_id}>
+                                <span className="text-gray-900 dark:text-gray-100 text-xs font-mono truncate ml-2 max-w-[320px]" title={job.repo_id}>
                                     {job.repo_id}
                                 </span>
                             </div>
@@ -333,13 +333,15 @@ function JobDetailsPanel({ job, onStopJob, onResumeJob, onDeleteJob, jobActions 
                         {job.revision && (
                             <div className="flex justify-between">
                                 <span className="text-gray-500 dark:text-gray-400">Revision:</span>
-                                <span className="text-gray-900 dark:text-gray-100">{job.revision}</span>
+                                <span className="text-gray-900 dark:text-gray-100 text-xs font-mono truncate ml-2 max-w-[320px]" title={job.revision}>
+                                    {job.revision}
+                                </span>
                             </div>
                         )}
                         {job.image_ref && (
                             <div className="flex justify-between">
                                 <span className="text-gray-500 dark:text-gray-400">Image:</span>
-                                <span className="text-gray-900 dark:text-gray-100 text-xs font-mono truncate ml-2 max-w-[200px]" title={job.image_ref}>
+                                <span className="text-gray-900 dark:text-gray-100 text-xs font-mono truncate ml-2 max-w-[320px]" title={job.image_ref}>
                                     {job.image_ref}
                                 </span>
                             </div>

--- a/web/src/routes/jobs/components/JobDetailsPanel.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.jsx
@@ -336,6 +336,14 @@ function JobDetailsPanel({ job, onStopJob, onResumeJob, onDeleteJob, jobActions 
                                 <span className="text-gray-900 dark:text-gray-100">{job.revision}</span>
                             </div>
                         )}
+                        {job.image_ref && (
+                            <div className="flex justify-between">
+                                <span className="text-gray-500 dark:text-gray-400">Image:</span>
+                                <span className="text-gray-900 dark:text-gray-100 text-xs font-mono truncate ml-2 max-w-[200px]" title={job.image_ref}>
+                                    {job.image_ref}
+                                </span>
+                            </div>
+                        )}
                         {job.params && Object.keys(job.params).length > 0 && (
                             <>
                                 {Object.entries(job.params).map(([key, value]) => (
@@ -380,6 +388,7 @@ JobDetailsPanel.propTypes = {
         task: PropTypes.string,
         repo_id: PropTypes.string,
         revision: PropTypes.string,
+        image_ref: PropTypes.string,
         input_dir: PropTypes.string,
         output_dir: PropTypes.string,
         resources: PropTypes.shape({

--- a/web/src/routes/jobs/components/JobDetailsPanel.test.jsx
+++ b/web/src/routes/jobs/components/JobDetailsPanel.test.jsx
@@ -182,3 +182,32 @@ describe("JobDetailsPanel resume action", () => {
     expect(screen.queryByLabelText("Resume job")).not.toBeInTheDocument();
   });
 });
+
+describe("JobDetailsPanel image reference", () => {
+  const job = (extra = {}) => ({
+    id: "job-001",
+    name: "Batch Translation",
+    status: "stopped",
+    task: "translate",
+    repo_id: "google/gemma-3-4b-it",
+    ...extra,
+  });
+
+  test("shows the pinned image, with the full reference as a title", () => {
+    render(
+      <JobDetailsPanel
+        job={job({ image_ref: "ghcr.io/princeton-ddss/tigerflow-ml:0.1.1" })}
+      />,
+    );
+    const value = screen.getByTitle("ghcr.io/princeton-ddss/tigerflow-ml:0.1.1");
+    expect(value).toHaveTextContent("ghcr.io/princeton-ddss/tigerflow-ml:0.1.1");
+    expect(screen.getByText("Image:")).toBeInTheDocument();
+  });
+
+  test("omits the row when no image was recorded", () => {
+    // Null for jobs created before image_ref, or never launched — showing an
+    // empty "Image:" row would imply the pin is missing rather than unknown.
+    render(<JobDetailsPanel job={job()} />);
+    expect(screen.queryByText("Image:")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- **CLI**: adds a `VERSION` column to `blackfish ls` and `blackfish batch ls` showing the image *tag*, and the full `repo:tag` to `blackfish details <id>`. Tag only in the tables because `batch ls --all` already renders at 141 chars — past a standard 120-wide terminal — and the full reference would add ~45 more. Named `VERSION` rather than `IMAGE` since `IMAGE` in the services table already means the service *type* (`text_generation`).
- **UI**: adds an Image row to the service summary and the batch job details panel. `image_ref` is NULL for anything created before the migration or never launched, so every site falls back to a dash. Memory gets its own `CircleStackIcon`, since Image now uses the cube it was previously sharing.
- **Presentation only.** Both GET endpoints already serialize `image_ref` (full ORM objects, no DTO), and every CLI command fetches over the HTTP API — so no backend, serializer, or migration work was needed.

Second commit aligns the job-detail value rows: `revision` now gets the same monospace/truncated treatment as model and image, and the cutoff widens 200px → 320px. At `text-xs` monospace a commit SHA is ~264px and a full image reference ~271px, so both were truncating at a width originally sized for `repo_id` (~152px), inside a 768px panel.

Part of #212. Follow-ups: `GET /api/images` discovery (#482) and the launcher selectors (#483).

## Test plan

- `uv run just lint` / `just test` — 923 passed, 7 skipped; MyPy strict clean. Coverage unchanged at 70%.
- `npm run lint` / `npm test` — 513 passed, 0 lint errors (one pre-existing warning in an untouched file).
- New UI tests: the service summary renders the tag with the full reference as a `title`, and a dash when unset; the job panel shows the row for a pinned job and omits it when nothing was recorded. `ServiceSummary` snapshots updated — reviewed the diff to confirm it is purely the added row, in both the loaded and no-profile branches.
- **Verified against live data** rather than fixtures only. The local database has both populated and NULL rows, so the fallback is exercised for real:

```
0b87cc9d-2974   detect       0.1.1   facebook/detr-resnet-50   ...   detect - test
2af13d86-9b9a   chat         -       google/gemma-3-4b-it      ...   chat-gemma-3-4b-it
```

```
$ blackfish details 6e363ef2-...
    "image": "text_generation",
    "image_ref": "vllm/vllm-openai:v0.20.0",
```

  Worth noting: two existing services already show `v0.20.0` because they were launched after #480 merged — the backfill populated them in normal use, so this confirms the record is being written as well as displayed.

- Both tables remain readable at the new width (147 / 151 chars), and NULL renders as `-` rather than `None` or an empty cell.

Closes #481.
