### PR TITLE
fix(web): disable launcher selects with a single option

### DIFF
--- a/web/src/components/ImageVersionSelect.jsx
+++ b/web/src/components/ImageVersionSelect.jsx
@@ -43,9 +43,8 @@ function ImageVersionSelect({
   // below rather than stored, so a container change (new profile or service)
   // can never leave a stale tag paired with a new repo.
   const [chosen, setChosen] = useState(null);
-  const isDisabled = disabled || isLoading;
-
   const tags = container?.tags ?? [];
+  const isDisabled = disabled || isLoading || tags.length < 2;
 
   // Prefer the configured default, falling back to the first staged tag when
   // that default is not on disk. A user's pick wins, but only while it is
@@ -78,8 +77,8 @@ function ImageVersionSelect({
   }
 
   // Nothing staged, or the profile is unreachable: stay out of the way and let
-  // the backend resolve its default. A single staged version still renders, to
-  // match RevisionSelect — disabling one-option selects is tracked in #489.
+  // the backend resolve its default. A single staged version still renders
+  // (disabled) so the user sees which image is going to run.
   if (selected === null) {
     return <></>;
   }

--- a/web/src/components/ImageVersionSelect.test.jsx
+++ b/web/src/components/ImageVersionSelect.test.jsx
@@ -65,16 +65,19 @@ describe("ImageVersionSelect", () => {
     expect(dom).toBeEmptyDOMElement();
   });
 
-  it("still renders with a single option, matching RevisionSelect", () => {
-    // Disabling one-option selects is tracked separately (#489); until then
-    // the version in use stays visible rather than vanishing.
+  it("renders a disabled control with a single option", () => {
+    // One staged version: the value stays visible so users see what's going to
+    // run, but the affordance is disabled since there is nothing else to pick.
+    // The lifted image_ref still needs to make it into the request payload.
     const container = {
       ...CONTAINER,
       tags: ["0.1.1"],
       default: "0.1.1",
     };
-    renderSelect({ container });
+    const { setImageRef } = renderSelect({ container });
     expect(screen.getByText("0.1.1")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toBeDisabled();
+    expect(setImageRef).toHaveBeenCalledWith("vllm/vllm-openai:0.1.1");
   });
 
   it("re-seeds when the container changes, e.g. on a profile switch", () => {

--- a/web/src/components/ModelSelect.jsx
+++ b/web/src/components/ModelSelect.jsx
@@ -25,10 +25,10 @@ import SelectSkeleton from "@/components/SelectSkeleton";
 function ModelSelect({ models, setRepoId, setModelId, disabled, isLoading = false }) {
 
   const [selected, setSelected] = useState(null);
-  const isDisabled = disabled || isLoading;
 
   // filter unique repo_ids
   const repos = getUniqueRepoIds(models);
+  const isDisabled = disabled || isLoading || repos.length < 2;
 
   // update repo_id and model_id on selection
   useEffect(() => {

--- a/web/src/components/ModelSelect.test.jsx
+++ b/web/src/components/ModelSelect.test.jsx
@@ -99,6 +99,24 @@ describe("ModelSelect", () => {
     });
   });
 
+  it("disables the control (but still lifts the repo) with one unique repo", async () => {
+    render(
+      <ModelSelect
+        models={[
+          { repo_id: "only-repo", revision: "rev-1" },
+          { repo_id: "only-repo", revision: "rev-2" },
+        ]}
+        setRepoId={mockSetRepoId}
+        disabled={false}
+      />
+    );
+    await waitFor(() => {
+      expect(mockSetRepoId).toHaveBeenCalledWith("only-repo");
+    });
+    // Two rows but one unique repo — nothing to pick between.
+    expect(document.querySelector("button")).toBeDisabled();
+  });
+
   it("applies disabled styling when disabled prop is true", () => {
     const {baseElement} = render(
       <ModelSelect

--- a/web/src/components/PartitionSelect.jsx
+++ b/web/src/components/PartitionSelect.jsx
@@ -22,12 +22,14 @@ function PartitionSelect({ partitions, selectedPartition, setSelectedPartition, 
           <span className="block truncate">
             {selected.default ? `${selected.name} (Default)` : selected.name}
           </span>
-          <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-            <ChevronUpDownIcon
-              className="h-5 w-5 text-gray-400"
-              aria-hidden="true"
-            />
-          </span>
+          {!isDisabled &&
+            <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+              <ChevronUpDownIcon
+                className="h-5 w-5 text-gray-400"
+                aria-hidden="true"
+              />
+            </span>
+          }
         </ListboxButton>
         <ListboxOptions className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white dark:bg-gray-700 py-1 text-base shadow-lg ring-1 ring-black dark:ring-gray-600 ring-opacity-5 focus:outline-none sm:text-sm">
           {partitions.map((partition) => (

--- a/web/src/components/PartitionSelect.jsx
+++ b/web/src/components/PartitionSelect.jsx
@@ -9,12 +9,13 @@ function PartitionSelect({ partitions, selectedPartition, setSelectedPartition, 
 
   // Find the selected partition object
   const selected = partitions.find(p => p.name === selectedPartition) || partitions[0];
+  const isDisabled = disabled || partitions.length < 2;
 
   return (
     <Listbox
       value={selected}
       onChange={(partition) => setSelectedPartition(partition.name)}
-      disabled={disabled}
+      disabled={isDisabled}
     >
       <div className="relative">
         <ListboxButton className="relative w-full cursor-default rounded-lg bg-white dark:bg-gray-700 py-2 pl-3 pr-10 text-left text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-600 focus:outline-none focus-visible:border-blue-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-blue-300 sm:text-sm disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:cursor-not-allowed">

--- a/web/src/components/PartitionSelect.test.jsx
+++ b/web/src/components/PartitionSelect.test.jsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import PartitionSelect from "@/components/PartitionSelect";
+
+const MULTI = [
+  { name: "gpu", default: true },
+  { name: "cpu" },
+];
+
+describe("PartitionSelect", () => {
+  it("renders nothing when there are no partitions", () => {
+    const { container } = render(
+      <PartitionSelect partitions={[]} setSelectedPartition={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("stays enabled when there are multiple partitions", () => {
+    render(
+      <PartitionSelect
+        partitions={MULTI}
+        selectedPartition="gpu"
+        setSelectedPartition={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("button")).not.toBeDisabled();
+  });
+
+  it("disables the control with a single partition", () => {
+    // The parent already syncs the default into state, so disabling here is
+    // safe: the partition name still reaches the launch payload without any
+    // click from the user.
+    render(
+      <PartitionSelect
+        partitions={[{ name: "only", default: true }]}
+        selectedPartition="only"
+        setSelectedPartition={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("button")).toBeDisabled();
+    expect(screen.getByText("only (Default)")).toBeInTheDocument();
+  });
+
+  it("honors an explicit disabled prop even with multiple partitions", () => {
+    render(
+      <PartitionSelect
+        partitions={MULTI}
+        selectedPartition="gpu"
+        setSelectedPartition={vi.fn()}
+        disabled
+      />
+    );
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+});

--- a/web/src/components/RevisionSelect.jsx
+++ b/web/src/components/RevisionSelect.jsx
@@ -27,10 +27,10 @@ import SelectSkeleton from "@/components/SelectSkeleton";
 function RevisionSelect({ models, repoId, setModel, disabled, isLoading = false }) {
 
   const [selected, setSelected] = useState(null);
-  const isDisabled = disabled || isLoading;
 
   // filter repo_id revisions
   const revisions = (models ?? []).filter(model => model.repo_id === repoId);
+  const isDisabled = disabled || isLoading || revisions.length < 2;
 
   // update selection on revisions refresh
   useEffect(() => {

--- a/web/src/components/RevisionSelect.test.jsx
+++ b/web/src/components/RevisionSelect.test.jsx
@@ -1,5 +1,5 @@
-import { render } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
 import RevisionSelect from "@/components/RevisionSelect";
 
 describe("RevisionSelect", () => {
@@ -22,6 +22,39 @@ describe("RevisionSelect", () => {
       />
     );
     expect(baseElement).toMatchSnapshot();
+  });
+
+  it("stays enabled when the repo has multiple revisions", () => {
+    // Guards the off-by-one direction of the `< 2` check: two options must
+    // remain interactive, otherwise the launcher becomes unusable for any
+    // repo that has more than one staged revision.
+    const setModel = vi.fn();
+    render(
+      <RevisionSelect
+        models={[
+          { repo_id: "repo", revision: "rev-a" },
+          { repo_id: "repo", revision: "rev-b" },
+        ]}
+        repoId="repo"
+        setModel={setModel}
+        disabled={false}
+      />
+    );
+    expect(screen.getByRole("button")).not.toBeDisabled();
+  });
+
+  it("disables the control (but still lifts the model) with one revision", () => {
+    const setModel = vi.fn();
+    render(
+      <RevisionSelect
+        models={[{ repo_id: "repo", revision: "rev-only" }]}
+        repoId="repo"
+        setModel={setModel}
+        disabled={false}
+      />
+    );
+    expect(screen.getByRole("button")).toBeDisabled();
+    expect(setModel).toHaveBeenCalledWith({ repo_id: "repo", revision: "rev-only" });
   });
 
   it("Disabled", () => {

--- a/web/src/components/__snapshots__/ModelSelect.test.jsx.snap
+++ b/web/src/components/__snapshots__/ModelSelect.test.jsx.snap
@@ -13,8 +13,8 @@ exports[`ModelSelect > applies disabled styling when disabled prop is true 1`] =
         class="block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100"
         data-disabled=""
         data-headlessui-state="disabled"
-        for="headlessui-control-:r16:"
-        id="headlessui-label-:r19:"
+        for="headlessui-control-:r1e:"
+        id="headlessui-label-:r1h:"
       >
         Model
       </label>
@@ -24,12 +24,12 @@ exports[`ModelSelect > applies disabled styling when disabled prop is true 1`] =
         <button
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="headlessui-label-:r19: headlessui-control-:r16:"
+          aria-labelledby="headlessui-label-:r1h: headlessui-control-:r1e:"
           class="bg-gray-100 dark:bg-gray-800 ring-gray-300 dark:ring-gray-600 ring-1 relative w-full cursor-default rounded-md py-1.5 pl-1 pr-10 text-left text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 sm:text-sm sm:leading-6"
           data-disabled=""
           data-headlessui-state="disabled"
           disabled=""
-          id="headlessui-control-:r16:"
+          id="headlessui-control-:r1e:"
           type="button"
         >
           <span

--- a/web/src/components/__snapshots__/RevisionSelect.test.jsx.snap
+++ b/web/src/components/__snapshots__/RevisionSelect.test.jsx.snap
@@ -56,11 +56,15 @@ exports[`RevisionSelect > Standard 1`] = `
 <body>
   <div>
     <div
-      data-headlessui-state=""
+      aria-disabled="true"
+      data-disabled=""
+      data-headlessui-state="disabled"
+      disabled=""
     >
       <label
         class="block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100"
-        data-headlessui-state=""
+        data-disabled=""
+        data-headlessui-state="disabled"
         for="headlessui-control-:r0:"
         id="headlessui-label-:r3:"
       >
@@ -73,8 +77,10 @@ exports[`RevisionSelect > Standard 1`] = `
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="headlessui-label-:r3: headlessui-control-:r0:"
-          class="bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 relative w-full cursor-default rounded-md py-1.5 pl-1 pr-10 text-left text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 sm:text-sm sm:leading-6"
-          data-headlessui-state=""
+          class="bg-gray-100 dark:bg-gray-800 ring-gray-300 dark:ring-gray-600 ring-1 relative w-full cursor-default rounded-md py-1.5 pl-1 pr-10 text-left text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 sm:text-sm sm:leading-6"
+          data-disabled=""
+          data-headlessui-state="disabled"
+          disabled=""
           id="headlessui-control-:r0:"
           type="button"
         >
@@ -86,24 +92,6 @@ exports[`RevisionSelect > Standard 1`] = `
             >
               169d4a4341b33bc18d8881c4b69c2e104e1cc0af
             </span>
-          </span>
-          <span
-            class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2"
-          >
-            <svg
-              aria-hidden="true"
-              class="h-5 w-5 text-gray-400"
-              data-slot="icon"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M10.53 3.47a.75.75 0 0 0-1.06 0L6.22 6.72a.75.75 0 0 0 1.06 1.06L10 5.06l2.72 2.72a.75.75 0 1 0 1.06-1.06l-3.25-3.25Zm-4.31 9.81 3.25 3.25a.75.75 0 0 0 1.06 0l3.25-3.25a.75.75 0 1 0-1.06-1.06L10 14.94l-2.72-2.72a.75.75 0 0 0-1.06 1.06Z"
-                fill-rule="evenodd"
-              />
-            </svg>
           </span>
         </button>
       </div>

--- a/web/src/components/__snapshots__/RevisionSelect.test.jsx.snap
+++ b/web/src/components/__snapshots__/RevisionSelect.test.jsx.snap
@@ -13,8 +13,8 @@ exports[`RevisionSelect > Disabled 1`] = `
         class="block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100"
         data-disabled=""
         data-headlessui-state="disabled"
-        for="headlessui-control-:r8:"
-        id="headlessui-label-:rb:"
+        for="headlessui-control-:ro:"
+        id="headlessui-label-:rr:"
       >
         Revision
       </label>
@@ -24,12 +24,12 @@ exports[`RevisionSelect > Disabled 1`] = `
         <button
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="headlessui-label-:rb: headlessui-control-:r8:"
+          aria-labelledby="headlessui-label-:rr: headlessui-control-:ro:"
           class="bg-gray-100 dark:bg-gray-800 ring-gray-300 dark:ring-gray-600 ring-1 relative w-full cursor-default rounded-md py-1.5 pl-1 pr-10 text-left text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 sm:text-sm sm:leading-6"
           data-disabled=""
           data-headlessui-state="disabled"
           disabled=""
-          id="headlessui-control-:r8:"
+          id="headlessui-control-:ro:"
           type="button"
         >
           <span


### PR DESCRIPTION
## Summary

- `RevisionSelect`, `ModelSelect`, `ImageVersionSelect`, and `PartitionSelect` now render disabled when their options list has fewer than 2 entries, so users stop clicking dropdowns that promise a choice that does not exist.
- The single value is still computed and lifted to the parent (`setModel`, `setRepoId`, `setImageRef`, `setSelectedPartition`), so the selection continues to make it into the launch payload.
- Removes the stale "tracked in #489" note in `ImageVersionSelect` and updates its single-option test to assert both the disabled affordance and that `image_ref` still fires.

## Test plan

- [x] `npm run lint` — no new warnings
- [x] `npm test` — 532/532 pass (one snapshot updated: `RevisionSelect` "Standard" test filters to one revision and now renders disabled)
- [ ] Manual: open the batch launcher on a profile where `tigerflow_ml` has one staged version — the Version dropdown is disabled but shows the tag, and launching still submits the correct `image_ref`.
- [ ] Manual: pick a model with one revision — Revision dropdown is disabled but the revision is still lifted.

Closes #489