### PR TITLE
feat(lib): add GET /api/containers to list staged images

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "jinja2>=3.1.5,<4",
   "litestar>=2.16,<3",
   "log-symbols>=0.0.14,<0.1",
+  "packaging>=24,<26",
   "pillow>=12,<13",
   "prettytable>=3.12,<4",
   "psutil>=7.1.3,<8",

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -120,6 +120,7 @@ from blackfish.server.setup import (
     repair_slurm_profile,
 )
 from blackfish.server.images import ImageSpec
+from blackfish.server.image_probe import list_staged_tags
 from blackfish.server.models.model import (
     Model,
     PIPELINE_IMAGES,
@@ -1026,6 +1027,56 @@ async def delete_audio(path: str, profile: Optional[str] = None) -> Path | str:
 async def get_ports(request: Request) -> int:  # type: ignore
     """Find an available port on the server. This endpoint allows a UI to run local services."""
     return find_port()
+
+
+class StagedContainer(BaseModel):
+    """The container versions available for one service on a profile."""
+
+    service: str  # logical service name, e.g. "text_generation"
+    repo: str  # always from config; a .sif filename cannot yield a repo
+    tags: list[str]  # staged tags, version-ordered, unparsable ones last
+    default: str  # the configured tag; always present
+    default_staged: bool  # whether that tag's .sif is actually on disk
+
+
+@get("/api/containers", guards=ENDPOINT_GUARDS)
+async def list_containers(profile: str) -> list[StagedContainer]:
+    """List the container images staged on a profile, per service.
+
+    Named ``containers`` rather than ``images`` to keep it clear of
+    ``/api/image``, which serves uploaded image *files* and takes the same
+    ``profile`` parameter.
+
+    Args:
+        profile: Name of the profile to inspect.
+    """
+    try:
+        resolved = deserialize_profile(blackfish_config.HOME_DIR, profile)
+    except FileNotFoundError:
+        raise NotFoundException(detail="Profile config not found.")
+
+    if resolved is None:
+        raise NotFoundException(detail=f"Profile '{profile}' not found.")
+
+    try:
+        staged = await list_staged_tags(resolved, blackfish_config.IMAGES)
+    except TigerFlowError as e:
+        logger.warning(f"Failed to list containers for {profile}: {e.error_type}")
+        raise InternalServerException(detail=e.user_message())
+    except Exception as e:
+        logger.error(f"Unexpected error listing containers for {profile}: {e}")
+        raise InternalServerException(detail="Failed to list container images.")
+
+    return [
+        StagedContainer(
+            service=service,
+            repo=spec.repo,
+            tags=staged[service],
+            default=spec.tag,
+            default_staged=spec.tag in staged[service],
+        )
+        for service, spec in blackfish_config.IMAGES.items()
+    ]
 
 
 def is_valid_image_ref(ref: str | None) -> str | None:
@@ -3676,6 +3727,7 @@ app = Litestar(
         login,
         logout,
         get_ports,
+        list_containers,
         RemoteFileBrowserSession,
         get_files,
         upload_image,

--- a/lib/src/blackfish/server/image_probe.py
+++ b/lib/src/blackfish/server/image_probe.py
@@ -44,7 +44,9 @@ def sort_tags(tags: list[str]) -> list[str]:
 
     A plain string sort is wrong — ``"0.1.10" < "0.1.2"`` — and tag styles are
     inconsistent across images (vLLM publishes ``v0.20.0``, the DDSS images
-    publish a bare ``0.1.2``), so the leading ``v`` is tolerated.
+    publish a bare ``0.1.2``). ``Version`` accepts either form per PEP 440, so
+    no prefix stripping is needed; hand-stripping with ``lstrip("v")`` would
+    also mangle a malformed ``vv1.0.0`` into a valid-looking version.
 
     Tags that are not versions at all (``latest``, ``nightly``) are still
     runnable, so they are kept and sorted last rather than hidden; callers must
@@ -53,7 +55,7 @@ def sort_tags(tags: list[str]) -> list[str]:
 
     def key(tag: str) -> tuple[int, Version | str]:
         try:
-            return (0, Version(tag.lstrip("v")))
+            return (0, Version(tag))
         except InvalidVersion:
             return (1, tag)
 

--- a/lib/src/blackfish/server/image_probe.py
+++ b/lib/src/blackfish/server/image_probe.py
@@ -1,0 +1,117 @@
+"""Discover which container images are actually staged on a profile.
+
+Images are staged out of band by administrators (``apptainer pull`` into
+``{cache_dir}/images/``). ``config.IMAGES`` records only the *pinned* spec per
+service, so it cannot answer "which versions could this profile run?" — that is
+what this module is for.
+
+The repo always comes from configuration and only the tag from the filename:
+``ImageSpec.sif`` drops the registry prefix
+(``ghcr.io/princeton-ddss/tigerflow-ml:0.1.1`` -> ``tigerflow-ml_0.1.1.sif``),
+so a filename alone cannot identify a repo.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+from typing import TYPE_CHECKING
+
+from packaging.version import InvalidVersion, Version
+
+from blackfish.server.jobs.client import LocalRunner, SSHRunner
+
+if TYPE_CHECKING:
+    from blackfish.server.images import ImageSpec
+    from blackfish.server.models.profile import BlackfishProfile
+
+# Shorter than the runner's 120s default: this sits behind a UI dropdown, so a
+# slow login node should fail fast rather than hang the request.
+PROBE_TIMEOUT = 20.0
+
+
+def _runner_for(profile: "BlackfishProfile") -> SSHRunner | LocalRunner:
+    """Return a runner that executes on the profile's host."""
+    from blackfish.server.models.profile import SlurmProfile
+
+    if isinstance(profile, SlurmProfile) and not profile.is_local():
+        return SSHRunner(profile.user, profile.host, timeout=PROBE_TIMEOUT)
+    return LocalRunner()
+
+
+def sort_tags(tags: list[str]) -> list[str]:
+    """Order tags by version, ascending, with unparsable tags last.
+
+    A plain string sort is wrong — ``"0.1.10" < "0.1.2"`` — and tag styles are
+    inconsistent across images (vLLM publishes ``v0.20.0``, the DDSS images
+    publish a bare ``0.1.2``), so the leading ``v`` is tolerated.
+
+    Tags that are not versions at all (``latest``, ``nightly``) are still
+    runnable, so they are kept and sorted last rather than hidden; callers must
+    never auto-select them, since they say nothing about which image they name.
+    """
+
+    def key(tag: str) -> tuple[int, Version | str]:
+        try:
+            return (0, Version(tag.lstrip("v")))
+        except InvalidVersion:
+            return (1, tag)
+
+    return sorted(tags, key=key)
+
+
+def extract_tag(filename: str, spec: "ImageSpec") -> str | None:
+    """Return the tag in ``filename`` for ``spec``, or None if it isn't a match.
+
+    Strips the *known* image-name prefix rather than splitting on the last
+    underscore, so a tag that itself contains underscores survives
+    (``vllm-openai_v1_2_3.sif`` -> ``v1_2_3``).
+    """
+    if not filename.endswith(".sif"):
+        return None
+    prefix = f"{spec.repo.rsplit('/', 1)[-1]}_"
+    stem = filename[: -len(".sif")]
+    if not stem.startswith(prefix):
+        return None
+    tag = stem[len(prefix) :]
+    return tag or None
+
+
+async def _list_sif_files(profile: "BlackfishProfile") -> list[str]:
+    """List the ``.sif`` filenames staged in the profile's images directory.
+
+    A missing images directory is a valid state (a fresh profile), not an
+    error: ``ls`` exits non-zero for it, so the failure is swallowed and an
+    empty list returned. A genuine transport failure still surfaces, because
+    the runner raises before any command exit code is inspected.
+    """
+    images_dir = os.path.join(profile.cache_dir, "images")
+    command = f"ls -1 {shlex.quote(images_dir)} 2>/dev/null | grep '\\.sif$' || true"
+
+    runner = _runner_for(profile)
+    _, stdout, _ = await runner.run(command)
+    return [
+        line.strip() for line in stdout.decode("utf-8").splitlines() if line.strip()
+    ]
+
+
+async def list_staged_tags(
+    profile: "BlackfishProfile", images: dict[str, "ImageSpec"]
+) -> dict[str, list[str]]:
+    """Map each configured service to the tags staged on ``profile``.
+
+    Every service in ``images`` appears in the result, with an empty list when
+    nothing is staged for it. Staged files matching no configured service (for
+    example a deprecated image left on disk) are ignored — without a repo there
+    is nothing launchable to attach them to.
+
+    Raises:
+        TigerFlowError: the profile could not be reached.
+    """
+    filenames = await _list_sif_files(profile)
+
+    staged: dict[str, list[str]] = {}
+    for service, spec in images.items():
+        tags = [t for f in filenames if (t := extract_tag(f, spec)) is not None]
+        staged[service] = sort_tags(tags)
+    return staged

--- a/lib/tests/api/test_containers.py
+++ b/lib/tests/api/test_containers.py
@@ -1,0 +1,132 @@
+"""Tests for the GET /api/containers endpoint.
+
+Note this is about *container* images. `test_images.py` covers /api/image,
+which serves uploaded image files — a different endpoint entirely, which is
+why this route is named `containers`.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from litestar.testing import AsyncTestClient
+
+from blackfish.server.images import ImageSpec
+from blackfish.server.jobs.client import TigerFlowError
+
+pytestmark = pytest.mark.anyio
+
+IMAGES = {
+    "text_generation": ImageSpec(repo="vllm/vllm-openai", tag="v0.20.0"),
+    "tigerflow_ml": ImageSpec(repo="ghcr.io/princeton-ddss/tigerflow-ml", tag="0.1.1"),
+}
+
+
+class TestListContainersAPI:
+    async def test_requires_authentication(
+        self, no_auth_client: AsyncTestClient
+    ) -> None:
+        response = await no_auth_client.get("/api/containers?profile=default")
+        assert response.status_code in (401, 403) or response.is_redirect
+
+    async def test_unknown_profile_returns_404(self, client: AsyncTestClient) -> None:
+        response = await client.get("/api/containers?profile=nonexistent")
+        assert response.status_code == 404
+
+    async def test_lists_staged_tags_per_service(self, client: AsyncTestClient) -> None:
+        staged = {
+            "text_generation": ["v0.8.4", "v0.20.0"],
+            "tigerflow_ml": ["0.1.1"],
+        }
+        with (
+            patch("blackfish.server.asgi.blackfish_config.IMAGES", IMAGES),
+            patch(
+                "blackfish.server.asgi.list_staged_tags",
+                new=_returns(staged),
+            ),
+        ):
+            response = await client.get("/api/containers?profile=default")
+
+        assert response.status_code == 200
+        body = {row["service"]: row for row in response.json()}
+        assert body["text_generation"]["tags"] == ["v0.8.4", "v0.20.0"]
+        # The repo always comes from config: a .sif filename cannot yield one.
+        assert body["tigerflow_ml"]["repo"] == "ghcr.io/princeton-ddss/tigerflow-ml"
+
+    async def test_every_service_reports_its_configured_default(
+        self, client: AsyncTestClient
+    ) -> None:
+        """config.IMAGES always has a default per service, so every row names
+        one — whether or not it is staged."""
+        staged = {"text_generation": ["v0.20.0"], "tigerflow_ml": []}
+        with (
+            patch("blackfish.server.asgi.blackfish_config.IMAGES", IMAGES),
+            patch("blackfish.server.asgi.list_staged_tags", new=_returns(staged)),
+        ):
+            response = await client.get("/api/containers?profile=default")
+
+        body = {row["service"]: row for row in response.json()}
+        assert body["text_generation"]["default"] == "v0.20.0"
+        assert body["tigerflow_ml"]["default"] == "0.1.1"
+
+    async def test_default_staged_reflects_whether_the_file_exists(
+        self, client: AsyncTestClient
+    ) -> None:
+        """The configured default can be absent from disk — an admin deleted
+        it, or an env override names a tag nobody staged. The response must
+        name the expected tag so a caller can say which one is missing."""
+        staged = {"text_generation": ["v0.8.4"], "tigerflow_ml": ["0.1.1"]}
+        with (
+            patch("blackfish.server.asgi.blackfish_config.IMAGES", IMAGES),
+            patch("blackfish.server.asgi.list_staged_tags", new=_returns(staged)),
+        ):
+            response = await client.get("/api/containers?profile=default")
+
+        body = {row["service"]: row for row in response.json()}
+        # v0.20.0 is configured but not in the staged list.
+        assert body["text_generation"]["default"] == "v0.20.0"
+        assert body["text_generation"]["default_staged"] is False
+        assert body["tigerflow_ml"]["default_staged"] is True
+
+    async def test_profile_with_no_images_directory_returns_empty_tags(
+        self, client: AsyncTestClient
+    ) -> None:
+        """A fresh profile is a valid state, not an error."""
+        staged = {"text_generation": [], "tigerflow_ml": []}
+        with (
+            patch("blackfish.server.asgi.blackfish_config.IMAGES", IMAGES),
+            patch("blackfish.server.asgi.list_staged_tags", new=_returns(staged)),
+        ):
+            response = await client.get("/api/containers?profile=default")
+
+        assert response.status_code == 200
+        assert all(row["tags"] == [] for row in response.json())
+
+    async def test_unreachable_profile_returns_a_friendly_500(
+        self, client: AsyncTestClient
+    ) -> None:
+        with (
+            patch("blackfish.server.asgi.blackfish_config.IMAGES", IMAGES),
+            patch(
+                "blackfish.server.asgi.list_staged_tags",
+                new=_raises(TigerFlowError("timeout", "hpc.example.com")),
+            ),
+        ):
+            response = await client.get("/api/containers?profile=hpc")
+
+        assert response.status_code == 500
+        # The friendly message, not a raw traceback.
+        assert "timed out" in response.json()["detail"].lower()
+
+
+def _returns(value):
+    async def _fn(*args, **kwargs):
+        return value
+
+    return _fn
+
+
+def _raises(exc):
+    async def _fn(*args, **kwargs):
+        raise exc
+
+    return _fn

--- a/lib/tests/unit/test_image_probe.py
+++ b/lib/tests/unit/test_image_probe.py
@@ -1,0 +1,158 @@
+"""Tests for staged container image discovery."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from blackfish.server.image_probe import (
+    extract_tag,
+    list_staged_tags,
+    sort_tags,
+)
+from blackfish.server.images import ImageSpec
+from blackfish.server.models.profile import LocalProfile
+
+pytestmark = pytest.mark.anyio
+
+VLLM = ImageSpec(repo="vllm/vllm-openai", tag="v0.20.0")
+TIGERFLOW = ImageSpec(repo="ghcr.io/princeton-ddss/tigerflow-ml", tag="0.1.1")
+
+# The filenames actually staged on the cluster, plus the orphan.
+STAGED = [
+    "speech-recognition-inference_0.1.2.sif",
+    "speech-recognition-inference_0.2.1.sif",
+    "text-generation-inference_2.3.0.sif",
+    "tigerflow-ml_0.1.1.sif",
+    "vllm-openai_v0.8.4.sif",
+    "vllm-openai_v0.8.5.sif",
+    "vllm-openai_v0.10.2.sif",
+    "vllm-openai_v0.20.0.sif",
+]
+
+
+class TestExtractTag:
+    def test_extracts_the_tag_for_a_matching_image(self) -> None:
+        assert extract_tag("vllm-openai_v0.20.0.sif", VLLM) == "v0.20.0"
+
+    def test_ignores_a_different_image(self) -> None:
+        """The orphan on the cluster: a real .sif with no configured service."""
+        assert extract_tag("text-generation-inference_2.3.0.sif", VLLM) is None
+
+    def test_ignores_non_sif_files(self) -> None:
+        assert extract_tag("vllm-openai_v0.20.0.txt", VLLM) is None
+
+    def test_strips_the_registry_prefix_from_the_repo(self) -> None:
+        """ImageSpec.sif drops the registry, so matching uses the bare name."""
+        assert extract_tag("tigerflow-ml_0.1.1.sif", TIGERFLOW) == "0.1.1"
+
+    def test_keeps_underscores_inside_a_tag(self) -> None:
+        """Strip the known prefix rather than rsplit("_", 1), which would
+        return "3" here and silently corrupt the tag."""
+        assert extract_tag("vllm-openai_v1_2_3.sif", VLLM) == "v1_2_3"
+
+    def test_rejects_an_empty_tag(self) -> None:
+        assert extract_tag("vllm-openai_.sif", VLLM) is None
+
+    def test_does_not_match_a_name_that_merely_shares_a_prefix(self) -> None:
+        """A shorter image name must not swallow a longer one's files."""
+        short = ImageSpec(repo="ghcr.io/x/vllm", tag="1.0")
+        assert extract_tag("vllm-openai_v0.20.0.sif", short) is None
+
+
+class TestSortTags:
+    def test_orders_by_version_not_string(self) -> None:
+        """The trap this exists for: as strings, v0.10.2 sorts before v0.8.4,
+        which would present v0.8.4 as the newest available version."""
+        assert sort_tags(["v0.10.2", "v0.20.0", "v0.8.4", "v0.8.5"]) == [
+            "v0.8.4",
+            "v0.8.5",
+            "v0.10.2",
+            "v0.20.0",
+        ]
+
+    def test_tolerates_a_leading_v(self) -> None:
+        """vLLM publishes v0.20.0; the DDSS images publish a bare 0.1.2."""
+        assert sort_tags(["v0.2.0", "0.10.0", "v0.3.0"]) == [
+            "v0.2.0",
+            "v0.3.0",
+            "0.10.0",
+        ]
+
+    def test_unparsable_tags_sort_last_without_raising(self) -> None:
+        """`latest` is runnable, so it is kept — but it says nothing about
+        which image it names, so it must never sort first."""
+        assert sort_tags(["latest", "0.2.0", "nightly", "0.1.0"]) == [
+            "0.1.0",
+            "0.2.0",
+            "latest",
+            "nightly",
+        ]
+
+    def test_empty(self) -> None:
+        assert sort_tags([]) == []
+
+
+def _profile() -> LocalProfile:
+    return LocalProfile(
+        name="test", home_dir="/home/test/.blackfish", cache_dir="/cache"
+    )
+
+
+def _mock_runner(stdout: bytes, returncode: int = 0):
+    runner = AsyncMock()
+    runner.run = AsyncMock(return_value=(returncode, stdout, b""))
+    return runner
+
+
+class TestListStagedTags:
+    async def test_groups_tags_by_service_in_version_order(self) -> None:
+        images = {"text_generation": VLLM, "tigerflow_ml": TIGERFLOW}
+        runner = _mock_runner("\n".join(STAGED).encode())
+
+        with patch("blackfish.server.image_probe._runner_for", return_value=runner):
+            staged = await list_staged_tags(_profile(), images)
+
+        assert staged["text_generation"] == ["v0.8.4", "v0.8.5", "v0.10.2", "v0.20.0"]
+        assert staged["tigerflow_ml"] == ["0.1.1"]
+
+    async def test_every_configured_service_appears(self) -> None:
+        """A service with nothing staged still gets an entry, so callers never
+        have to distinguish "absent" from "empty"."""
+        images = {"text_generation": VLLM, "tigerflow_ml": TIGERFLOW}
+        runner = _mock_runner(b"vllm-openai_v0.20.0.sif\n")
+
+        with patch("blackfish.server.image_probe._runner_for", return_value=runner):
+            staged = await list_staged_tags(_profile(), images)
+
+        assert set(staged) == set(images)
+        assert staged["tigerflow_ml"] == []
+
+    async def test_orphan_files_are_ignored(self) -> None:
+        """A .sif matching no configured service has no repo to attach to."""
+        runner = _mock_runner(b"text-generation-inference_2.3.0.sif\n")
+
+        with patch("blackfish.server.image_probe._runner_for", return_value=runner):
+            staged = await list_staged_tags(_profile(), {"text_generation": VLLM})
+
+        assert staged["text_generation"] == []
+
+    async def test_missing_images_directory_yields_empty_not_an_error(self) -> None:
+        """A fresh profile has no images dir. The probe's `|| true` turns that
+        into empty output, so it must not read as a failure."""
+        runner = _mock_runner(b"")
+
+        with patch("blackfish.server.image_probe._runner_for", return_value=runner):
+            staged = await list_staged_tags(_profile(), {"text_generation": VLLM})
+
+        assert staged["text_generation"] == []
+
+    async def test_probe_swallows_ls_errors_in_the_shell(self) -> None:
+        """The command ends in `|| true`, so a missing directory cannot make
+        the whole probe look like a transport failure."""
+        runner = _mock_runner(b"")
+
+        with patch("blackfish.server.image_probe._runner_for", return_value=runner):
+            await list_staged_tags(_profile(), {"text_generation": VLLM})
+
+        command = runner.run.call_args.args[0]
+        assert command.endswith("|| true")
+        assert "/cache/images" in command

--- a/lib/tests/unit/test_image_probe.py
+++ b/lib/tests/unit/test_image_probe.py
@@ -77,6 +77,20 @@ class TestSortTags:
             "0.10.0",
         ]
 
+    def test_handles_an_uppercase_v_prefix(self) -> None:
+        """Version accepts v/V per PEP 440, so no hand-stripping is needed."""
+        assert sort_tags(["V2.0.0", "v1.0.0"]) == ["v1.0.0", "V2.0.0"]
+
+    def test_a_doubled_v_prefix_is_not_a_version(self) -> None:
+        """Guards the reason for not hand-stripping: lstrip("v") removes every
+        leading v, so "vv1.0.0" would parse as 1.0.0 and sort *between* the
+        real versions instead of last with the other unparsable tags."""
+        assert sort_tags(["vv1.0.0", "0.1.0", "V2.0.0"]) == [
+            "0.1.0",
+            "V2.0.0",
+            "vv1.0.0",
+        ]
+
     def test_unparsable_tags_sort_last_without_raising(self) -> None:
         """`latest` is runnable, so it is kept — but it says nothing about
         which image it names, so it must never sort first."""

--- a/lib/uv.lock
+++ b/lib/uv.lock
@@ -252,6 +252,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "litestar" },
     { name = "log-symbols" },
+    { name = "packaging" },
     { name = "pillow" },
     { name = "prettytable" },
     { name = "psutil" },
@@ -309,6 +310,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.5,<4" },
     { name = "litestar", specifier = ">=2.16,<3" },
     { name = "log-symbols", specifier = ">=0.0.14,<0.1" },
+    { name = "packaging", specifier = ">=24,<26" },
     { name = "pillow", specifier = ">=12,<13" },
     { name = "prettytable", specifier = ">=3.12,<4" },
     { name = "psutil", specifier = ">=7.1.3,<8" },
@@ -2076,11 +2078,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.2"
+version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Blackfish could not enumerate staged container images. `config.IMAGES` holds exactly one pinned spec per service, and `blackfish image ls` only checks whether *that one* is present — so versions an admin had already staged were invisible and unselectable. On Della that is six runnable versions across two services.
- Adds `GET /api/containers?profile=<name>`, which lists `{cache_dir}/images/*.sif` in one round trip and matches each file against the configured image names. The **repo always comes from config and only the tag from the filename**: `ImageSpec.sif` drops the registry prefix (`ghcr.io/princeton-ddss/tigerflow-ml:0.1.1` → `tigerflow-ml_0.1.1.sif`), so a filename alone cannot identify a repo. Staged files matching no configured service are ignored — there is nothing launchable to attach them to.
- Response is grouped by service, since a version is only meaningful in the context of one image. Every configured service always appears with a named `default` plus a `default_staged` flag, so a caller can say "configured default `0.9.9` is not staged" rather than only "something is wrong".

### Details worth calling out

**Ordering is version-aware, not lexical.** Verified on the real staged tags: as strings they sort `['v0.10.2', 'v0.20.0', 'v0.8.4', 'v0.8.5']`, which would present `v0.8.4` as the newest available. `packaging.version` gives `['v0.8.4', 'v0.8.5', 'v0.10.2', 'v0.20.0']`. Unparsable tags (`latest`, `nightly`) are legitimately runnable, so they are kept and sorted last rather than hidden — callers must never auto-select them.

**A missing images directory is a valid state, not an error.** A bare `ls` on a nonexistent directory exits non-zero, which would surface as a 500 for any fresh profile. The probe ends in `|| true` so that case yields empty output instead. A genuine transport failure still surfaces, because the runner raises on SSH exit 255 / timeout *before* any command exit code is inspected — the two remain cleanly separable.

**Named `/api/containers`, not `/api/images`.** `/api/image` already exists for uploaded image *files* and takes the same `?profile=` parameter, so `/api/images` would sit one character from an unrelated route — compounding an overload that has already caused trouble (`Service.image` is the service type, `Model.image` an HF pipeline tag, `ImageSpec` the container).

**Tag extraction strips the known prefix** rather than `rsplit("_", 1)`, so a tag containing underscores survives (`vllm-openai_v1_2_3.sif` → `v1_2_3`) instead of being silently truncated to `3`.

`cli/image.py` is deliberately left alone — rewiring it onto this helper is a refactor of a `# pragma: no cover` path that this issue does not require. That does leave a third copy of the four-line `SSHRunner`/`LocalRunner` branch (alongside `cli/image.py` and `jobs/base.py`), which is the point at which consolidating them becomes worthwhile; noted as a follow-up.

Third of four sub-issues under #212. This unblocks the launcher selectors (#483).

## Test plan

- `uv run just lint` — clean, MyPy strict included. `uv run just test` — 952 passed, 7 skipped (23 new). Coverage unchanged at 71%.
- Unit tests cover tag extraction (orphans, non-`.sif` files, underscore-containing tags, a name that merely shares a prefix), ordering (the string-sort trap on real tags, `v`-prefixed vs bare, unparsable last), and the probe command shape.
- Route tests cover auth, 404 on an unknown profile, per-service grouping, every service naming its default, `default_staged: false` when that default is absent, empty tags for a profile with no images directory, and a friendly 500 on `TigerFlowError`. Verified the `default_staged` test fails when the field is hardcoded.
- **Verified against the live cluster:**

```
$ curl -s 'localhost:8000/api/containers?profile=default' | jq -c '.[] | {service, tags, default_staged}'
{"service":"text_generation","tags":["v0.8.4","v0.8.5","v0.10.2","v0.20.0"],"default_staged":true}
{"service":"speech_recognition","tags":["0.1.2","0.2.1"],"default_staged":true}
{"service":"tigerflow_ml","tags":["0.1.1"],"default_staged":true}
```

  All four vLLM tags in correct version order; `speech-recognition 0.2.1` surfaced for the first time; the `text-generation-inference_2.3.0.sif` orphan correctly excluded.

- Edge cases confirmed live: an unknown profile returns 404, and the local profile (whose `images/` directory does not exist) returns entries with empty `tags` rather than an error — the case the `|| true` guard exists for.

Closes #482.
