### PR TITLE
feat(lib): unify grace_period default at 600s across entry points

### DIFF
--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -397,7 +397,7 @@ def start(reload: bool | None) -> None:  # pragma: no cover
     "--grace-period",
     "-g",
     type=int,
-    default=180,
+    default=config.GRACE_PERIOD,
     help="Time (s) to wait before setting service health to 'unhealthy'.",
 )
 @click.option(

--- a/lib/src/blackfish/cli/classes.py
+++ b/lib/src/blackfish/cli/classes.py
@@ -1,11 +1,13 @@
 from dataclasses import dataclass
 from typing import Optional
 
+from blackfish.server.config import config
+
 
 @dataclass
 class ServiceOptions:
     mount: Optional[str] = None
-    grace_period: int = 180
+    grace_period: int = config.GRACE_PERIOD
     # A pinned container image as "repo:tag". None means "use the configured
     # default", which the server records on the service once it launches.
     image_ref: Optional[str] = None

--- a/lib/src/blackfish/client.py
+++ b/lib/src/blackfish/client.py
@@ -28,7 +28,7 @@ from litestar.datastructures import State
 from yaspin import yaspin
 from log_symbols.symbols import LogSymbols
 
-from blackfish.server.config import BlackfishConfig
+from blackfish.server.config import BlackfishConfig, config
 from blackfish.server.http_client import create_http_client
 from blackfish.server.models.profile import (
     deserialize_profile,
@@ -285,7 +285,7 @@ class Blackfish:
         container_config: Optional[dict[str, Any]] = None,
         job_config: Optional[dict[str, Any]] = None,
         mount: Optional[str] = None,
-        grace_period: int = 180,
+        grace_period: int = config.GRACE_PERIOD,
         image_ref: Optional[str] = None,
         auto_cleanup: bool = True,
         **kwargs: dict[str, Any],  # BlackfishConfig
@@ -474,7 +474,7 @@ class Blackfish:
         container_config: Optional[dict[str, Any]] = None,
         job_config: Optional[dict[str, Any]] = None,
         mount: Optional[str] = None,
-        grace_period: int = 180,
+        grace_period: int = config.GRACE_PERIOD,
         image_ref: Optional[str] = None,
         auto_cleanup: bool = True,
         **kwargs: dict[str, Any],  # BlackfishConfig

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -1109,7 +1109,7 @@ class ServiceRequest(BaseModel):
     container_config: ContainerConfig
     job_config: JobConfig
     mount: Optional[str] = None
-    grace_period: int = 180  # seconds
+    grace_period: int = blackfish_config.GRACE_PERIOD
 
 
 @dataclass

--- a/lib/src/blackfish/server/config.py
+++ b/lib/src/blackfish/server/config.py
@@ -16,6 +16,7 @@ DEFAULT_STATIC_DIR = Path(__file__).parent.parent
 DEFAULT_HOME_DIR = os.path.expanduser("~/.blackfish")
 DEFAULT_DEBUG = True
 DEFAULT_MAX_FILE_SIZE = 50 * 1024 * 1024  # 50MB
+DEFAULT_GRACE_PERIOD = 600  # seconds
 
 
 class ContainerProvider(StrEnum):
@@ -60,6 +61,7 @@ class BlackfishConfig:
         auth_token: Optional[str] = None,
         container_provider: Optional[ContainerProvider] = None,
         max_file_size: int = DEFAULT_MAX_FILE_SIZE,
+        grace_period: int = DEFAULT_GRACE_PERIOD,
     ) -> None:
         self.BASE_PATH = os.getenv("BLACKFISH_BASE_PATH", base_path)
         self.HOST = os.getenv("BLACKFISH_HOST", host)
@@ -85,6 +87,7 @@ class BlackfishConfig:
         else:
             self.CONTAINER_PROVIDER = container_provider
         self.MAX_FILE_SIZE = int(os.getenv("BLACKFISH_MAX_FILE_SIZE", max_file_size))
+        self.GRACE_PERIOD = int(os.getenv("BLACKFISH_GRACE_PERIOD", grace_period))
         self.IMAGES: dict[str, ImageSpec] = {}
         for service, default in DEFAULT_IMAGES.items():
             override = os.getenv(f"BLACKFISH_{service.upper()}_IMAGE")


### PR DESCRIPTION
## Summary
- The Python API, CLI, and REST defaults were 180s while the web UI already sent 600s. Three minutes is too tight for the large models this platform serves; cold-cache GPFS reads for a 72B FP16 model comfortably exceed it.
- Add `GRACE_PERIOD` (default 600s, overridable via `BLACKFISH_GRACE_PERIOD`) to `BlackfishConfig` next to `MAX_FILE_SIZE` and friends.
- Reference `config.GRACE_PERIOD` at every entry point: `client.create`, `client.run`, `BatchJobRequest`, the `--grace-period` CLI option, and `ServiceOptions`. Web UI already agrees.

## Test plan
- [x] `uv run just lint`
- [x] `uv run just test` (964 pass, 7 skipped — no test churn expected; call sites with explicit `grace_period=180` in tests intentionally exercise specific behaviors and remain unchanged)
- [x] Verify `BLACKFISH_GRACE_PERIOD=<n>` env override propagates to a newly launched service.

## Notes
- Paired with #472 (fixed the clock the grace period is measured against) which merged as #503. With both landed, a large model on a cold cache should surface a truthful STARTING window rather than a spurious UNHEALTHY.

Closes #471