### PR TITLE
fix(lib): forward upstream status on non-streaming proxy path

### DIFF
--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -1887,6 +1887,16 @@ async def asyncpost(
     client: httpx.AsyncClient, url: str, data: Any, headers: Any
 ) -> Any:
     response = await client.post(url, content=data, headers=headers)
+    if not response.is_success:
+        try:
+            error_body = response.json()
+            error_message = error_body.get("message", "Upstream service error")
+        except Exception:
+            error_message = response.text or "Upstream service error"
+        raise HTTPException(
+            status_code=response.status_code,
+            detail=error_message,
+        )
     return response.json()
 
 

--- a/lib/tests/unit/test_asgi_proxy.py
+++ b/lib/tests/unit/test_asgi_proxy.py
@@ -1,0 +1,58 @@
+"""Unit tests for the non-streaming proxy helper (`asyncpost`).
+
+Regression coverage for #453: a downstream 4xx/5xx must surface as an
+`HTTPException` with the upstream status, not be returned as a successful
+JSON body.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from litestar.exceptions import HTTPException
+
+pytestmark = pytest.mark.anyio
+
+
+def _client(handler):
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+async def test_asyncpost_returns_json_on_success():
+    from blackfish.server.asgi import asyncpost
+
+    def handler(request):
+        return httpx.Response(200, json={"ok": True})
+
+    async with _client(handler) as client:
+        result = await asyncpost(client, "http://svc/x", b"{}", {})
+
+    assert result == {"ok": True}
+
+
+async def test_asyncpost_forwards_upstream_status_and_message():
+    from blackfish.server.asgi import asyncpost
+
+    def handler(request):
+        return httpx.Response(422, json={"message": "bad audio format"})
+
+    async with _client(handler) as client:
+        with pytest.raises(HTTPException) as exc_info:
+            await asyncpost(client, "http://svc/x", b"{}", {})
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "bad audio format"
+
+
+async def test_asyncpost_falls_back_to_text_when_body_is_not_json():
+    from blackfish.server.asgi import asyncpost
+
+    def handler(request):
+        return httpx.Response(500, content=b"upstream crashed")
+
+    async with _client(handler) as client:
+        with pytest.raises(HTTPException) as exc_info:
+            await asyncpost(client, "http://svc/x", b"{}", {})
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "upstream crashed"


### PR DESCRIPTION
## Summary
- The non-streaming branch of `proxy_service` (`asyncpost`) called `response.json()` unconditionally, causing upstream 4xx/5xx errors to be returned to the frontend as successful responses.
- `asyncpost` now checks `response.is_success` and raises `HTTPException` with the upstream status code and message, mirroring the streaming branch.

## Test plan
- [x] `uv run just lint`
- [x] `uv run just test`

Closes #453