### PR TITLE
fix(web): reset file manager to page 1 on directory or filter change

### DIFF
--- a/web/src/components/FileManagerTable.jsx
+++ b/web/src/components/FileManagerTable.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
     ChevronLeftIcon,
     ChevronRightIcon,
@@ -69,6 +69,11 @@ function FileManagerTable({
     directorySelectionMode = false,
 }) {
     const [currentPage, setCurrentPage] = useState(1);
+
+    // Reset to the first page when the directory or filter changes.
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [path, query]);
 
     const indexOfLastFile = currentPage * filesPerPage;
     const indexOfFirstFile = indexOfLastFile - filesPerPage;

--- a/web/src/components/FileManagerTable.test.jsx
+++ b/web/src/components/FileManagerTable.test.jsx
@@ -1,0 +1,98 @@
+import { render, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { test, expect, vi } from "vitest";
+import FileManagerTable from "@/components/FileManagerTable";
+
+const FILES_PER_PAGE = 10;
+
+function makeFiles(n, dir = "/root") {
+  return Array.from({ length: n }, (_, i) => ({
+    name: `file ${i}`,
+    is_dir: false,
+    path: `${dir}/file_${i}.txt`,
+    size: 64,
+    modified_at: "2025-06-19T14:16:50",
+  }));
+}
+
+function renderTable(props = {}) {
+  return render(
+    <FileManagerTable
+      content={makeFiles(30)}
+      path="/root"
+      root="/root"
+      filesPerPage={FILES_PER_PAGE}
+      query=""
+      setPath={vi.fn()}
+      isLoading={false}
+      error={null}
+      refresh={vi.fn()}
+      status={{ disabled: false }}
+      {...props}
+    />
+  );
+}
+
+test("resets to the first page when the directory changes", async () => {
+  const user = userEvent.setup();
+  const { getByText, queryByText, rerender } = renderTable();
+
+  // 30 files / 10 per page -> 3 pages. Navigate to page 3.
+  await act(async () => {
+    await user.click(getByText("3"));
+  });
+  expect(getByText("file 20")).toBeInTheDocument();
+
+  // Navigating to a new directory with fewer files should reset to page 1
+  // rather than leaving an out-of-range page.
+  await act(async () => {
+    rerender(
+      <FileManagerTable
+        content={makeFiles(5, "/root/sub")}
+        path="/root/sub"
+        root="/root"
+        filesPerPage={FILES_PER_PAGE}
+        query=""
+        setPath={vi.fn()}
+        isLoading={false}
+        error={null}
+        refresh={vi.fn()}
+        status={{ disabled: false }}
+      />
+    );
+  });
+
+  expect(getByText("file 0")).toBeInTheDocument();
+  expect(queryByText("3")).not.toBeInTheDocument();
+});
+
+test("resets to the first page when the filter changes", async () => {
+  const user = userEvent.setup();
+  const { getByText, queryByText, rerender } = renderTable();
+
+  await act(async () => {
+    await user.click(getByText("3"));
+  });
+  expect(getByText("file 20")).toBeInTheDocument();
+
+  await act(async () => {
+    rerender(
+      <FileManagerTable
+        content={makeFiles(30)}
+        path="/root"
+        root="/root"
+        filesPerPage={FILES_PER_PAGE}
+        query="file 1"
+        setPath={vi.fn()}
+        isLoading={false}
+        error={null}
+        refresh={vi.fn()}
+        status={{ disabled: false }}
+      />
+    );
+  });
+
+  // "file 1" matches file 1 and file 10-19 -> 11 results, 2 pages, page 1.
+  expect(getByText("file 1")).toBeInTheDocument();
+  expect(queryByText("3")).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary

- `FileManagerTable` kept a local `currentPage` that was never reset, so navigating to a new directory (or applying a filter) while on page 2+ could leave the table on an out-of-range page showing blank/partial content.
- Adds `useEffect(() => setCurrentPage(1), [path, query])`, matching the fix applied to the audio file browser in #427. Pagination state stays local to `FileManagerTable` rather than being lifted — the component already renders its own pagination row, so there was no layout reason to lift it here.
- Adds `FileManagerTable.test.jsx` (the component previously had no test file) covering both reset paths.

## Test plan

- `cd web && npm test` — 541 passed (56 files), no snapshot churn.
- `cd web && npm run lint` — 0 errors. The single remaining warning is pre-existing in `ImageAttachment.jsx`, untouched by this PR.
- Both new tests were verified to fail against the unpatched component and pass with the fix, so they are genuine regression tests:
  - page 3 → navigate to a directory with fewer files → resets to page 1
  - page 3 → apply a filter → resets to page 1

Closes #429