### PR TITLE
fix(lib): include any-to-any models in image-text-to-text filter

### DIFF
--- a/lib/docs/assets/img/coverage.svg
+++ b/lib/docs/assets/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">61%</text>
-        <text x="80" y="14">61%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">71%</text>
+        <text x="80" y="14">71%</text>
     </g>
 </svg>

--- a/lib/docs/assets/img/coverage.svg
+++ b/lib/docs/assets/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">72%</text>
-        <text x="80" y="14">72%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">61%</text>
+        <text x="80" y="14">61%</text>
     </g>
 </svg>

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -569,6 +569,10 @@ COMPATIBLE_PIPELINES: dict[str, list[str]] = {
         "image-to-text",
         "any-to-any",
     ],
+    "image-text-to-text": [
+        "image-text-to-text",
+        "any-to-any",
+    ],
     "object-detection": [
         "object-detection",
         "zero-shot-object-detection",

--- a/lib/tests/api/test_models.py
+++ b/lib/tests/api/test_models.py
@@ -80,6 +80,27 @@ class TestFetchModelsAPI:
         vlm_ids = [m["id"] for m in result if m["image"] == "image-text-to-text"]
         assert vlm_model_id in vlm_ids
 
+    async def test_fetch_image_text_to_text_includes_any_to_any(
+        self, client: AsyncTestClient
+    ):
+        """image-text-to-text must widen to any-to-any as well.
+
+        vLLM's VLM code path serves omni/any-to-any models through the same
+        entry point as image-text-to-text, so the OCR batch launcher (and any
+        other consumer filtering by that pipeline) needs both tags.
+        """
+        any_to_any_model_id = "d4e5f6a7-b8c9-0123-def0-234567890123"
+
+        response = await client.get(
+            "/api/models", params={"image": "image-text-to-text"}
+        )
+
+        assert response.status_code == 200
+        result = response.json()
+        images = {model.get("image") for model in result}
+        assert "any-to-any" in images
+        assert any_to_any_model_id in [m["id"] for m in result]
+
     async def test_refresh_preserves_existing_model_ids(self, client: AsyncTestClient):
         """Test that refresh preserves IDs for models that already exist."""
         # Get existing model ID before refresh

--- a/lib/tests/data_fixtures.py
+++ b/lib/tests/data_fixtures.py
@@ -167,6 +167,14 @@ def models_fixture() -> list[Model | dict[str, Any]]:
             "model_dir": "/home/test/.blackfish/models/models--llava-hf/llava-1.5-7b-hf",
         },
         {
+            "id": "d4e5f6a7-b8c9-0123-def0-234567890123",
+            "repo": "Qwen/Qwen2.5-Omni-7B",
+            "profile": "default",
+            "revision": "main",
+            "image": "any-to-any",
+            "model_dir": "/home/test/.blackfish/models/models--Qwen/Qwen2.5-Omni-7B",
+        },
+        {
             "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
             "repo": "openai/whisper-large-v3",
             "profile": "hpc",


### PR DESCRIPTION
## Summary

- Adds an `image-text-to-text` entry to `COMPATIBLE_PIPELINES` that widens to `any-to-any`, mirroring the existing `text-generation` entry (which already lists both).
- The OCR batch launcher (and any other consumer of `GET /api/models?image=image-text-to-text`) now surfaces omni/multimodal models alongside VLMs.

## Test plan

- [x] `just lint` — clean
- [x] `just test` — 960 passed, 7 skipped
- [x] New API test asserts `any-to-any` models come back when filtering by `image-text-to-text`
- [x] Verified against the running dev server: `curl /api/models?image=image-text-to-text` returned 3 `any-to-any` models alongside 57 `image-text-to-text` (before the fix, only the latter surfaced)

Closes #496