### PR TITLE
fix(lib): hide model rows for deleted profiles

### DIFF
--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -2134,7 +2134,9 @@ async def get_models(
         logger.info("Querying model table...")
 
         # Build query with optional filters
-        query = sa.select(Model)
+        # Hide models whose profile has been deleted from profiles.cfg (#478).
+        active_profiles = [p.name for p in profiles]
+        query = sa.select(Model).where(Model.profile.in_(active_profiles))
         if profile is not None:
             query = query.where(Model.profile == profile)
         if image is not None:

--- a/lib/tests/api/test_models.py
+++ b/lib/tests/api/test_models.py
@@ -43,6 +43,23 @@ class TestFetchModelsAPI:
         for model in result:
             assert model.get("profile") == "test"
 
+    async def test_fetch_models_hides_orphans_from_deleted_profiles(
+        self, client: AsyncTestClient
+    ):
+        """Rows whose profile is not in profiles.cfg must not surface (#478).
+
+        The fixture seeds a model with profile="deleted" (not in the test
+        profiles.cfg). A stale row is a false capability claim — the model
+        can't launch without an active profile — so listings hide it.
+        """
+        orphan_id = "e5f6a7b8-c9d0-1234-ef01-345678901234"
+
+        response = await client.get("/api/models")
+        assert response.status_code == 200
+        result = response.json()
+        assert orphan_id not in {m["id"] for m in result}
+        assert "deleted" not in {m["profile"] for m in result}
+
     async def test_fetch_models_by_image(self, client: AsyncTestClient):
         """Test fetching models by image."""
         response = await client.get("/api/models", params={"image": "text_generation"})
@@ -639,13 +656,20 @@ class TestDeleteModelsAPI:
         assert len(result) == 1
         assert result[0]["status"] == "ok"
 
-        # Verify the other model still exists
-        get_response = await client.get(
-            "/api/models", params={"profile": "specific-profile"}
+        # Verify the other model still exists. Query the session directly
+        # rather than /api/models: the listing filters out rows whose profile
+        # isn't in profiles.cfg (#478), and "specific-profile" isn't.
+        remaining = (
+            (
+                await session.execute(
+                    sa.select(Model).where(Model.profile == "specific-profile")
+                )
+            )
+            .scalars()
+            .all()
         )
-        remaining_models = get_response.json()
-        assert len(remaining_models) == 1
-        assert remaining_models[0]["revision"] == "specific-v2"
+        assert len(remaining) == 1
+        assert remaining[0].revision == "specific-v2"
 
 
 class TestCreateModelAPI:

--- a/lib/tests/api/test_models.py
+++ b/lib/tests/api/test_models.py
@@ -60,6 +60,19 @@ class TestFetchModelsAPI:
         assert orphan_id not in {m["id"] for m in result}
         assert "deleted" not in {m["profile"] for m in result}
 
+    async def test_fetch_models_by_deleted_profile_returns_empty(
+        self, client: AsyncTestClient
+    ):
+        """Explicitly asking for a deleted profile returns [], not the orphans.
+
+        Pins the intended contract: the profile filter can't be used to
+        surface hidden orphan rows, and the response is the same 200 [] a
+        never-existed profile gets (see test_fetch_nonexistent_profile_…).
+        """
+        response = await client.get("/api/models", params={"profile": "deleted"})
+        assert response.status_code == 200
+        assert response.json() == []
+
     async def test_fetch_models_by_image(self, client: AsyncTestClient):
         """Test fetching models by image."""
         response = await client.get("/api/models", params={"image": "text_generation"})

--- a/lib/tests/data_fixtures.py
+++ b/lib/tests/data_fixtures.py
@@ -175,6 +175,16 @@ def models_fixture() -> list[Model | dict[str, Any]]:
             "model_dir": "/home/test/.blackfish/models/models--Qwen/Qwen2.5-Omni-7B",
         },
         {
+            # Orphan: profile "deleted" is not in tests/profiles.cfg, so this
+            # row simulates a model left behind by a deleted profile (#478).
+            "id": "e5f6a7b8-c9d0-1234-ef01-345678901234",
+            "repo": "meta-llama/Llama-3.2-1B",
+            "profile": "deleted",
+            "revision": "1",
+            "image": "text_generation",
+            "model_dir": "/home/test/.blackfish/models/models--meta-llama/Llama-3.2-1B",
+        },
+        {
             "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
             "repo": "openai/whisper-large-v3",
             "profile": "hpc",

--- a/lib/tests/profiles.cfg
+++ b/lib/tests/profiles.cfg
@@ -16,3 +16,15 @@ user = test
 host = localhost
 home_dir = /home/test/.blackfish
 cache_dir = /home/test/.blackfish/cache
+
+[test]
+type = local
+home_dir = /home/test/.blackfish
+cache_dir = /home/test/.blackfish
+
+[test-slurm]
+type = slurm
+user = test
+host = test-server
+home_dir = /home/test/.blackfish
+cache_dir = /home/test/.blackfish/cache


### PR DESCRIPTION
## Summary

- `GET /api/models` (no `refresh`, no `profile` filter) was returning rows for profiles that had been removed from `profiles.cfg` — a false capability claim, since those models can't be launched without an active profile. Now the unfiltered listing scopes to active profile names.
- Refresh path is already safe: it requires `profile` and 404s when the name isn't in `profiles.cfg`.
- No deletion: profile removal is often a rename/reconfigure, so re-adding a profile of the same name restores its models for free. Rows in `jobs`, `service`, and `download_task` are untouched — those are historical records, not capability claims.

## Test plan

- [x] `just lint` — clean
- [x] `just test` — 961 passed (was 960 — new orphan-hiding test)
- [x] Added `test` / `test-slurm` to `tests/profiles.cfg` so existing fixture models don't accidentally count as orphans, and updated `test_delete_models_specific_combination` to verify via `session` since it uses ad-hoc profile names
- [x] Verified against the running dev server: `/api/models` now returns only rows for profiles present in `profiles.cfg`

Closes #478