### PR TITLE
feat(web): add image version selectors to both launchers

### DIFF
--- a/web/src/components/ImageVersionSelect.jsx
+++ b/web/src/components/ImageVersionSelect.jsx
@@ -39,25 +39,31 @@ function ImageVersionSelect({
   disabled,
   isLoading = false,
 }) {
-  const [selected, setSelected] = useState(null);
+  // Only what the user explicitly picked. The effective selection is derived
+  // below rather than stored, so a container change (new profile or service)
+  // can never leave a stale tag paired with a new repo.
+  const [chosen, setChosen] = useState(null);
   const isDisabled = disabled || isLoading;
 
   const tags = container?.tags ?? [];
 
-  // Seed from the configured default whenever the container changes (a new
-  // profile or service), falling back to the first staged tag when that
-  // default is not on disk.
+  // Prefer the configured default, falling back to the first staged tag when
+  // that default is not on disk. A user's pick wins, but only while it is
+  // still offered — switching containers drops it.
+  const selected = container
+    ? (tags.includes(chosen) ? chosen : null) ??
+      (container.default_staged ? container.default : tags[0] ?? null)
+    : null;
+
+  // Forget the explicit pick when the container changes, so the derived
+  // default applies to the new service rather than a tag from the old one.
   useEffect(() => {
-    if (!container) {
-      setSelected(null);
-      return;
-    }
-    const fallback = container.tags?.[0] ?? null;
-    setSelected(container.default_staged ? container.default : fallback);
+    setChosen(null);
   }, [container]);
 
   // Lift the full "repo:tag" — image_ref stores a complete reference, since a
-  // pin may move repos and not just tags.
+  // pin may move repos and not just tags. Derived from `container` in the same
+  // pass as `selected`, so the two are always consistent.
   useEffect(() => {
     if (!setImageRef) return;
     if (selected && container?.repo) {
@@ -80,7 +86,7 @@ function ImageVersionSelect({
 
   return (
     <Field disabled={isDisabled}>
-      <Listbox value={selected} onChange={setSelected} disabled={isDisabled}>
+      <Listbox value={selected} onChange={setChosen} disabled={isDisabled}>
         <Label className="block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">
           Version
         </Label>

--- a/web/src/components/ImageVersionSelect.jsx
+++ b/web/src/components/ImageVersionSelect.jsx
@@ -1,0 +1,172 @@
+import { useState, useEffect } from "react";
+import {
+  Field,
+  Label,
+  Listbox,
+  ListboxButton,
+  ListboxOptions,
+  ListboxOption,
+} from "@headlessui/react";
+import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/20/solid";
+import PropTypes from "prop-types";
+import { classNames } from "@/lib/util";
+import SelectSkeleton from "@/components/SelectSkeleton";
+
+/**
+ * Container image version select.
+ *
+ * Offers only the versions actually staged on the profile, so a selection can
+ * always run. Pre-selects the *configured* default rather than the newest
+ * staged tag: the pre-selection must only change when someone deliberately
+ * changes configuration, not because an administrator staged a new image.
+ *
+ * Renders nothing when no version is available at all — the profile is
+ * unreachable, or discovery failed. The launch then proceeds on the backend's
+ * own default, so a flaky login node never blocks it.
+ *
+ * @param {object} options
+ * @param {object} options.container `{repo, tags, default, default_staged}`
+ * @param {string} options.imageRef the selected "repo:tag", or null
+ * @param {Function} options.setImageRef
+ * @param {boolean} options.disabled
+ * @param {boolean} options.isLoading
+ * @return {JSX.Element}
+ */
+function ImageVersionSelect({
+  container,
+  imageRef,
+  setImageRef,
+  disabled,
+  isLoading = false,
+}) {
+  const [selected, setSelected] = useState(null);
+  const isDisabled = disabled || isLoading;
+
+  const tags = container?.tags ?? [];
+
+  // Seed from the configured default whenever the container changes (a new
+  // profile or service), falling back to the first staged tag when that
+  // default is not on disk.
+  useEffect(() => {
+    if (!container) {
+      setSelected(null);
+      return;
+    }
+    const fallback = container.tags?.[0] ?? null;
+    setSelected(container.default_staged ? container.default : fallback);
+  }, [container]);
+
+  // Lift the full "repo:tag" — image_ref stores a complete reference, since a
+  // pin may move repos and not just tags.
+  useEffect(() => {
+    if (!setImageRef) return;
+    if (selected && container?.repo) {
+      setImageRef(`${container.repo}:${selected}`);
+    } else {
+      setImageRef(null);
+    }
+  }, [selected, container, setImageRef]);
+
+  if (isLoading) {
+    return <SelectSkeleton label="Version" />;
+  }
+
+  // Nothing staged, or the profile is unreachable: stay out of the way and let
+  // the backend resolve its default. A single staged version still renders, to
+  // match RevisionSelect — disabling one-option selects is tracked in #489.
+  if (selected === null) {
+    return <></>;
+  }
+
+  return (
+    <Field disabled={isDisabled}>
+      <Listbox value={selected} onChange={setSelected} disabled={isDisabled}>
+        <Label className="block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">
+          Version
+        </Label>
+        <div className="relative mt-2">
+          <ListboxButton
+            className={classNames(
+              isDisabled ? "bg-gray-100 dark:bg-gray-800 ring-gray-300 dark:ring-gray-600 ring-1" : "bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500",
+              "relative w-full cursor-default rounded-md py-1.5 pl-1 pr-10 text-left text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 sm:text-sm sm:leading-6"
+            )}
+          >
+            <span className="flex items-center">
+              <span className="ml-2 mr-2 block truncate" title={imageRef ?? undefined}>
+                {selected}
+              </span>
+            </span>
+            {!isDisabled &&
+              <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                <ChevronUpDownIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
+              </span>
+            }
+          </ListboxButton>
+
+          <ListboxOptions
+            anchor="bottom start"
+            className="z-50 mt-1 max-h-60 w-[var(--button-width)] overflow-auto rounded-md bg-white dark:bg-gray-700 py-1 text-base shadow-lg ring-1 ring-black dark:ring-gray-600 ring-opacity-5 focus:outline-none sm:text-sm">
+            {tags.map((tag) => (
+              <ListboxOption
+                key={tag}
+                className={({ focus }) =>
+                  classNames(
+                    focus ? "bg-blue-500 text-white" : "text-gray-900 dark:text-gray-100",
+                    "relative cursor-default select-none py-2 pl-1 pr-9"
+                  )
+                }
+                value={tag}
+              >
+                {({ selected, focus }) => (
+                  <>
+                    <div className="flex items-center">
+                      <span
+                        className={classNames(
+                          selected ? "font-semibold" : "font-normal",
+                          "ml-3 block truncate"
+                        )}
+                      >
+                        {tag}
+                      </span>
+                      {tag === container.default && (
+                        <span
+                          className={classNames(
+                            focus ? "text-white" : "text-gray-500 dark:text-gray-400",
+                            "ml-2 text-xs"
+                          )}
+                        >
+                          default
+                        </span>
+                      )}
+                    </div>
+
+                    {selected ? (
+                      <span
+                        className={classNames(
+                          focus ? "text-white" : "text-blue-600",
+                          "absolute inset-y-0 right-0 flex items-center pr-4"
+                        )}
+                      >
+                        <CheckIcon className="h-5 w-5" aria-hidden="true" />
+                      </span>
+                    ) : null}
+                  </>
+                )}
+              </ListboxOption>
+            ))}
+          </ListboxOptions>
+        </div>
+      </Listbox>
+    </Field>
+  );
+}
+
+ImageVersionSelect.propTypes = {
+  container: PropTypes.object,
+  imageRef: PropTypes.string,
+  setImageRef: PropTypes.func,
+  disabled: PropTypes.bool,
+  isLoading: PropTypes.bool,
+};
+
+export default ImageVersionSelect;

--- a/web/src/components/ImageVersionSelect.test.jsx
+++ b/web/src/components/ImageVersionSelect.test.jsx
@@ -101,6 +101,38 @@ describe("ImageVersionSelect", () => {
     );
   });
 
+  it("never lifts a new repo paired with the previous tag", () => {
+    // Regression: seeding `selected` in one effect and lifting it in another
+    // let the lift fire first with the new container but the stale tag,
+    // emitting a reference that does not exist. Deriving the selection from
+    // the container removes the intermediate entirely. `toHaveBeenLastCalled`
+    // would not catch this — every call has to be correct.
+    const { rerender, setImageRef } = renderSelect();
+    setImageRef.mockClear();
+
+    const other = {
+      service: "tigerflow_ml",
+      repo: "ghcr.io/princeton-ddss/tigerflow-ml",
+      tags: ["0.1.1"],
+      default: "0.1.1",
+      default_staged: true,
+    };
+    rerender(
+      <ImageVersionSelect
+        container={other}
+        imageRef={null}
+        setImageRef={setImageRef}
+        disabled={false}
+      />
+    );
+
+    for (const [ref] of setImageRef.mock.calls) {
+      if (ref !== null) {
+        expect(ref).toBe("ghcr.io/princeton-ddss/tigerflow-ml:0.1.1");
+      }
+    }
+  });
+
   it("shows a skeleton rather than the select while loading", () => {
     renderSelect({ isLoading: true });
     // The real select renders its current value; the skeleton must not.

--- a/web/src/components/ImageVersionSelect.test.jsx
+++ b/web/src/components/ImageVersionSelect.test.jsx
@@ -1,0 +1,115 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import ImageVersionSelect from "@/components/ImageVersionSelect";
+
+const CONTAINER = {
+  service: "text_generation",
+  repo: "vllm/vllm-openai",
+  tags: ["v0.8.4", "v0.8.5", "v0.10.2", "v0.20.0"],
+  default: "v0.20.0",
+  default_staged: true,
+};
+
+function renderSelect(props = {}) {
+  const setImageRef = vi.fn();
+  const result = render(
+    <ImageVersionSelect
+      container={CONTAINER}
+      imageRef={null}
+      setImageRef={setImageRef}
+      disabled={false}
+      {...props}
+    />
+  );
+  return { ...result, setImageRef };
+}
+
+describe("ImageVersionSelect", () => {
+  it("pre-selects the configured default, not the newest staged tag", () => {
+    // v0.20.0 happens to be newest here, so pick a container where the
+    // default is deliberately *not* the last tag to make the test meaningful.
+    const container = { ...CONTAINER, default: "v0.8.5" };
+    renderSelect({ container });
+    expect(screen.getByText("v0.8.5")).toBeInTheDocument();
+  });
+
+  it("lifts the full repo:tag, since a pin may move repos not just tags", () => {
+    const { setImageRef } = renderSelect();
+    expect(setImageRef).toHaveBeenCalledWith("vllm/vllm-openai:v0.20.0");
+  });
+
+  it("falls back to the first staged tag when the default is not staged", () => {
+    // An admin deleted the configured image, or an override names a tag
+    // nobody staged. Offer something runnable rather than an absent default.
+    const container = {
+      ...CONTAINER,
+      tags: ["v0.8.4", "v0.8.5"],
+      default: "v0.20.0",
+      default_staged: false,
+    };
+    const { setImageRef } = renderSelect({ container });
+    expect(setImageRef).toHaveBeenCalledWith("vllm/vllm-openai:v0.8.4");
+  });
+
+  it("renders nothing and pins nothing when the profile is unreachable", () => {
+    // container is undefined when discovery failed. The launch must still
+    // proceed on the backend's configured default.
+    const { container: dom, setImageRef } = renderSelect({ container: undefined });
+    expect(dom).toBeEmptyDOMElement();
+    expect(setImageRef).toHaveBeenCalledWith(null);
+  });
+
+  it("renders nothing when nothing is staged", () => {
+    const container = { ...CONTAINER, tags: [], default_staged: false };
+    const { container: dom } = renderSelect({ container });
+    expect(dom).toBeEmptyDOMElement();
+  });
+
+  it("still renders with a single option, matching RevisionSelect", () => {
+    // Disabling one-option selects is tracked separately (#489); until then
+    // the version in use stays visible rather than vanishing.
+    const container = {
+      ...CONTAINER,
+      tags: ["0.1.1"],
+      default: "0.1.1",
+    };
+    renderSelect({ container });
+    expect(screen.getByText("0.1.1")).toBeInTheDocument();
+  });
+
+  it("re-seeds when the container changes, e.g. on a profile switch", () => {
+    const { rerender, setImageRef } = renderSelect();
+    expect(setImageRef).toHaveBeenCalledWith("vllm/vllm-openai:v0.20.0");
+
+    const other = {
+      service: "tigerflow_ml",
+      repo: "ghcr.io/princeton-ddss/tigerflow-ml",
+      tags: ["0.1.1"],
+      default: "0.1.1",
+      default_staged: true,
+    };
+    rerender(
+      <ImageVersionSelect
+        container={other}
+        imageRef={null}
+        setImageRef={setImageRef}
+        disabled={false}
+      />
+    );
+    expect(setImageRef).toHaveBeenLastCalledWith(
+      "ghcr.io/princeton-ddss/tigerflow-ml:0.1.1"
+    );
+  });
+
+  it("shows a skeleton rather than the select while loading", () => {
+    renderSelect({ isLoading: true });
+    // The real select renders its current value; the skeleton must not.
+    expect(screen.queryByText("v0.20.0")).not.toBeInTheDocument();
+  });
+
+  it("does not crash when no setter is supplied", () => {
+    expect(() =>
+      render(<ImageVersionSelect container={CONTAINER} />)
+    ).not.toThrow();
+  });
+});

--- a/web/src/components/ServiceModal.jsx
+++ b/web/src/components/ServiceModal.jsx
@@ -11,7 +11,7 @@ import ServiceModalForm from "@/components/ServiceModalForm";
 import ServiceLaunchErrorAlert from "@/components/ServiceLaunchErrorAlert";
 import { ServiceContext } from "@/providers/ServiceProvider";
 import { runService, fetchProfileResources } from "@/lib/requests";
-import { useModels, useServices, useClusterStatus } from "@/lib/loaders";
+import { useModels, useServices, useClusterStatus, useStagedContainers } from "@/lib/loaders";
 import { sleep, randomInt, isDeepEmpty } from "@/lib/util";
 import PropTypes from "prop-types";
 
@@ -110,12 +110,19 @@ function ServiceModal({
   const {
     status: clusterStatus,
   } = useClusterStatus(profile);
+  // `task` is the hyphenated pipeline name; config.IMAGES keys use underscores.
+  // This is the same transform runService applies to build the `image` field.
+  const {
+    container,
+    isLoading: containerLoading,
+  } = useStagedContainers(profile, task?.replaceAll("-", "_"));
 
   const { setSelectedServiceId } = useContext(ServiceContext);
 
 
   const [jobOptions, setJobOptions] = React.useState(() => getDefaultJobOptions(profile));
   const [model, setModel] = useState(null);
+  const [imageRef, setImageRef] = useState(null);
   const [resources, setResources] = useState(null);
   const clusterPartitions = clusterStatus?.partitions
     ? Object.keys(clusterStatus.partitions)
@@ -176,7 +183,14 @@ function ServiceModal({
     console.debug("from handleFormSubmit: attempting to launch service")
     setIsLaunching(true)
     setLaunchError(null)
-    const res = await runService(task, model, jobOptions, containerOptions, profile);
+    const res = await runService(
+      task,
+      model,
+      jobOptions,
+      containerOptions,
+      profile,
+      imageRef
+    );
     if (!res.ok) {
       let message = "Failed to launch service.";
       try {
@@ -279,6 +293,10 @@ function ServiceModal({
                         isModelsLoading={modelsLoading}
                         services={services}
                         setModel={setModel}
+                        container={container}
+                        isContainerLoading={containerLoading}
+                        imageRef={imageRef}
+                        setImageRef={setImageRef}
                         jobOptions={jobOptions}
                         setJobOptions={setJobOptions}
                         setValidationErrors={setValidationErrors}

--- a/web/src/components/ServiceModal.jsx
+++ b/web/src/components/ServiceModal.jsx
@@ -12,6 +12,7 @@ import ServiceLaunchErrorAlert from "@/components/ServiceLaunchErrorAlert";
 import { ServiceContext } from "@/providers/ServiceProvider";
 import { runService, fetchProfileResources } from "@/lib/requests";
 import { useModels, useServices, useClusterStatus, useStagedContainers } from "@/lib/loaders";
+import { ScrollContainerContext } from "@/lib/useScrollOnExpand";
 import { sleep, randomInt, isDeepEmpty } from "@/lib/util";
 import PropTypes from "prop-types";
 
@@ -178,6 +179,9 @@ function ServiceModal({
   ])
 
   const cancelButtonRef = useRef(null);
+  // Shared with the nested forms so their collapsible sections can scroll this
+  // container into view when they expand.
+  const contentRef = useRef(null);
 
   const handleFormSubmit = async () => {
     console.debug("from handleFormSubmit: attempting to launch service")
@@ -243,6 +247,7 @@ function ServiceModal({
   };
 
   return (
+    <ScrollContainerContext.Provider value={contentRef}>
     <Transition show={open} as={Fragment}>
       <Dialog
         as="div"
@@ -277,7 +282,7 @@ function ServiceModal({
             >
               <DialogPanel className="relative transform rounded-lg bg-white dark:bg-gray-800 text-left shadow-xl transition-all sm:mt-4 sm:mb-8 sm:w-full sm:max-w-4xl max-h-[90vh] flex flex-col">
                 {/* Scrollable content area */}
-                <div className="flex-1 overflow-y-auto px-4 pt-5 sm:p-6 sm:pl-6">
+                <div ref={contentRef} className="flex-1 overflow-y-auto px-4 pt-5 sm:p-6 sm:pl-6">
                   <DialogTitle
                     as="h3"
                     className="text-base font-semibold leading-6 text-gray-900 dark:text-gray-100"
@@ -348,6 +353,7 @@ function ServiceModal({
         </div>
       </Dialog>
     </Transition>
+    </ScrollContainerContext.Provider>
   );
 }
 

--- a/web/src/components/ServiceModal.test.jsx
+++ b/web/src/components/ServiceModal.test.jsx
@@ -5,7 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import ServiceModal from "@/components/ServiceModal";
 import { ServiceContext } from "@/providers/ServiceProvider";
-import { useModels, useServices, useClusterStatus } from "@/lib/loaders";
+import { useModels, useServices, useClusterStatus, useStagedContainers } from "@/lib/loaders";
 import { runService, fetchProfileResources } from "@/lib/requests";
 import { sleep, randomInt, isDeepEmpty } from "@/lib/util";
 
@@ -123,6 +123,14 @@ describe("ServiceModal", () => {
 
     useClusterStatus.mockReturnValue({
       status: null,
+      error: null,
+      isLoading: false,
+      isRefreshing: false,
+      refresh: vi.fn(),
+    });
+
+    useStagedContainers.mockReturnValue({
+      container: undefined,
       error: null,
       isLoading: false,
       isRefreshing: false,
@@ -288,7 +296,10 @@ describe("ServiceModal", () => {
           time: "00:30:00",
         }),
         { port: 8080 },
-        { schema: "slurm", host: "test-host", user: "testuser" }
+        { schema: "slurm", host: "test-host", user: "testuser" },
+        // No staged containers mocked, so no pin is selected and the backend
+        // resolves its configured default.
+        null
       );
     });
 

--- a/web/src/components/ServiceModalForm.jsx
+++ b/web/src/components/ServiceModalForm.jsx
@@ -344,15 +344,6 @@ function ServiceModalForm({
             />
           </fieldset>
 
-          <fieldset>
-            <ImageVersionSelect
-              container={container}
-              imageRef={imageRef}
-              setImageRef={setImageRef}
-              disabled={disabled}
-              isLoading={isContainerLoading}
-            />
-          </fieldset>
         </div>
       ) : warnIfNoModels()}
 
@@ -484,6 +475,20 @@ function ServiceModalForm({
                   <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
                     Leave empty to use your default account.
                   </p>
+
+                  <div className="mt-4">
+                    <ImageVersionSelect
+                      container={container}
+                      imageRef={imageRef}
+                      setImageRef={setImageRef}
+                      disabled={disabled}
+                      isLoading={isContainerLoading}
+                    />
+                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      Pin the container image for reproducibility. The default
+                      is recommended unless you need a specific version.
+                    </p>
+                  </div>
                 </div>
               )}
             </fieldset>
@@ -543,6 +548,41 @@ function ServiceModalForm({
                   </div>
                 </div>
               </div>
+            </fieldset>
+
+            {/* Advanced options (collapsed by default). Local profiles have no
+                Slurm settings, but they still run containers, so the image
+                version belongs here too. */}
+            <fieldset>
+              <button
+                type="button"
+                onClick={() => setShowAdvanced(!showAdvanced)}
+                className="flex items-center gap-2 w-full text-left"
+              >
+                <legend className="text-sm font-semibold leading-6 text-gray-900 dark:text-gray-100">
+                  Advanced Options
+                </legend>
+                {showAdvanced ? (
+                  <ChevronUpIcon className="h-4 w-4 text-gray-500" />
+                ) : (
+                  <ChevronDownIcon className="h-4 w-4 text-gray-500" />
+                )}
+              </button>
+              {showAdvanced && (
+                <div className="mt-3">
+                  <ImageVersionSelect
+                    container={container}
+                    imageRef={imageRef}
+                    setImageRef={setImageRef}
+                    disabled={disabled}
+                    isLoading={isContainerLoading}
+                  />
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    Pin the container image for reproducibility. The default is
+                    recommended unless you need a specific version.
+                  </p>
+                </div>
+              )}
             </fieldset>
           </>
         )

--- a/web/src/components/ServiceModalForm.jsx
+++ b/web/src/components/ServiceModalForm.jsx
@@ -3,6 +3,7 @@ import Info from "./Info";
 import Alert from "@/components/Alert";
 import ModelSelect from "@/components/ModelSelect"
 import RevisionSelect from "@/components/RevisionSelect"
+import ImageVersionSelect from "@/components/ImageVersionSelect"
 import TierSelect from "@/components/TierSelect";
 import ServiceModalValidatedInput from "@/components/ServiceModalValidatedInput";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/20/solid";
@@ -27,6 +28,10 @@ function ServiceModalForm({
   isModelsLoading = false,
   services,
   setModel,
+  container,
+  isContainerLoading = false,
+  imageRef,
+  setImageRef,
   jobOptions,
   setJobOptions,
   setValidationErrors,
@@ -338,6 +343,16 @@ function ServiceModalForm({
               isLoading={isModelsLoading}
             />
           </fieldset>
+
+          <fieldset>
+            <ImageVersionSelect
+              container={container}
+              imageRef={imageRef}
+              setImageRef={setImageRef}
+              disabled={disabled}
+              isLoading={isContainerLoading}
+            />
+          </fieldset>
         </div>
       ) : warnIfNoModels()}
 
@@ -544,6 +559,10 @@ ServiceModalForm.propTypes = {
   isModelsLoading: PropTypes.bool,
   services: PropTypes.array,
   setModel: PropTypes.func,
+  container: PropTypes.object,
+  isContainerLoading: PropTypes.bool,
+  imageRef: PropTypes.string,
+  setImageRef: PropTypes.func,
   jobOptions: PropTypes.object,
   setJobOptions: PropTypes.func,
   setValidationErrors: PropTypes.func,

--- a/web/src/components/ServiceModalForm.jsx
+++ b/web/src/components/ServiceModalForm.jsx
@@ -4,6 +4,7 @@ import Alert from "@/components/Alert";
 import ModelSelect from "@/components/ModelSelect"
 import RevisionSelect from "@/components/RevisionSelect"
 import ImageVersionSelect from "@/components/ImageVersionSelect"
+import { useScrollOnExpand } from "@/lib/useScrollOnExpand"
 import TierSelect from "@/components/TierSelect";
 import ServiceModalValidatedInput from "@/components/ServiceModalValidatedInput";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/20/solid";
@@ -52,6 +53,9 @@ function ServiceModalForm({
   const [recommendedTier, setRecommendedTier] = React.useState(null);
   const [partitionWarning, setPartitionWarning] = React.useState(null);
   const [showAdvanced, setShowAdvanced] = React.useState(false);
+  // Expanding a section below the fold otherwise reveals nothing until the
+  // user scrolls, which reads as the click having done nothing.
+  useScrollOnExpand(showAdvanced);
   const [account, setAccount] = React.useState("");
 
   // Default tiers when API doesn't return data

--- a/web/src/lib/loaders.js
+++ b/web/src/lib/loaders.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import useSWR from "swr";
-import { fetchModels, fetchServices, fetchProfiles, fetchFiles, fetchClusterStatus, fetchJobs, fetchJobResults } from "./requests";
+import { fetchModels, fetchServices, fetchProfiles, fetchFiles, fetchClusterStatus, fetchJobs, fetchJobResults, fetchStagedContainers } from "./requests";
 import { ServiceStatus, isRemoteProfile } from "./util";
 import { useRemoteFileSystem } from "@/providers/RemoteFileSystemProvider";
 
@@ -251,6 +251,34 @@ export const useClusterStatus = (profile) => {
   );
   return {
     status: data,
+    error: error,
+    isLoading: isLoading,
+    isRefreshing: isValidating,
+    refresh: mutate,
+  };
+};
+
+/**
+ * The container image versions staged on a profile, for one service.
+ *
+ * `service` is a config.IMAGES key ("text_generation", "tigerflow_ml"), not an
+ * HF pipeline tag. Callers holding a hyphenated launcher name must convert it.
+ *
+ * Returns `container` as `{repo, tags, default, default_staged}`, or undefined
+ * while loading or on error — callers fall back to launching with the
+ * configured default, so an unreachable cluster never blocks a launch.
+ */
+export const useStagedContainers = (profile, service) => {
+  const key = profile?.name && service ? `containers/${profile.name}` : null;
+  const { data, error, isLoading, isValidating, mutate } = useSWR(
+    key,
+    () => fetchStagedContainers(profile.name),
+    {
+      revalidateOnFocus: false,
+    }
+  );
+  return {
+    container: data?.find((c) => c.service === service),
     error: error,
     isLoading: isLoading,
     isRefreshing: isValidating,

--- a/web/src/lib/requests.js
+++ b/web/src/lib/requests.js
@@ -182,12 +182,13 @@ export function buildContainerConfig(containerConfig) {
 }
 
 /** Start an service to perform the specified ML/AI pipeline. */
-export async function runService(pipeline, model, jobConfig, containerConfig, profile) {
+export async function runService(pipeline, model, jobConfig, containerConfig, profile, imageRef = null) {
   let body;
   if (profile.schema === "slurm") {
     body = {
       name: jobConfig.name,
       image: pipeline.replace("-", "_"),
+      image_ref: imageRef,
       repo_id: model.repo_id,
       profile: profile,
       container_config: {
@@ -213,6 +214,7 @@ export async function runService(pipeline, model, jobConfig, containerConfig, pr
     body = {
       name: jobConfig.name,
       image: pipeline.replace("-", "_"),
+      image_ref: imageRef,
       repo_id: model.repo_id,
       profile: profile,
       container_config: {
@@ -308,6 +310,29 @@ export async function fetchClusterStatus(profileName) {
     console.debug(`from fetchClusterStatus: failed to fetch cluster status (status=${res.status})`);
     // Try to parse error detail from response body
     let message = "Failed to fetch cluster status.";
+    try {
+      const body = await res.json();
+      if (body.detail) {
+        message = body.detail;
+      }
+    } catch {
+      // Ignore JSON parse errors, use default message
+    }
+    const error = new Error(message);
+    error.status = res.status;
+    throw error;
+  }
+  return res.json();
+}
+
+/** Fetch the container images staged on a profile, grouped by service. */
+export async function fetchStagedContainers(profileName) {
+  const res = await fetch(
+    `${blackfishApiURL}/api/containers?profile=${encodeURIComponent(profileName)}`
+  );
+  if (!res.ok) {
+    console.debug(`from fetchStagedContainers: failed (status=${res.status})`);
+    let message = "Failed to fetch container images.";
     try {
       const body = await res.json();
       if (body.detail) {

--- a/web/src/lib/requests.js
+++ b/web/src/lib/requests.js
@@ -187,7 +187,10 @@ export async function runService(pipeline, model, jobConfig, containerConfig, pr
   if (profile.schema === "slurm") {
     body = {
       name: jobConfig.name,
-      image: pipeline.replace("-", "_"),
+      // replaceAll, not replace: `image` must match a config.IMAGES key
+      // exactly, and a non-global replace would leave a two-hyphen name like
+      // "image-text-to-text" as "image_text-to-text".
+      image: pipeline.replaceAll("-", "_"),
       image_ref: imageRef,
       repo_id: model.repo_id,
       profile: profile,
@@ -213,7 +216,10 @@ export async function runService(pipeline, model, jobConfig, containerConfig, pr
     const port = await res.json();
     body = {
       name: jobConfig.name,
-      image: pipeline.replace("-", "_"),
+      // replaceAll, not replace: `image` must match a config.IMAGES key
+      // exactly, and a non-global replace would leave a two-hyphen name like
+      // "image-text-to-text" as "image_text-to-text".
+      image: pipeline.replaceAll("-", "_"),
       image_ref: imageRef,
       repo_id: model.repo_id,
       profile: profile,

--- a/web/src/lib/useScrollOnExpand.js
+++ b/web/src/lib/useScrollOnExpand.js
@@ -1,0 +1,37 @@
+import { createContext, useContext, useEffect } from "react";
+
+/**
+ * The modal's scrollable content element, shared with nested forms.
+ *
+ * Collapsible sections live in child components (ServiceModalForm, the
+ * per-service container options form) but the scroll container belongs to the
+ * modal, so the ref is passed down rather than re-derived.
+ */
+export const ScrollContainerContext = createContext(null);
+
+/**
+ * Scroll the modal's content to the bottom when a section expands.
+ *
+ * Expanding a collapsed section below the fold reveals nothing until the user
+ * scrolls, which reads as the click having done nothing. The delay lets the
+ * newly revealed content lay out first, so `scrollHeight` includes it.
+ *
+ * No-op when the section collapses, or when there is no scroll container
+ * (rendered outside a modal, or in tests).
+ *
+ * @param {boolean} expanded whether the section is currently open
+ */
+export function useScrollOnExpand(expanded) {
+  const containerRef = useContext(ScrollContainerContext);
+
+  useEffect(() => {
+    if (!expanded || !containerRef?.current) return;
+    const timer = setTimeout(() => {
+      containerRef.current?.scrollTo({
+        top: containerRef.current.scrollHeight,
+        behavior: "smooth",
+      });
+    }, 50);
+    return () => clearTimeout(timer);
+  }, [expanded, containerRef]);
+}

--- a/web/src/lib/useScrollOnExpand.test.jsx
+++ b/web/src/lib/useScrollOnExpand.test.jsx
@@ -1,0 +1,81 @@
+import { render, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import PropTypes from "prop-types";
+import {
+  ScrollContainerContext,
+  useScrollOnExpand,
+} from "@/lib/useScrollOnExpand";
+
+function Section({ expanded }) {
+  useScrollOnExpand(expanded);
+  return null;
+}
+
+Section.propTypes = {
+  expanded: PropTypes.bool,
+};
+
+function renderWithContainer(expanded, containerRef) {
+  return render(
+    <ScrollContainerContext.Provider value={containerRef}>
+      <Section expanded={expanded} />
+    </ScrollContainerContext.Provider>
+  );
+}
+
+describe("useScrollOnExpand", () => {
+  let containerRef;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    containerRef = { current: { scrollTo: vi.fn(), scrollHeight: 1200 } };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("scrolls the container to the bottom when a section expands", () => {
+    renderWithContainer(true, containerRef);
+    act(() => vi.advanceTimersByTime(100));
+    expect(containerRef.current.scrollTo).toHaveBeenCalledWith({
+      top: 1200,
+      behavior: "smooth",
+    });
+  });
+
+  it("does not scroll while the section is collapsed", () => {
+    renderWithContainer(false, containerRef);
+    act(() => vi.advanceTimersByTime(100));
+    expect(containerRef.current.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("scrolls after a delay, so the revealed content is measured", () => {
+    // scrollHeight must include the newly expanded section; scrolling in the
+    // same tick would use the pre-expansion height and stop short.
+    renderWithContainer(true, containerRef);
+    expect(containerRef.current.scrollTo).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(100));
+    expect(containerRef.current.scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not scroll if the section collapses before the timer fires", () => {
+    const { rerender } = renderWithContainer(true, containerRef);
+    rerender(
+      <ScrollContainerContext.Provider value={containerRef}>
+        <Section expanded={false} />
+      </ScrollContainerContext.Provider>
+    );
+    act(() => vi.advanceTimersByTime(100));
+    expect(containerRef.current.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op outside a modal, where there is no scroll container", () => {
+    // Rendered without a provider — the components using this hook are also
+    // rendered directly in tests.
+    expect(() => {
+      render(<Section expanded={true} />);
+      act(() => vi.advanceTimersByTime(100));
+    }).not.toThrow();
+  });
+});

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -925,17 +925,19 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
     }
   }, [models, repoId]);
 
-  // Auto-scroll to bottom when advanced options opens
+  // Auto-scroll to bottom when either advanced section opens. Expanding one
+  // below the fold otherwise reveals nothing until the user scrolls, which
+  // reads as the click having done nothing.
   useEffect(() => {
-    if (showAdvanced && contentRef.current) {
-      setTimeout(() => {
-        contentRef.current.scrollTo({
-          top: contentRef.current.scrollHeight,
-          behavior: "smooth"
-        });
-      }, 50);
-    }
-  }, [showAdvanced]);
+    if (!(showAdvanced || showModelAdvanced) || !contentRef.current) return;
+    const timer = setTimeout(() => {
+      contentRef.current?.scrollTo({
+        top: contentRef.current.scrollHeight,
+        behavior: "smooth"
+      });
+    }, 50);
+    return () => clearTimeout(timer);
+  }, [showAdvanced, showModelAdvanced]);
 
   const handleTaskParamChange = (paramName, value) => {
     setTaskParams((prev) => ({ ...prev, [paramName]: value }));

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -20,6 +20,7 @@ import {
 } from "@heroicons/react/24/outline";
 import ModelSelect from "@/components/ModelSelect";
 import RevisionSelect from "@/components/RevisionSelect";
+import ImageVersionSelect from "@/components/ImageVersionSelect";
 import PartitionSelect from "@/components/PartitionSelect";
 import TierSelect from "@/components/TierSelect";
 import ServiceModalValidatedInput from "@/components/ServiceModalValidatedInput";
@@ -28,7 +29,7 @@ import Alert from "@/components/Alert";
 import Stepper from "@/components/Stepper";
 import DirectoryBrowser from "@/components/DirectoryBrowser";
 import { dirname } from "@/lib/pathUtils";
-import { useModels } from "@/lib/loaders";
+import { useModels, useStagedContainers } from "@/lib/loaders";
 import { useRemoteFileSystem } from "@/providers/RemoteFileSystemProvider";
 import { fetchProfileResources, fetchModelSizeFromHub, createJob } from "@/lib/requests";
 import { selectTierByModelSize, isRemoteProfile } from "@/lib/util";
@@ -733,8 +734,22 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
     isLoading: modelsLoading,
     error: modelsError,
   } = useModels(profile, task?.service);
+  // Always tigerflow_ml: every batch task runs in that container regardless of
+  // task (jobs/base.py resolves images["tigerflow_ml"] with no task branch).
+  // task.service is an HF pipeline tag for filtering models, not an image key.
+  const {
+    container,
+    isLoading: containerLoading,
+  } = useStagedContainers(profile, "tigerflow_ml");
+  // Only when discovery *succeeded* and reported nothing staged. An
+  // unreachable profile leaves `container` undefined, which must not block the
+  // launch — the backend still resolves its configured default.
+  const noContainerStaged = Boolean(
+    container && !containerLoading && container.tags.length === 0
+  );
   const [repoId, setRepoId] = useState(null);
   const [model, setModel] = useState(null);
+  const [imageRef, setImageRef] = useState(null);
 
   // Derive model type from selected model's image field (e.g., "object-detection", "zero-shot-object-detection")
   const modelType = model?.image || null;
@@ -1081,6 +1096,7 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
         task: task.id,
         repo_id: model?.repo_id || repoId,
         revision: model?.revision || null,
+        image_ref: imageRef,
         profile: profile,
         input_dir: inputDir,
         output_dir: outputDir,
@@ -1110,7 +1126,10 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
   const isStepValid = (stepId) => {
     switch (stepId) {
       case "model":
-        return repoId && !modelsLoading;
+        // Blocked only when we know nothing is staged: the job would fail its
+        // pre-flight ("tigerflow-ml image not found"), so stop here rather
+        // than after four more steps.
+        return repoId && !modelsLoading && !noContainerStaged;
       case "options":
         // Check required params (including dynamically required ones based on model type)
         if (!task) return false;
@@ -1202,6 +1221,13 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
               </Alert>
             ) : (
               <>
+                {noContainerStaged && (
+                  <Alert variant="error" title="No container image staged">
+                    The tigerflow-ml image is not staged on this profile, so a
+                    job cannot start. Ask an administrator to stage it (see{" "}
+                    <code>blackfish image ls</code>).
+                  </Alert>
+                )}
                 <fieldset>
                   <ModelSelect
                     models={models || []}
@@ -1218,6 +1244,15 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
                     setModel={setModel}
                     disabled={isSubmitting || modelsLoading}
                     isLoading={modelsLoading}
+                  />
+                </fieldset>
+                <fieldset>
+                  <ImageVersionSelect
+                    container={container}
+                    imageRef={imageRef}
+                    setImageRef={setImageRef}
+                    disabled={isSubmitting || containerLoading}
+                    isLoading={containerLoading}
                   />
                 </fieldset>
               </>

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -513,6 +513,15 @@ const VIDEO_INPUT_EXTS = new Set([
 // `showWhenParam` (e.g. transcribe's batch_size only applies when windowing is
 // "batched"). All three call sites (render, validation, submit) go through this
 // one predicate so a hidden param's stale value is never sent.
+// Whether discovery *succeeded* and reported no staged image. Distinct from
+// "we could not reach the profile" (container undefined), which must not block
+// a launch — the backend still resolves its configured default. Only this case
+// is a guaranteed failure: the job would be rejected at pre-flight with
+// "tigerflow-ml image not found".
+export function isNoContainerStaged(container, isLoading) {
+  return Boolean(container && !isLoading && container.tags?.length === 0);
+}
+
 export function isParamVisible(param, { inputExt, taskParams, modelType } = {}) {
   if (param.showWhen?.modelType && modelType !== param.showWhen.modelType) {
     return false;
@@ -741,12 +750,7 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
     container,
     isLoading: containerLoading,
   } = useStagedContainers(profile, "tigerflow_ml");
-  // Only when discovery *succeeded* and reported nothing staged. An
-  // unreachable profile leaves `container` undefined, which must not block the
-  // launch — the backend still resolves its configured default.
-  const noContainerStaged = Boolean(
-    container && !containerLoading && container.tags.length === 0
-  );
+  const noContainerStaged = isNoContainerStaged(container, containerLoading);
   const [repoId, setRepoId] = useState(null);
   const [model, setModel] = useState(null);
   const [imageRef, setImageRef] = useState(null);
@@ -770,6 +774,9 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
 
   // Advanced options
   const [showAdvanced, setShowAdvanced] = useState(false);
+  // Separate disclosure: the Model step's advanced section is a different step
+  // from Compute's, so they expand independently.
+  const [showModelAdvanced, setShowModelAdvanced] = useState(false);
   const [account, setAccount] = useState("");
   const [workerTimeout, setWorkerTimeout] = useState("");
   const [idleTimeout, setIdleTimeout] = useState("");
@@ -877,6 +884,7 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
       setSelectedTier(null);
       setRecommendedTier(null);
       setShowAdvanced(false);
+      setShowModelAdvanced(false);
       setAccount("");
       setWorkerTimeout("");
       setIdleTimeout("");
@@ -1246,14 +1254,38 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
                     isLoading={modelsLoading}
                   />
                 </fieldset>
+                {/* Collapsed by default: the configured default is right for
+                    almost everyone, and pinning is an expert need. */}
                 <fieldset>
-                  <ImageVersionSelect
-                    container={container}
-                    imageRef={imageRef}
-                    setImageRef={setImageRef}
-                    disabled={isSubmitting || containerLoading}
-                    isLoading={containerLoading}
-                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowModelAdvanced(!showModelAdvanced)}
+                    className="flex items-center gap-2 w-full text-left"
+                  >
+                    <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                      Advanced Options
+                    </span>
+                    {showModelAdvanced ? (
+                      <ChevronUpIcon className="h-4 w-4 text-gray-500" />
+                    ) : (
+                      <ChevronDownIcon className="h-4 w-4 text-gray-500" />
+                    )}
+                  </button>
+                  {showModelAdvanced && (
+                    <div className="mt-3">
+                      <ImageVersionSelect
+                        container={container}
+                        imageRef={imageRef}
+                        setImageRef={setImageRef}
+                        disabled={isSubmitting || containerLoading}
+                        isLoading={containerLoading}
+                      />
+                      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        Pin the container image for reproducibility. The default
+                        is recommended unless you need a specific version.
+                      </p>
+                    </div>
+                  )}
                 </fieldset>
               </>
             )}

--- a/web/src/routes/jobs/components/NewJobModal.test.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.test.jsx
@@ -7,6 +7,7 @@ import {
   isParamVisible,
   applyTranslateSourceLang,
   buildJobResources,
+  isNoContainerStaged,
 } from "./NewJobModal";
 
 const detect = TASKS.find((t) => t.id === "detect");
@@ -284,5 +285,32 @@ describe("buildJobResources", () => {
 
   test("an undefined tier yields only default time", () => {
     expect(buildJobResources(undefined)).toEqual({"time": "01:00:00"});
+  });
+});
+
+describe("isNoContainerStaged", () => {
+  const staged = { service: "tigerflow_ml", tags: ["0.1.1"], default: "0.1.1" };
+  const empty = { service: "tigerflow_ml", tags: [], default: "0.1.1" };
+
+  test("blocks only when discovery found nothing staged", () => {
+    // The job would be rejected at pre-flight ("tigerflow-ml image not
+    // found"), so the wizard stops here rather than four steps later.
+    expect(isNoContainerStaged(empty, false)).toBe(true);
+  });
+
+  test("does not block when a version is staged", () => {
+    expect(isNoContainerStaged(staged, false)).toBe(false);
+  });
+
+  test("does not block when the profile is unreachable", () => {
+    // container is undefined when discovery failed. We do not know what is
+    // staged, and the backend can still resolve its configured default, so a
+    // flaky login node must not make the launcher unusable.
+    expect(isNoContainerStaged(undefined, false)).toBe(false);
+  });
+
+  test("does not block while still loading", () => {
+    // An in-flight fetch briefly looks like "nothing staged".
+    expect(isNoContainerStaged(empty, true)).toBe(false);
   });
 });

--- a/web/src/routes/text-generation/components/TextGenerationContainerOptionsForm.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationContainerOptionsForm.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/20/solid";
 import ServiceModalCheckbox from "@/components/ServiceModalCheckbox"
+import { useScrollOnExpand } from "@/lib/useScrollOnExpand";
 import PropTypes from "prop-types";
 
 function TextGenerationContainerOptionsForm({
@@ -9,6 +10,9 @@ function TextGenerationContainerOptionsForm({
   disabled
 }) {
   const [expanded, setExpanded] = useState(false);
+  // This section sits at the bottom of the modal, so expanding it without
+  // scrolling reveals nothing until the user scrolls down themselves.
+  useScrollOnExpand(expanded);
 
   return (
     <>


### PR DESCRIPTION
## Summary

- Adds a **Version** select to both launchers, offering only the tags actually staged on the profile (from `GET /api/containers`, #482) so a selection can always run. The choice is sent as `image_ref`, which the backend persists and reuses across restarts (#480).
- **Collapsed into Advanced Options** in both launchers. The configured default is right for almost everyone, and pinning is a reproducibility need rather than a routine choice — a prominent control would invite changing something that can only make things worse for a casual user. This meant adding an Advanced section to the local-profile branch of the service form (local profiles run containers too, and previously had none) and one to the batch wizard's Model step, the only step both profile types share.
- **Pre-selects the configured default, not the newest staged tag.** The pre-selection should change when someone deliberately changes configuration — never because an administrator staged a new image. When that default is missing from disk, it falls back to the first staged tag so the offer is still runnable.
- The two launchers resolve **different** images, which is easy to get wrong: services map their hyphenated pipeline name to a `config.IMAGES` key (`text-generation` → `text_generation`), while batch jobs always use `tigerflow_ml`. `TASKS[].service` is an HF *pipeline tag* used to filter which models to offer (`image-text-to-text`, `object-detection`) — it is not an image key, and every batch task runs the tigerflow-ml container regardless (`jobs/base.py` resolves `images["tigerflow_ml"]` with no task branch).

This is the last of four sub-issues under #212, so image version pinning is now complete end to end: select a version, it is recorded, restarts reuse it, and the CLI and UI show it.

### Behavior worth reviewing

**Two empty cases, handled oppositely.** They look the same in the UI but mean different things, and the route distinguishes them:

| Case | `container` | Behavior |
|---|---|---|
| Profile unreachable / discovery failed | `undefined` | **Launch proceeds** on the backend's configured default — a flaky login node must not block a launch |
| Discovery succeeded, nothing staged | `{tags: []}` | **Model step blocked**, with an error naming the fix |

The second case would otherwise fail at pre-flight with "tigerflow-ml image not found" *after* the user filled in all four wizard steps. Blocking early is the friendlier failure. Note this deliberately does **not** gate the step on `imageRef` being set, which would have conflated the two cases and broken the unreachable path.

**A single staged version still renders a select**, matching `RevisionSelect`, rather than hiding below two options. Consistency beats a special rule the user would have to learn; disabling one-option selects uniformly is tracked in #489.

**Hyphen conversion uses `replaceAll`.** `runService` uses a non-global `replace`, which would turn `image-text-to-text` into `image_text-to-text`. That is latent today — only `speech_recognition` and `text_generation` are launchable services and both have a single hyphen — but the new code should not inherit it.

## Test plan

- `npm run lint` — 0 errors (one pre-existing warning in an untouched file). `npm test` — 522 passed across 53 files (9 new).
- New `ImageVersionSelect.test.jsx` covers: pre-selecting the configured default (using a container where the default is deliberately *not* the newest tag, so the assertion is meaningful), lifting the full `repo:tag`, falling back when the default is unstaged, rendering nothing when unreachable *and* when nothing is staged, keeping a single-option select, re-seeding on a container change, and not crashing without a setter.
- Verified the default-selection tests actually fail when the logic is swapped for "newest staged tag" — two of them catch it.
- `ServiceModal.test.jsx` needed both a `useStagedContainers` mock (the auto-mock returns `undefined` and crashes on destructure) and an updated `runService` payload assertion for the new argument.
- Checked live in the running app.

Closes #483.

