### PR TITLE
fix(lib): bound the sacct liveness query by job creation time

### DIFF
--- a/lib/src/blackfish/server/jobs/base.py
+++ b/lib/src/blackfish/server/jobs/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import os
 import shlex
 from enum import StrEnum, auto
@@ -636,16 +637,47 @@ class BatchJob(UUIDAuditBase):
             logger.warning(f"Failed to scancel job {self.pid} for {self.id}: {e}")
 
     async def _slurm_state(self) -> JobState:
-        """Return the current Slurm state of this job's allocation."""
+        """Return the current Slurm state of this job's allocation.
+
+        Slurm recycles job IDs once its counter wraps (``MaxJobId``), and the
+        accounting database keeps old records forever. Without a lower time
+        bound, ``sacct -j <id>`` can return a *different*, long-finished job
+        that happens to share the id — reported as a terminal state, which the
+        restart policy reads as "this allocation ended", stalling a job that is
+        actually running.
+
+        ``-S`` bounds the query to records starting no earlier than shortly
+        before this job was created. The bound follows the job rather than being
+        a fixed window, so a long-running allocation is never excluded by its
+        own age.
+
+        ``env TZ=UTC`` makes both sides agree on the timezone: ``created_at`` is
+        UTC, while ``sacct`` interprets naive timestamps as cluster-local. On a
+        UTC-4 cluster an unconverted bound lands in the future, and sacct then
+        errors with "Start time ... is after end time" rather than returning
+        anything. ``env`` is used (rather than a shell prefix) because the local
+        path executes without a shell.
+        """
         if not self.pid:
             return JobState.MISSING
+
+        # Buffer against clock skew between this host and the cluster, and
+        # against the gap between row creation and sbatch actually recording a
+        # start time. Generous because being slightly too early costs nothing —
+        # a wrapped-around id is years old, not hours.
+        start_bound = self.created_at - datetime.timedelta(hours=6)
+
         sacct_cmd = [
+            "env",
+            "TZ=UTC",
             "sacct",
             "-n",
             "-P",
             "-X",
             "-j",
             str(self.pid),
+            "-S",
+            start_bound.strftime("%Y-%m-%dT%H:%M:%S"),
             "-o",
             "State",
         ]

--- a/lib/src/blackfish/server/jobs/base.py
+++ b/lib/src/blackfish/server/jobs/base.py
@@ -661,27 +661,27 @@ class BatchJob(UUIDAuditBase):
         if not self.pid:
             return JobState.MISSING
 
-        # Buffer against clock skew between this host and the cluster, and
-        # against the gap between row creation and sbatch actually recording a
-        # start time. Generous because being slightly too early costs nothing —
-        # a wrapped-around id is years old, not hours.
-        start_bound = self.created_at - datetime.timedelta(hours=6)
-
-        sacct_cmd = [
-            "env",
-            "TZ=UTC",
-            "sacct",
-            "-n",
-            "-P",
-            "-X",
-            "-j",
-            str(self.pid),
-            "-S",
-            start_bound.strftime("%Y-%m-%dT%H:%M:%S"),
-            "-o",
-            "State",
-        ]
         try:
+            # Buffer against clock skew between this host and the cluster, and
+            # against the gap between row creation and sbatch actually recording
+            # a start time. Generous because being slightly too early costs
+            # nothing — a wrapped-around id is years old, not hours.
+            start_bound = self.created_at - datetime.timedelta(hours=6)
+
+            sacct_cmd = [
+                "env",
+                "TZ=UTC",
+                "sacct",
+                "-n",
+                "-P",
+                "-X",
+                "-j",
+                str(self.pid),
+                "-S",
+                start_bound.strftime("%Y-%m-%dT%H:%M:%S"),
+                "-o",
+                "State",
+            ]
             if self.host == "localhost":
                 result = await remote.run(sacct_cmd)
             else:

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -1,5 +1,6 @@
 """Unit tests for BatchJob orchestration logic."""
 
+import datetime
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import UUID
 
@@ -1250,3 +1251,97 @@ class TestBatchJobImagePinning:
         client = create_tigerflow_client(job, MockAppConfig())
 
         assert client.image == DEFAULT_IMAGES["tigerflow_ml"]
+
+
+class TestSlurmStateQuery:
+    """Tests for the sacct query in BatchJob._slurm_state().
+
+    Slurm recycles job IDs once its counter wraps, and the accounting database
+    keeps old records forever. An unbounded query can return a different,
+    long-finished job that shares the id — read as a terminal state, which
+    stalls a job that is actually running.
+    """
+
+    def _job(self, **kwargs) -> BatchJob:
+        job = create_test_batch_job(**kwargs)
+        job.created_at = datetime.datetime(
+            2026, 8, 21, 16, 38, 14, tzinfo=datetime.timezone.utc
+        )
+        return job
+
+    @patch("blackfish.server.jobs.base.remote")
+    async def test_query_is_bounded_by_the_jobs_creation_time(
+        self, mock_remote: Mock
+    ) -> None:
+        """-S excludes records that predate this job, so a recycled id can't
+        match a years-old record from another user."""
+        mock_remote.run = AsyncMock(return_value=Mock(stdout=b"RUNNING"))
+        job = self._job(host="localhost", pid="12728301")
+
+        await job._slurm_state()
+
+        cmd = mock_remote.run.call_args.args[0]
+        assert "-S" in cmd
+        bound = cmd[cmd.index("-S") + 1]
+        # Six hours before creation: early enough to absorb clock skew, but
+        # nowhere near a wrapped-around record from a previous counter cycle.
+        assert bound == "2026-08-21T10:38:14"
+
+    @patch("blackfish.server.jobs.base.remote")
+    async def test_query_forces_utc(self, mock_remote: Mock) -> None:
+        """created_at is UTC but sacct reads naive timestamps as cluster-local.
+
+        Without this, on a UTC-4 cluster the bound lands hours in the future and
+        sacct fails with "Start time ... is after end time" — which would
+        silently disable the liveness check. `env` is used rather than a shell
+        prefix because the local path executes without a shell.
+        """
+        mock_remote.run = AsyncMock(return_value=Mock(stdout=b"RUNNING"))
+        job = self._job(host="localhost", pid="12728301")
+
+        await job._slurm_state()
+
+        cmd = mock_remote.run.call_args.args[0]
+        assert cmd[:3] == ["env", "TZ=UTC", "sacct"]
+
+    @patch("blackfish.server.jobs.base.remote")
+    async def test_the_bound_follows_the_job_not_a_fixed_window(
+        self, mock_remote: Mock
+    ) -> None:
+        """A long-running allocation must not be excluded by its own age.
+
+        A fixed window (e.g. "now-1days") would hide any job that started
+        earlier than that, leaving it permanently unobservable.
+        """
+        mock_remote.run = AsyncMock(return_value=Mock(stdout=b"RUNNING"))
+        job = self._job(host="localhost", pid="12728301")
+        job.created_at = datetime.datetime(
+            2026, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc
+        )
+
+        await job._slurm_state()
+
+        cmd = mock_remote.run.call_args.args[0]
+        assert cmd[cmd.index("-S") + 1] == "2026-01-01T21:04:05"
+
+    @patch("blackfish.server.jobs.base.remote")
+    async def test_missing_pid_skips_the_query(self, mock_remote: Mock) -> None:
+        """No pid means nothing to look up — don't shell out at all."""
+        mock_remote.run = AsyncMock()
+        job = self._job(host="localhost", pid=None)
+
+        assert await job._slurm_state() == JobState.MISSING
+        mock_remote.run.assert_not_called()
+
+    @patch("blackfish.server.jobs.base.remote")
+    async def test_query_failure_is_not_terminal(self, mock_remote: Mock) -> None:
+        """A failed lookup must report MISSING, not a terminal state.
+
+        MISSING is non-terminal, so the restart policy waits for the next
+        observation rather than treating an unreadable cluster as "the
+        allocation ended".
+        """
+        mock_remote.run = AsyncMock(side_effect=OSError("ssh exploded"))
+        job = self._job(host="localhost", pid="12728301")
+
+        assert await job._slurm_state() == JobState.MISSING


### PR DESCRIPTION
## Summary

- Slurm recycles job IDs once its counter wraps (`MaxJobId = 67043328` on Della), and the accounting database keeps old records forever. An unbounded `sacct -j <id>` can therefore return a *different*, long-finished job that shares the id. The restart policy reads that terminal state as "this allocation ended", and with `processed=0` (accurate for a job still loading its model) it increments `stalled_restarts` to 1 — which is fatal, since `max_stalled_restarts` defaults to 1.
- The damage compounds: STALLED is terminal, and `poll()` returns early on a terminal status *before* observing. One affected job processed **all 1000 files successfully** while its row stayed frozen at `finished=0, staged=1000`.
- Fix: bound the query with `-S` derived from the job's own `created_at`, so the window follows the job and never excludes a long-running allocation.

Observed live — the same id, one command reporting `COMPLETED` while the other reported `RUNNING`:

```
$ sacct -n -P -X -j 12728301 -o State          →  COMPLETED
$ squeue -j 12728301 -h -o %T                  →  RUNNING
$ sacct -X -j 12728301 -o JobID,User,State,Start
  12728301|xxxx|COMPLETED|2017-10-03T17:39:29     ← a 2017 job, different user
```

All three affected jobs collided with records from the same 2017 afternoon (`jhlu_4120`, `jhlu_2640`, `jhlu_5551`).

### Two details worth calling out

**`env TZ=UTC` is load-bearing.** `created_at` is stored UTC; `sacct` reads naive timestamps as cluster-local (Della is `America/New_York`, UTC-4). An unconverted bound lands in the future and sacct *errors* rather than returning empty:

```
sacct: error: Start time (2026-08-21T15:38:14) requested is after end time (2026-08-21T14:55:15)
```

That would be caught and turned into `MISSING` — failing safe, but silently disabling the liveness check. `env` rather than a shell prefix because the local path uses `create_subprocess_exec` with no shell, where a bare `TZ=UTC` element becomes the program name.

**The bound follows the job, not a fixed window.** `-S now-1days` was the obvious first idea, but it hides any allocation that *started* earlier than that — a long-running job would become permanently unobservable. Deriving from `created_at` (minus a 6h buffer for clock skew and the gap before sbatch records a start time) avoids that.

`-u <user>` was considered and rejected: `self.user` is NULL for local profiles, where `sacct` runs without SSH, so it would be malformed on that path.

Not included: raising `max_stalled_restarts` from 1. With the query fixed the stall guard receives correct inputs; the threshold is a separate policy question, not a reaction to this bug.

## Test plan

- `uv run just lint` — clean, MyPy strict included. `uv run just test` — 929 passed, 7 skipped (5 new). Coverage unchanged at 71%.
- 5 new tests in `TestSlurmStateQuery`, each verified to fail when its own piece is reverted: removing `-S` fails the two bound tests, removing `env TZ=UTC` fails the timezone test.
- Covers the non-terminal fallbacks too — no pid skips the query entirely, and a failed lookup reports `MISSING` rather than a terminal state, so an unreachable cluster never reads as "the allocation ended".
- **Verified against the real cluster.** The 2017 record still exists in the accounting database, and the bounded query excludes it:

```
$ env TZ=UTC sacct -n -P -X -j 12728301 -o JobID,User,State,Start -S 2017-01-01T00:00:00 -E 2018-01-01T00:00:00
12728301|xxxx|COMPLETED|2017-10-03T17:39:29        ← still present

$ env TZ=UTC sacct -n -P -X -j 12728301 -o JobID,User,State,Start -S 2026-08-21T10:38:14
12728301|cs7101|FAILED|2026-08-21T16:38:28          ← only ours
```

- **Verified on real jobs.** Resuming the two frozen jobs reconciled them to `1000/1000 STOPPED`, `staged=0`, `stalled_restarts=0` — confirming their pipelines had completed all along and only the liveness check was wrong. The allocations were then reaped by the existing natural-completion `scancel` path.

One caveat on interpretation: this bug is intermittent — it only bites when a recycled id lands on an existing record — so a passing run is not by itself proof. The direct evidence is the accounting-database check above.

Closes #484.
