### PR TITLE
docs(lib): document how to clean up profile resources

### DIFF
--- a/lib/docs/usage/cli.md
+++ b/lib/docs/usage/cli.md
@@ -185,13 +185,47 @@ blackfish profile rm --name <profile> --force
 
 !!! note
 
-    Deleting a profile does not remove its remote resources (e.g., models, images, or job files in `home_dir` or `cache_dir`). These may be shared with other profiles and should be cleaned up manually if no longer needed.
+    Deleting a profile does not remove its remote resources (models, images, or job files in `home_dir` and `cache_dir`). These may be shared with other profiles, so Blackfish leaves the decision — and the `rm` — to you. See [Cleaning up profile resources](#cleaning-up-profile-resources) below.
 
 !!! warning
 
     Force-deleting the default profile leaves Blackfish without an explicitly flagged default. It
     will fall back to a profile named "default" or, failing that, the first profile listed—set a new
     default explicitly to avoid surprises.
+
+#### Cleaning up profile resources
+
+`profile rm` deletes the profile from Blackfish. It does not touch the profile's on-disk resources, because Blackfish can't safely tell whether they're shared with another profile (or with other users, in the case of `cache_dir`). Clean these up by hand once you've confirmed nothing else depends on them.
+
+For a **local profile**, everything lives on your machine:
+
+```shell
+# Job files, logs, and models the profile downloaded to home_dir.
+rm -rf <home_dir>/jobs
+
+# Only remove the model cache if no other profile uses this cache_dir.
+rm -rf <cache_dir>/models
+```
+
+For a **slurm profile**, the same directories live on the cluster:
+
+```shell
+ssh <user>@<host> "rm -rf <home_dir>/jobs"
+
+# Same caveat: check that cache_dir isn't shared before removing models.
+ssh <user>@<host> "rm -rf <cache_dir>/models"
+```
+
+Container images in `cache_dir/images` are almost always shared with other users on HPC systems — leave them alone unless you're certain.
+
+To remove Blackfish itself along with all of its local state (config, database, downloaded models under `~/.blackfish`), uninstall the package and remove the home directory:
+
+```shell
+pip uninstall blackfish-ai   # or `uv tool uninstall blackfish-ai`
+rm -rf ~/.blackfish
+```
+
+Remote resources on any cluster you targeted need to be removed on the cluster itself using the commands above.
 
 ## Services
 

--- a/lib/docs/usage/cli.md
+++ b/lib/docs/usage/cli.md
@@ -195,37 +195,28 @@ blackfish profile rm --name <profile> --force
 
 #### Cleaning up profile resources
 
-`profile rm` deletes the profile from Blackfish. It does not touch the profile's on-disk resources, because Blackfish can't safely tell whether they're shared with another profile (or with other users, in the case of `cache_dir`). Clean these up by hand once you've confirmed nothing else depends on them.
+`profile rm` deletes the profile from Blackfish but does not touch its `home_dir` or `cache_dir`. Both may be shared with other profiles or with other users, so Blackfish leaves the cleanup to you.
 
-For a **local profile**, everything lives on your machine:
-
-```shell
-# Job files, logs, and models the profile downloaded to home_dir.
-rm -rf <home_dir>/jobs
-
-# Only remove the model cache if no other profile uses this cache_dir.
-rm -rf <cache_dir>/models
-```
-
-For a **slurm profile**, the same directories live on the cluster:
+Once you've confirmed nothing else depends on a directory, remove it directly:
 
 ```shell
-ssh <user>@<host> "rm -rf <home_dir>/jobs"
+# Local
+rm -rf <dir>
 
-# Same caveat: check that cache_dir isn't shared before removing models.
-ssh <user>@<host> "rm -rf <cache_dir>/models"
+# Slurm
+ssh <user>@<host> "rm -rf <dir>"
 ```
 
-Container images in `cache_dir/images` are almost always shared with other users on HPC systems — leave them alone unless you're certain.
+`cache_dir` is usually a shared location on HPC systems (e.g., `/shared/.blackfish`) — check with your admin before removing.
 
-To remove Blackfish itself along with all of its local state (config, database, downloaded models under `~/.blackfish`), uninstall the package and remove the home directory:
+To remove Blackfish itself along with all of its local state, uninstall the package and remove `~/.blackfish`:
 
 ```shell
 pip uninstall blackfish-ai   # or `uv tool uninstall blackfish-ai`
 rm -rf ~/.blackfish
 ```
 
-Remote resources on any cluster you targeted need to be removed on the cluster itself using the commands above.
+Remote resources on any cluster you targeted need to be removed on the cluster using the commands above.
 
 ## Services
 


### PR DESCRIPTION
## Summary

Replaces the short \"note\" under \`profile rm\` with a proper subsection that spells out the manual cleanup story we couldn't automate safely (see #250 discussion): local vs. slurm commands, the shared \`cache_dir\` / \`images\` hazards, and the full \"remove Blackfish\" path.

## Test plan

- [x] \`just docs\` builds cleanly
- [x] Rendered locally — new section slots in after the \`--force\` warning under \`### rm - Delete a profile\`

Closes #250