### PR TITLE
fix(lib): anchor Slurm grace period to job start, not submission

### DIFF
--- a/lib/src/blackfish/server/job.py
+++ b/lib/src/blackfish/server/job.py
@@ -2,12 +2,46 @@ import os
 import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from enum import StrEnum, auto
 from typing import Optional, Union
 from blackfish.server import remote
 from blackfish.server.logger import logger
 from blackfish.server.config import ContainerProvider
+
+
+def _split_state_start(stdout: bytes) -> tuple[bytes, bytes]:
+    """Split the first line of ``sacct ... -P -o State,Start`` output.
+
+    Returns ``(state_bytes, start_bytes)``. If ``stdout`` is empty (no matching
+    job) both fields are empty. If ``Start`` is missing (older Slurm or unusual
+    output) the start field is empty.
+    """
+    line = stdout.split(b"\n", 1)[0].strip()
+    if line == b"":
+        return b"", b""
+    parts = line.split(b"|", 1)
+    if len(parts) == 1:
+        return parts[0], b""
+    return parts[0], parts[1]
+
+
+def parse_sacct_start(value: str) -> Optional[datetime]:
+    """Parse the ``Start`` field returned by ``sacct``.
+
+    Assumes ``sacct`` was invoked with ``TZ=UTC`` so the timestamp is naive
+    ISO-8601 in UTC. Returns ``None`` for the empty string or ``"Unknown"``
+    (the value Slurm reports for jobs that have not started).
+    """
+    stripped = value.strip()
+    if stripped == "" or stripped.lower() == "unknown":
+        return None
+    try:
+        return datetime.fromisoformat(stripped).replace(tzinfo=timezone.utc)
+    except ValueError:
+        logger.warning(f"Failed to parse sacct Start value: {stripped!r}")
+        return None
 
 
 class JobState(StrEnum):
@@ -108,6 +142,7 @@ class SlurmJob(Job):
     node: Optional[str] = None
     port: Optional[int] = None
     state: Optional[JobState] = None
+    started_at: Optional[datetime] = None
     options: Optional[JobConfig] = None
 
     def is_local(self) -> bool:
@@ -117,6 +152,9 @@ class SlurmJob(Job):
         """Attempt to update the job state from Slurm accounting and return the new
         state (or current state if the update fails).
 
+        Also refreshes ``started_at`` from ``sacct``'s ``Start`` column so callers
+        can measure elapsed time from actual job start rather than submission.
+
         If the job state switches from PENDING or MISSING to RUNNING, also update
         the job node and port.
 
@@ -124,7 +162,11 @@ class SlurmJob(Job):
         """
         if verbose:
             logger.debug(f"Updating job state (job_id={self.job_id}).")
+        # TZ=UTC forces sacct to emit Start in UTC; without it Slurm uses the
+        # cluster-local timezone, which we would have to detect and convert.
         sacct_cmd = [
+            "env",
+            "TZ=UTC",
             "sacct",
             "-n",
             "-P",
@@ -134,7 +176,7 @@ class SlurmJob(Job):
             "-j",
             str(self.job_id),
             "-o",
-            "State",
+            "State,Start",
         ]
         try:
             if self.is_local():
@@ -142,7 +184,9 @@ class SlurmJob(Job):
             else:
                 result = await remote.ssh(f"{self.user}@{self.host}", sacct_cmd)
 
-            new_state = parse_state(result.stdout)
+            state_field, start_field = _split_state_start(result.stdout)
+            new_state = parse_state(state_field)
+            self.started_at = parse_sacct_start(start_field.decode("utf-8"))
             if verbose:
                 logger.debug(
                     f"The current job state is: {format_state(new_state)} (job_id={self.job_id})"

--- a/lib/src/blackfish/server/remote/exec.py
+++ b/lib/src/blackfish/server/remote/exec.py
@@ -101,6 +101,17 @@ class RemoteAuthError(RemoteError):
     """SSH transport failed: authentication was rejected."""
 
 
+# Callers that need Slurm to emit timestamps in UTC prefix their command
+# with this. Errors should surface the underlying program, not "env".
+_ENV_UTC_PREFIX = ["env", "TZ=UTC"]
+
+
+def _strip_env_utc(cmd: list[str]) -> list[str]:
+    if cmd[: len(_ENV_UTC_PREFIX)] == _ENV_UTC_PREFIX:
+        return cmd[len(_ENV_UTC_PREFIX) :]
+    return cmd
+
+
 class RemoteCommandError(RemoteError):
     """The command ran to completion but exited with a non-zero status."""
 
@@ -111,9 +122,10 @@ class RemoteCommandError(RemoteError):
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
+        program = _strip_env_utc(cmd)[0]
         detail = stderr.decode("utf-8", "replace").strip()
         super().__init__(
-            f"Command {cmd[0]!r} exited with status {returncode}"
+            f"Command {program!r} exited with status {returncode}"
             + (f": {detail}" if detail else "")
         )
 

--- a/lib/src/blackfish/server/services/base.py
+++ b/lib/src/blackfish/server/services/base.py
@@ -459,7 +459,7 @@ class Service(UUIDAuditBase):
                             f"Service running for {dt.total_seconds():.0f} seconds"
                             f" (anchor={'job.started_at' if job.started_at else 'created_at'})."
                         )
-                        if dt.seconds > self.grace_period:
+                        if dt.total_seconds() > self.grace_period:
                             logger.debug(
                                 f"Service {self.id} grace period exceeded. Setting"
                                 " status to UNHEALTHY."
@@ -525,8 +525,10 @@ class Service(UUIDAuditBase):
                     if self.created_at is None:
                         raise Exception("Service is missing value `created_at`.")
                     dt = datetime.now(timezone.utc) - self.created_at
-                    logger.debug(f"Service created {dt.seconds} seconds ago.")
-                    if dt.seconds > self.grace_period:
+                    logger.debug(
+                        f"Service created {dt.total_seconds():.0f} seconds ago."
+                    )
+                    if dt.total_seconds() > self.grace_period:
                         logger.debug(
                             f"Service {self.id} grace period exceeded. Setting"
                             "status to UNHEALTHY."

--- a/lib/src/blackfish/server/services/base.py
+++ b/lib/src/blackfish/server/services/base.py
@@ -446,10 +446,19 @@ class Service(UUIDAuditBase):
                         ServiceStatus.PENDING,
                         ServiceStatus.STARTING,
                     ]:
-                        if self.created_at is None:
+                        # Measure grace from the job's actual start time (from
+                        # sacct) so queue time does not count against it. Fall
+                        # back to created_at if sacct did not report Start yet
+                        # (e.g. reported as "Unknown" or a transient parse
+                        # failure); this preserves prior behavior in that case.
+                        anchor = job.started_at or self.created_at
+                        if anchor is None:
                             raise Exception("Service is missing value `created_at`.")
-                        dt = datetime.now(timezone.utc) - self.created_at
-                        logger.debug(f"Service created {dt.seconds} seconds ago.")
+                        dt = datetime.now(timezone.utc) - anchor
+                        logger.debug(
+                            f"Service running for {dt.total_seconds():.0f} seconds"
+                            f" (anchor={'job.started_at' if job.started_at else 'created_at'})."
+                        )
                         if dt.seconds > self.grace_period:
                             logger.debug(
                                 f"Service {self.id} grace period exceeded. Setting"

--- a/lib/tests/unit/test_job.py
+++ b/lib/tests/unit/test_job.py
@@ -1,8 +1,14 @@
+from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
 
-from blackfish.server.job import JobState, SlurmJob
+from blackfish.server.job import (
+    JobState,
+    SlurmJob,
+    _split_state_start,
+    parse_sacct_start,
+)
 from blackfish.server.remote import CompletedProcess, RemoteConnectionError
 
 pytestmark = pytest.mark.anyio
@@ -126,3 +132,69 @@ async def test_cancel_warning(mock_ssh, mock_warning):
     job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
     await job.cancel()
     mock_warning.assert_called()
+
+
+def test_split_state_start_empty():
+    assert _split_state_start(b"") == (b"", b"")
+
+
+def test_split_state_start_state_only():
+    # Older Slurm or a State-only query
+    assert _split_state_start(b"RUNNING\n") == (b"RUNNING", b"")
+
+
+def test_split_state_start_with_start():
+    assert _split_state_start(b"RUNNING|2026-08-25T14:49:36\n") == (
+        b"RUNNING",
+        b"2026-08-25T14:49:36",
+    )
+
+
+def test_split_state_start_first_line_only():
+    # sacct can return multiple lines (e.g. steps); we only look at the first.
+    assert _split_state_start(b"RUNNING|2026-08-25T14:49:36\nCOMPLETED|...\n") == (
+        b"RUNNING",
+        b"2026-08-25T14:49:36",
+    )
+
+
+def test_parse_sacct_start_valid():
+    assert parse_sacct_start("2026-08-25T14:49:36") == datetime(
+        2026, 8, 25, 14, 49, 36, tzinfo=timezone.utc
+    )
+
+
+def test_parse_sacct_start_unknown():
+    assert parse_sacct_start("Unknown") is None
+    assert parse_sacct_start("unknown") is None
+    assert parse_sacct_start("") is None
+
+
+def test_parse_sacct_start_malformed():
+    assert parse_sacct_start("not-a-date") is None
+
+
+@mock.patch.object(SlurmJob, "fetch_port")
+@mock.patch.object(SlurmJob, "fetch_node")
+@mock.patch("blackfish.server.remote.ssh")
+async def test_update_sets_started_at(mock_ssh, mock_fetch_node, mock_fetch_port):
+    mock_ssh.return_value = _completed(b"RUNNING|2026-08-25T14:49:36\n")
+    job = SlurmJob(
+        job_id=1, user="test", host="test", state=JobState.PENDING, data_dir="test"
+    )
+    await job.update()
+    assert job.state == JobState.RUNNING
+    assert job.started_at == datetime(2026, 8, 25, 14, 49, 36, tzinfo=timezone.utc)
+
+
+@mock.patch.object(SlurmJob, "fetch_port")
+@mock.patch.object(SlurmJob, "fetch_node")
+@mock.patch("blackfish.server.remote.ssh")
+async def test_update_unknown_start_leaves_started_at_none(
+    mock_ssh, mock_fetch_node, mock_fetch_port
+):
+    mock_ssh.return_value = _completed(b"PENDING|Unknown\n")
+    job = SlurmJob(job_id=1, user="test", host="test", data_dir="test")
+    await job.update()
+    assert job.state == JobState.PENDING
+    assert job.started_at is None

--- a/lib/tests/unit/test_remote.py
+++ b/lib/tests/unit/test_remote.py
@@ -82,6 +82,14 @@ async def test_run_nonzero_raises_command_error() -> None:
     assert exc_info.value.cmd == ["false"]
 
 
+async def test_command_error_reports_program_after_env_prefix() -> None:
+    """`env KEY=VAL prog ...` failures should surface `prog`, not `env`."""
+    with pytest.raises(RemoteCommandError) as exc_info:
+        await remote.run(["env", "TZ=UTC", "false"])
+    assert "'false'" in str(exc_info.value)
+    assert "'env'" not in str(exc_info.value)
+
+
 async def test_run_timeout() -> None:
     with pytest.raises(RemoteTimeout):
         await remote.run(["sleep", "5"], timeout=0.2)

--- a/lib/tests/unit/test_services.py
+++ b/lib/tests/unit/test_services.py
@@ -296,3 +296,83 @@ class TestServiceImagePinning:
         self._render(service)
 
         assert service.image_ref == "vllm/vllm-openai:v9.9.9"
+
+
+class TestGracePeriodAnchor:
+    """Regression tests for the grace-period clock (#472).
+
+    A STARTING service whose ping fails but whose Slurm job is RUNNING should
+    stay STARTING while `now - job.started_at <= grace_period` and flip to
+    UNHEALTHY once it exceeds it. The grace window is measured from the job's
+    actual start (`sacct` Start), not from service submission — so a long
+    queue does not consume startup budget.
+    """
+
+    def _service(self, *, started_at, grace_period=180, created_at=None):
+        from datetime import datetime, timedelta, timezone
+        from uuid import UUID
+
+        from blackfish.server.job import JobScheduler, JobState, SlurmJob
+        from blackfish.server.services.base import ServiceStatus
+        from blackfish.server.services.text_generation import TextGeneration
+
+        # created_at is deliberately far in the past to prove the anchor is
+        # started_at (a queue-time fallback to created_at would trip grace).
+        created_at = created_at or datetime.now(timezone.utc) - timedelta(hours=6)
+        service = TextGeneration(
+            id=UUID("2a7a8e62-40cc-4240-a825-463e5b11a81f"),
+            name="test-service",
+            model="meta-llama/Llama-3.1-8B-Instruct",
+            profile="default",
+            host="localhost",
+            user="alice",
+            home_dir="/home/alice/.blackfish",
+            cache_dir="/scratch/cache",
+            scheduler=JobScheduler.Slurm,
+            grace_period=grace_period,
+            job_id="1",
+            port=8080,
+            status=ServiceStatus.STARTING,
+        )
+        service.created_at = created_at
+        job = SlurmJob(
+            job_id=1,
+            user="alice",
+            host="localhost",
+            data_dir="/tmp",
+            state=JobState.RUNNING,
+            started_at=started_at,
+        )
+        return service, job
+
+    async def _refresh_with(self, service, job):
+        with (
+            patch.object(service, "get_job", return_value=job),
+            patch.object(service, "ping", return_value=None),
+            patch.object(service, "open_tunnel", return_value=None),
+        ):
+            return await service.refresh(session=MagicMock(), http_client=MagicMock())
+
+    async def test_starting_stays_starting_when_under_grace(self):
+        from datetime import datetime, timedelta, timezone
+
+        from blackfish.server.services.base import ServiceStatus
+
+        service, job = self._service(
+            started_at=datetime.now(timezone.utc) - timedelta(seconds=30),
+            grace_period=180,
+        )
+        status = await self._refresh_with(service, job)
+        assert status == ServiceStatus.STARTING
+
+    async def test_starting_flips_to_unhealthy_when_over_grace(self):
+        from datetime import datetime, timedelta, timezone
+
+        from blackfish.server.services.base import ServiceStatus
+
+        service, job = self._service(
+            started_at=datetime.now(timezone.utc) - timedelta(seconds=300),
+            grace_period=180,
+        )
+        status = await self._refresh_with(service, job)
+        assert status == ServiceStatus.UNHEALTHY


### PR DESCRIPTION
## Summary
- `Service.refresh` measured the Slurm grace period from `self.created_at` (service submission), so queue time counted against startup. A busy cluster could mark a service `UNHEALTHY` before the container had begun loading.
- `SlurmJob.update` now requests `-o State,Start` (prefixed with `TZ=UTC`) and stores the parsed timestamp on `SlurmJob.started_at`. `Service.refresh` measures the grace period from `job.started_at` when available, falling back to `created_at` on `Unknown`/parse failure. The `PENDING` branch already skipped the grace period, so the change is confined to the `RUNNING`/no-ping path.
- Local (Docker/Apptainer) path unchanged; there is no queue locally and the bug is far less acute. `docker inspect .State.StartedAt` is a natural follow-up.

## Test plan
- [x] `uv run just lint`
- [x] `uv run just test` (971 pass, 7 skipped — +9 new)
- [x] Verify on a real cluster: submit a large model on a queue, confirm status stays `PENDING`/`STARTING` for the full model-load window rather than flipping to `UNHEALTHY` after queue+grace.

## Follow-ups
- Docker path: use `docker inspect --format '{{.State.StartedAt}}'` to populate `LocalJob.started_at` (analogous but separate mechanism).
- Depends on / pairs well with #471 (grace-period default 180s → 600s) and #473 (`dt.seconds` → `dt.total_seconds()`).

Closes #472