### PR TITLE
chore(lib): bump tigerflow-ml to 0.2.0

### DIFF
--- a/lib/src/blackfish/server/image_probe.py
+++ b/lib/src/blackfish/server/image_probe.py
@@ -6,9 +6,8 @@ service, so it cannot answer "which versions could this profile run?" — that i
 what this module is for.
 
 The repo always comes from configuration and only the tag from the filename:
-``ImageSpec.sif`` drops the registry prefix
-(``ghcr.io/princeton-ddss/tigerflow-ml:0.1.1`` -> ``tigerflow-ml_0.1.1.sif``),
-so a filename alone cannot identify a repo.
+``ImageSpec.sif`` drops the registry prefix (``<host>/<org>/<name>:<tag>`` ->
+``<name>_<tag>.sif``), so a filename alone cannot identify a repo.
 """
 
 from __future__ import annotations

--- a/lib/src/blackfish/server/images.py
+++ b/lib/src/blackfish/server/images.py
@@ -66,10 +66,10 @@ DEFAULT_IMAGES: dict[str, ImageSpec] = {
         repo="ghcr.io/princeton-ddss/speech-recognition-inference",
         tag="0.1.2",
     ),
-    # Note: the GHCR image tag is "0.1.1" (no leading "v"), unlike the
-    # "v0.1.1" GitHub release tag.
+    # Note: the GHCR image tag is "0.2.0" (no leading "v"), unlike the
+    # "v0.2.0" GitHub release tag.
     "tigerflow_ml": ImageSpec(
         repo="ghcr.io/princeton-ddss/tigerflow-ml",
-        tag="0.1.1",
+        tag="0.2.0",
     ),
 }

--- a/lib/src/blackfish/server/jobs/tasks.py
+++ b/lib/src/blackfish/server/jobs/tasks.py
@@ -16,10 +16,10 @@ from typing import Any
 # allocation until the input directory is fully processed.
 SUPPORTED_TASKS: dict[str, str] = {
     "detect": "tigerflow_ml.image.detect.local",
-    "ocr": "tigerflow_ml.text.ocr.local",
+    "ocr": "tigerflow_ml.image.ocr.local",
     "transcribe": "tigerflow_ml.audio.transcribe.local",
     "translate": "tigerflow_ml.text.translate.local",
-    "chat": "tigerflow_ml.text.chat.local",
+    "chat": "tigerflow_ml.multimodal.chat.local",
 }
 
 # Default input file extensions for each task

--- a/lib/tests/unit/test_images.py
+++ b/lib/tests/unit/test_images.py
@@ -41,12 +41,14 @@ def test_image_spec_parse_rejects_malformed(bad):
 
 
 def test_default_tigerflow_ml_image():
-    """The tigerflow-ml batch-job image is pinned in DEFAULT_IMAGES."""
+    """The tigerflow-ml batch-job image is pinned in DEFAULT_IMAGES.
+
+    Guards against accidental removal of the pin. The concrete tag value is
+    intentionally not asserted; version-bump PRs should only touch images.py.
+    """
     spec = DEFAULT_IMAGES["tigerflow_ml"]
     assert spec.repo == "ghcr.io/princeton-ddss/tigerflow-ml"
-    assert spec.tag == "0.1.1"
-    assert spec.sif == "tigerflow-ml_0.1.1.sif"
-    assert spec.docker_ref == "ghcr.io/princeton-ddss/tigerflow-ml:0.1.1"
+    assert spec.tag  # a tag is set
 
 
 def test_default_images_covers_all_concrete_services():

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -831,7 +831,10 @@ class TestCreateTigerflowClient:
         assert client.image is DEFAULT_IMAGES["tigerflow_ml"]
         assert client.provider is ContainerProvider.Apptainer
         assert client.cache_dir == "/scratch/.blackfish"
-        assert client.sif_path == "/scratch/.blackfish/images/tigerflow-ml_0.1.1.sif"
+        assert (
+            client.sif_path
+            == f"/scratch/.blackfish/images/{DEFAULT_IMAGES['tigerflow_ml'].sif}"
+        )
 
     @patch("blackfish.server.jobs.base.deserialize_profile")
     def test_slurm_job_uses_apptainer_even_when_host_detects_docker(
@@ -1055,9 +1058,9 @@ class TestTasks:
         assert job._job_config().gres == DEFAULT_JOB_RESOURCES["gres"]
 
     def test_chat_task_is_supported(self) -> None:
-        """The chat task maps to the tigerflow-ml text.chat.local module."""
+        """The chat task maps to the tigerflow-ml multimodal.chat.local module."""
         assert is_supported_task("chat") is True
-        assert get_task_library("chat") == "tigerflow_ml.text.chat.local"
+        assert get_task_library("chat") == "tigerflow_ml.multimodal.chat.local"
 
     def test_chat_default_input_ext_is_text(self) -> None:
         """Chat defaults to text input (preliminary support is text-only)."""
@@ -1085,7 +1088,7 @@ class TestTasks:
         task = config["tasks"][0]
         assert task["name"] == "chat"
         assert task["kind"] == "local"
-        assert task["module"] == "tigerflow_ml.text.chat.local"
+        assert task["module"] == "tigerflow_ml.multimodal.chat.local"
         assert task["input_ext"] == ".txt"
         assert task["params"]["prompt"] == "Summarize: {text}"
 


### PR DESCRIPTION
## Summary
- Bump the pinned tigerflow-ml image from 0.1.1 to 0.2.0.
- Update `SUPPORTED_TASKS` for the module reorganization in 0.2.0 (ocr: text -> image, chat: text -> multimodal). Entry-point names are unchanged; other tasks (detect/transcribe/translate) did not move.
- Small drift cleanup so future bumps don't touch tests and comments: the doc example in image_probe.py no longer names a specific version, `test_default_tigerflow_ml_image` asserts the pin exists rather than re-checking its value, and the SIF-path test derives its expected filename from `DEFAULT_IMAGES`.

## Test plan
- [x] `uv run just lint`
- [x] `uv run just test` (967 pass, 7 skipped)
- [x] Verify on Della: run a `chat` and an `ocr` batch job with the new image and confirm the pipeline resolves the moved modules.

## Notes
- The new `embed` task (also 0.2.0) is not registered here — that is the Blackfish-side blocker for #463 and belongs in that issue.
- Part of the container-version bumps tracked by #451. SRI (0.1.2 -> 0.2.1, template changes required) and vLLM will follow in separate PRs.

Refs #451