### PR TITLE
feat: expose image_ref in the CLI and Python client

### DIFF
--- a/lib/docs/assets/img/coverage.svg
+++ b/lib/docs/assets/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">71%</text>
-        <text x="80" y="14">71%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">72%</text>
+        <text x="80" y="14">72%</text>
     </g>
 </svg>

--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -400,6 +400,15 @@ def start(reload: bool | None) -> None:  # pragma: no cover
     default=180,
     help="Time (s) to wait before setting service health to 'unhealthy'.",
 )
+@click.option(
+    "--image-ref",
+    type=str,
+    default=None,
+    help=(
+        "Pin the container image, e.g. 'vllm/vllm-openai:v0.20.0'. Defaults to"
+        " the configured image. See `blackfish ls` for the version in use."
+    ),
+)
 @click.pass_context
 def run(
     ctx: Context,
@@ -413,6 +422,7 @@ def run(
     profile: Optional[str],
     mount: Optional[str],
     grace_period: int,
+    image_ref: Optional[str],
 ) -> None:  # pragma: no cover
     """Run an inference service.
 
@@ -438,6 +448,7 @@ def run(
         "options": ServiceOptions(
             mount=mount,
             grace_period=grace_period,
+            image_ref=image_ref,
         ),
     }
 

--- a/lib/src/blackfish/cli/batch.py
+++ b/lib/src/blackfish/cli/batch.py
@@ -486,6 +486,16 @@ def remove_batch_job(
     help="Model revision (commit hash). Uses latest available if not specified.",
 )
 @click.option(
+    "--image-ref",
+    type=str,
+    default=None,
+    help=(
+        "Pin the tigerflow-ml container image, e.g."
+        " 'ghcr.io/princeton-ddss/tigerflow-ml:0.1.1'. Defaults to the"
+        " configured image. See `blackfish batch ls` for the version in use."
+    ),
+)
+@click.option(
     "--params",
     type=str,
     default=None,
@@ -523,6 +533,7 @@ def run_batch_job(
     input_dir: str,
     output_dir: str,
     revision: Optional[str],
+    image_ref: Optional[str],
     params: Optional[str],
     resources: Optional[str],
     max_workers: int,
@@ -632,6 +643,10 @@ def run_batch_job(
         click.echo(
             yaml.dump(pipeline_config, default_flow_style=False, sort_keys=False)
         )
+        # The image is rendered into the job script, not the pipeline config,
+        # so report it separately rather than leaving the pin invisible here.
+        if image_ref:
+            click.echo(f"Container image: {image_ref}")
         return
 
     # Build and submit the job
@@ -644,6 +659,7 @@ def run_batch_job(
                     "task": task,
                     "repo_id": model,
                     "revision": revision,
+                    "image_ref": image_ref,
                     "profile": asdict(matched_profile),
                     "input_dir": input_dir,
                     "output_dir": output_dir,

--- a/lib/src/blackfish/cli/classes.py
+++ b/lib/src/blackfish/cli/classes.py
@@ -6,3 +6,6 @@ from typing import Optional
 class ServiceOptions:
     mount: Optional[str] = None
     grace_period: int = 180
+    # A pinned container image as "repo:tag". None means "use the configured
+    # default", which the server records on the service once it launches.
+    image_ref: Optional[str] = None

--- a/lib/src/blackfish/cli/services/speech_recognition.py
+++ b/lib/src/blackfish/cli/services/speech_recognition.py
@@ -154,6 +154,7 @@ def run_speech_recognition(
                 scheduler=JobScheduler.Slurm,
                 mount=options.mount,
                 grace_period=options.grace_period,
+                image_ref=options.image_ref,
             )
             click.echo("\n🚧 Rendering job script for service:\n")
             click.echo(f"> name: {name}")
@@ -217,6 +218,7 @@ def run_speech_recognition(
                 provider=config.CONTAINER_PROVIDER,
                 mount=options.mount,
                 grace_period=options.grace_period,
+                image_ref=options.image_ref,
             )
             click.echo("\n🚧 Rendering job script for service:\n")
             click.echo(f"> name: {name}")

--- a/lib/src/blackfish/cli/services/speech_recognition.py
+++ b/lib/src/blackfish/cli/services/speech_recognition.py
@@ -166,6 +166,7 @@ def run_speech_recognition(
             click.echo(f"> scheduler: {service.scheduler}")
             click.echo(f"> mount: {options.mount}")
             click.echo(f"> grace_period: {options.grace_period}")
+            click.echo(f"> image_ref: {options.image_ref}")
             click.echo("\n👇 Here's the job script 👇\n")
             click.echo(service.render_job_script(container_config, job_config))
         else:
@@ -182,6 +183,7 @@ def run_speech_recognition(
                             "job_config": asdict(job_config),
                             "mount": options.mount,
                             "grace_period": options.grace_period,
+                            "image_ref": options.image_ref,
                         },
                     )
                 except (
@@ -226,6 +228,7 @@ def run_speech_recognition(
             click.echo(f"> provider: {config.CONTAINER_PROVIDER}")
             click.echo(f"> mount: {options.mount}")
             click.echo(f"> grace_period: {options.grace_period}")
+            click.echo(f"> image_ref: {options.image_ref}")
             click.echo("\n👇 Here's the job script 👇\n")
             click.echo(service.render_job_script(container_config, job_config))
         else:
@@ -242,6 +245,7 @@ def run_speech_recognition(
                             "job_config": asdict(job_config),
                             "mount": options.mount,
                             "grace_period": options.grace_period,
+                            "image_ref": options.image_ref,
                         },
                     )
                 except (

--- a/lib/src/blackfish/cli/services/text_generation.py
+++ b/lib/src/blackfish/cli/services/text_generation.py
@@ -169,6 +169,7 @@ def run_text_generation(
             click.echo(f"> scheduler: {service.scheduler}")
             click.echo(f"> mount: {options.mount}")
             click.echo(f"> grace_period: {options.grace_period}")
+            click.echo(f"> image_ref: {options.image_ref}")
             click.echo("\n👇 Here's the job script 👇\n")
             click.echo(service.render_job_script(container_config, job_config))
         else:
@@ -185,6 +186,7 @@ def run_text_generation(
                             "job_config": asdict(job_config),
                             "mount": options.mount,
                             "grace_period": options.grace_period,
+                            "image_ref": options.image_ref,
                         },
                     )
                 except (
@@ -229,6 +231,7 @@ def run_text_generation(
             click.echo(f"> provider: {config.CONTAINER_PROVIDER}")
             click.echo(f"> mount: {options.mount}")
             click.echo(f"> grace_period: {options.grace_period}")
+            click.echo(f"> image_ref: {options.image_ref}")
             click.echo("\n👇 Here's the job script 👇\n")
             click.echo(service.render_job_script(container_config, job_config))
         else:
@@ -245,6 +248,7 @@ def run_text_generation(
                             "job_config": asdict(job_config),
                             "mount": options.mount,
                             "grace_period": options.grace_period,
+                            "image_ref": options.image_ref,
                         },
                     )
                 except (

--- a/lib/src/blackfish/cli/services/text_generation.py
+++ b/lib/src/blackfish/cli/services/text_generation.py
@@ -157,6 +157,7 @@ def run_text_generation(
                 scheduler=JobScheduler.Slurm,
                 mount=options.mount,
                 grace_period=options.grace_period,
+                image_ref=options.image_ref,
             )
             click.echo("\n🚧 Rendering job script for service:\n")
             click.echo(f"> name: {name}")
@@ -220,6 +221,7 @@ def run_text_generation(
                 provider=config.CONTAINER_PROVIDER,
                 mount=options.mount,
                 grace_period=options.grace_period,
+                image_ref=options.image_ref,
             )
             click.echo("\n🚧 Rendering job script for service:\n")
             click.echo(f"> name: {name}")

--- a/lib/src/blackfish/client.py
+++ b/lib/src/blackfish/client.py
@@ -286,6 +286,7 @@ class Blackfish:
         job_config: Optional[dict[str, Any]] = None,
         mount: Optional[str] = None,
         grace_period: int = 180,
+        image_ref: Optional[str] = None,
         auto_cleanup: bool = True,
         **kwargs: dict[str, Any],  # BlackfishConfig
     ) -> ManagedService:
@@ -303,6 +304,9 @@ class Blackfish:
             job_config: Job configuration options (Slurm settings, etc.)
             mount: Optional directory to mount
             grace_period: Time in seconds to wait before marking unhealthy
+            image_ref: Pin the container image as "repo:tag" (e.g.
+                "vllm/vllm-openai:v0.20.0"). None uses the configured image,
+                which is then recorded on the service so restarts reuse it.
             auto_cleanup: If True, automatically stop and delete this service when the
                 Python script exits (default: True)
             **kwargs: Additional service-specific parameters
@@ -344,6 +348,7 @@ class Blackfish:
             "cache_dir": profile.cache_dir,
             "mount": mount,
             "grace_period": grace_period,
+            "image_ref": image_ref,
             **kwargs,
         }
 
@@ -470,6 +475,7 @@ class Blackfish:
         job_config: Optional[dict[str, Any]] = None,
         mount: Optional[str] = None,
         grace_period: int = 180,
+        image_ref: Optional[str] = None,
         auto_cleanup: bool = True,
         **kwargs: dict[str, Any],  # BlackfishConfig
     ) -> ManagedService:
@@ -477,16 +483,19 @@ class Blackfish:
 
         See async_launch_service for details.
         """
+        # Keyword arguments so adding a parameter to the async signature can't
+        # silently shift these onto the wrong ones.
         return await self.async_launch_service(
             name,
             image,
             model,
-            profile_name,
-            container_config,
-            job_config,
-            mount,
-            grace_period,
-            auto_cleanup,
+            profile_name=profile_name,
+            container_config=container_config,
+            job_config=job_config,
+            mount=mount,
+            grace_period=grace_period,
+            image_ref=image_ref,
+            auto_cleanup=auto_cleanup,
             **kwargs,
         )
 

--- a/lib/tests/cli/test_cli_batch_run.py
+++ b/lib/tests/cli/test_cli_batch_run.py
@@ -1,0 +1,85 @@
+"""Tests for `blackfish batch run` option plumbing."""
+
+from unittest.mock import Mock, patch
+
+from blackfish.cli.__main__ import main
+from blackfish.server.models.profile import SlurmProfile
+
+
+def _profile() -> SlurmProfile:
+    return SlurmProfile(
+        name="default",
+        host="hpc.example.com",
+        user="test",
+        home_dir="/home/test/.blackfish",
+        cache_dir="/home/test/.blackfish/cache",
+    )
+
+
+def _invoke(cli_runner, extra_args):
+    """Run `batch run` with the model-resolution collaborators stubbed."""
+    cmd = [
+        "batch",
+        "run",
+        "--name",
+        "test-job",
+        "--task",
+        "chat",
+        "--model",
+        "google/gemma-3-4b-it",
+        "--input-dir",
+        "/data/in",
+        "--output-dir",
+        "/data/out",
+        *extra_args,
+    ]
+
+    with (
+        patch("blackfish.cli.batch.resolve_profile_or_exit") as mock_resolve,
+        patch("blackfish.cli.batch.deserialize_profile") as mock_deserialize,
+        patch("blackfish.cli.batch.get_models") as mock_get_models,
+        patch("blackfish.cli.batch.get_model_dir") as mock_get_model_dir,
+        patch("blackfish.cli.batch.get_latest_commit") as mock_get_latest,
+        patch("blackfish.cli.batch.get_revisions") as mock_get_revisions,
+        patch("blackfish.cli.batch.api.post") as mock_post,
+    ):
+        mock_resolve.return_value = "default"
+        mock_deserialize.return_value = _profile()
+        mock_get_models.return_value = ["google/gemma-3-4b-it"]
+        mock_get_model_dir.return_value = "/models/gemma"
+        mock_get_latest.return_value = "abc123"
+        mock_get_revisions.return_value = ["abc123"]
+
+        response = Mock()
+        response.ok = True
+        response.json.return_value = {"id": "job-uuid-123"}
+        mock_post.return_value = response
+
+        result = cli_runner.invoke(main, cmd)
+
+    return result, mock_post
+
+
+class TestBatchRunImageRef:
+    def test_image_ref_is_forwarded_to_the_api(self, cli_runner, mock_config):
+        """--image-ref reaches the request body as image_ref."""
+        pin = "ghcr.io/princeton-ddss/tigerflow-ml:9.9.9"
+        _, mock_post = _invoke(cli_runner, ["--image-ref", pin])
+
+        assert mock_post.call_args[1]["json"]["image_ref"] == pin
+
+    def test_image_ref_defaults_to_none(self, cli_runner, mock_config):
+        """Omitting it sends null, so the server resolves its configured
+        default and records it on the job."""
+        _, mock_post = _invoke(cli_runner, [])
+
+        assert mock_post.call_args[1]["json"]["image_ref"] is None
+
+    def test_dry_run_reports_the_pinned_image(self, cli_runner, mock_config):
+        """The image is rendered into the job script rather than the pipeline
+        config, so a dry run must report it separately or the pin is
+        invisible."""
+        pin = "ghcr.io/princeton-ddss/tigerflow-ml:9.9.9"
+        result, _ = _invoke(cli_runner, ["--image-ref", pin, "--dry-run"])
+
+        assert pin in result.output

--- a/lib/tests/cli/test_cli_run.py
+++ b/lib/tests/cli/test_cli_run.py
@@ -1197,7 +1197,7 @@ class TestRunGroupOptions:
         cmd = [
             "run",
             "-p",
-            "default",
+            "cluster",
             "--image-ref",
             "vllm/vllm-openai:v9.9.9",
             "text-generation",
@@ -1236,3 +1236,54 @@ class TestRunGroupOptions:
             cli_runner.invoke(main, cmd)
 
         assert mock_post.call_args[1]["json"]["image_ref"] == "vllm/vllm-openai:v9.9.9"
+
+    def test_dry_run_renders_the_pinned_image(
+        self, cli_runner, mock_config, slurm_profile
+    ):
+        """The rendered script must pin the requested image, not the default.
+
+        The preview is exactly where a cautious user checks that a pin took
+        effect, so asserting only on the `> image_ref:` echo is not enough —
+        that line was correct while the script below it still referenced the
+        configured default.
+        """
+        cmd = [
+            "run",
+            "-p",
+            "cluster",
+            "--image-ref",
+            "vllm/vllm-openai:v9.9.9",
+            "text-generation",
+            "openai/gpt-2",
+            "--dry-run",
+        ]
+
+        with (
+            patch(
+                "blackfish.server.models.profile.deserialize_profile"
+            ) as mock_deserialize,
+            patch(
+                "blackfish.cli.services.text_generation.get_models"
+            ) as mock_get_models,
+            patch(
+                "blackfish.cli.services.text_generation.get_revisions"
+            ) as mock_get_revisions,
+            patch(
+                "blackfish.cli.services.text_generation.get_latest_commit"
+            ) as mock_get_latest,
+            patch(
+                "blackfish.cli.services.text_generation.get_model_dir"
+            ) as mock_get_model_dir,
+        ):
+            mock_deserialize.return_value = slurm_profile
+            mock_get_models.return_value = ["openai/gpt-2"]
+            mock_get_revisions.return_value = ["abc123"]
+            mock_get_latest.return_value = "abc123"
+            mock_get_model_dir.return_value = "/path/to/model"
+
+            result = cli_runner.invoke(main, cmd)
+
+        # The script itself, not the echo line above it.
+        script = result.output.split("> image_ref:")[-1]
+        assert "vllm-openai_v9.9.9" in script
+        assert "vllm-openai_v0.20.0" not in script

--- a/lib/tests/cli/test_cli_run.py
+++ b/lib/tests/cli/test_cli_run.py
@@ -1185,3 +1185,54 @@ class TestRunGroupOptions:
         assert "Started service" in result.output
         call_args = mock_post.call_args
         assert call_args[1]["json"]["grace_period"] == 300
+
+    def test_image_ref_is_forwarded_to_the_api(
+        self, cli_runner, mock_config, local_profile
+    ):
+        """--image-ref reaches the request body as image_ref.
+
+        The option is on the `run` group, so it travels through ServiceOptions
+        to whichever service subcommand runs.
+        """
+        cmd = [
+            "run",
+            "-p",
+            "default",
+            "--image-ref",
+            "vllm/vllm-openai:v9.9.9",
+            "text-generation",
+            "openai/gpt-2",
+        ]
+
+        with (
+            patch(
+                "blackfish.server.models.profile.deserialize_profile"
+            ) as mock_deserialize,
+            patch(
+                "blackfish.cli.services.text_generation.get_models"
+            ) as mock_get_models,
+            patch(
+                "blackfish.cli.services.text_generation.get_revisions"
+            ) as mock_get_revisions,
+            patch(
+                "blackfish.cli.services.text_generation.get_latest_commit"
+            ) as mock_get_latest,
+            patch(
+                "blackfish.cli.services.text_generation.get_model_dir"
+            ) as mock_get_model_dir,
+            patch("blackfish.cli.services.text_generation.api.post") as mock_post,
+        ):
+            mock_deserialize.return_value = local_profile
+            mock_get_models.return_value = ["openai/gpt-2"]
+            mock_get_revisions.return_value = ["abc123"]
+            mock_get_latest.return_value = "abc123"
+            mock_get_model_dir.return_value = "/path/to/model"
+
+            mock_response = Mock()
+            mock_response.ok = True
+            mock_response.json.return_value = {"id": "service-uuid-123"}
+            mock_post.return_value = mock_response
+
+            cli_runner.invoke(main, cmd)
+
+        assert mock_post.call_args[1]["json"]["image_ref"] == "vllm/vllm-openai:v9.9.9"


### PR DESCRIPTION
## Summary

- Image pinning (#212) was reachable from the web UI and the REST API but **not** from the CLI or the Python client. The read side already surfaced it — `blackfish ls` and `batch ls` show a `VERSION` column, `blackfish details` prints the full ref — so a user could see which image a service ran but had no way to choose it short of hand-rolling an HTTP request.
- Adds `--image-ref` to `blackfish run` and `blackfish batch run`, and an `image_ref` parameter to `Client.launch_service` / `async_launch_service`. Batch jobs have no Python client method, so there is nothing to add there.
- Thin plumbing: the API already accepts `image_ref` on both request models and validates it with `ImageSpec.parse`. Validation deliberately stays server-side rather than being duplicated in the CLI, where the two rules could drift apart — a malformed ref returns a 400 with a clear message (verified against the running server).

### Details

**The service option lives on the `run` group**, not the subcommands, travelling through `ServiceOptions` in `ctx.obj`. One declaration therefore covers both `text-generation` and `speech-recognition`, and their four POST sites.

**The batch dry run reports the pin separately.** `--dry-run` prints the *pipeline* config, but the image is rendered into the job script, not the pipeline YAML — so without an extra line the pin would be invisible exactly where a user goes to check it:

```
$ blackfish batch run --dry-run --image-ref ghcr.io/princeton-ddss/tigerflow-ml:9.9.9 ...
Pipeline config (dry run):
tasks:
- name: chat
  ...
Container image: ghcr.io/princeton-ddss/tigerflow-ml:9.9.9
```

**The client's sync wrapper now forwards by keyword.** It passed its arguments positionally, so inserting `image_ref` into the async signature silently shifted it onto `auto_cleanup` — caught by mypy here, but the same edit would land differently next time.

**Named `--image-ref`**, matching the API field and DB column rather than `--image`: in `blackfish ls`, `IMAGE` already means the service *type*, which is the overload that made `image_ref` necessary in the first place (`Service.image` is the polymorphic discriminator, `Model.image` an HF pipeline tag).

## Test plan

- `uv run just lint` — clean, MyPy strict included. `uv run just test` — 958 passed, 7 skipped. Coverage 71% → 72%.
- Four new tests, each covering one wiring hop that could realistically break: the service option reaches the request body (four hops: group → ServiceOptions → subcommand → POST), the batch option reaches its body, omitting it sends null rather than dropping the key, and the dry run reports the pin.
- Verified end to end against the running server: both `--help` outputs list the option, a batch dry run prints the pinned image, and a malformed ref returns 400.

Deliberately no tests for the client parameter. `test_api.py`'s fixture points at a `home_dir` that does not exist, so no profiles are configured and `async_launch_service` cannot construct a service — which is why every test in that file is a `hasattr` check rather than behavioral. Writing signature assertions around that would have tested nothing mypy does not already enforce. The fixture is tracked separately.

Closes #492.
