### PR TITLE
feat: add support for the embedding batch task

### DIFF
--- a/lib/docs/usage/cli.md
+++ b/lib/docs/usage/cli.md
@@ -458,6 +458,7 @@ Services are great for interactive work, but sometimes you need to run an ML tas
 | [`translate`](https://princeton-ddss.github.io/tigerflow-ml/next/tasks/translate)   | Translate text between languages          | `.txt`                 | `.txt`                  |
 | [`detect`](https://princeton-ddss.github.io/tigerflow-ml/next/tasks/detect)         | Zero-shot object detection on images      | `.png`, `.jpg`, etc.   | `.json`                 |
 | [`ocr`](https://princeton-ddss.github.io/tigerflow-ml/next/tasks/ocr)               | Extract text from images or scanned pages | `.png`, `.jpg`, etc.   | `.txt`, `.md`, `.json`  |
+| [`embed`](https://princeton-ddss.github.io/tigerflow-ml/next/tasks/embed)           | Generate vector embeddings for files      | `.txt`, `.md`, `.png`, `.pdf`, etc. | `.npy`     |
 
 ### `run` - Start a batch job
 

--- a/lib/docs/usage/cli.md
+++ b/lib/docs/usage/cli.md
@@ -458,6 +458,7 @@ Services are great for interactive work, but sometimes you need to run an ML tas
 | [`translate`](https://princeton-ddss.github.io/tigerflow-ml/next/tasks/translate)   | Translate text between languages          | `.txt`                 | `.txt`                  |
 | [`detect`](https://princeton-ddss.github.io/tigerflow-ml/next/tasks/detect)         | Zero-shot object detection on images      | `.png`, `.jpg`, etc.   | `.json`                 |
 | [`ocr`](https://princeton-ddss.github.io/tigerflow-ml/next/tasks/ocr)               | Extract text from images or scanned pages | `.png`, `.jpg`, etc.   | `.txt`, `.md`, `.json`  |
+| [`chat`](https://princeton-ddss.github.io/tigerflow-ml/next/tasks/chat)             | Prompt a chat model with text, images, audio, or video | `.txt`, `.png`, `.jpg`, `.wav`, `.mp4`, etc. | `.txt`, `.json` |
 | [`embed`](https://princeton-ddss.github.io/tigerflow-ml/next/tasks/embed)           | Generate vector embeddings for files      | `.txt`, `.md`, `.png`, `.pdf`, etc. | `.npy`     |
 
 ### `run` - Start a batch job

--- a/lib/docs/usage/ui.md
+++ b/lib/docs/usage/ui.md
@@ -18,6 +18,7 @@ Blackfish ships with a browser-based UI served alongside the API at `http://loca
     - **Translation** — translate text files between languages.
     - **Object Detection** — zero-shot object detection on images.
     - **OCR** — extract text from images or scanned pages.
+    - **Embedding** — generate vector embeddings for text, image, or PDF files.
 - **Settings** — profile management, theme preference, and Hugging
   Face token management.
 
@@ -73,7 +74,7 @@ when a Slurm profile is selected.
 
 - From the **Jobs** page, click **New Job** — this is a dropdown menu.
 - Pick the task you want to run: **Transcription**, **Translation**,
-  **Object Detection**, or **OCR**.
+  **Object Detection**, **OCR**, or **Embedding**.
 - The New Job modal opens as a stepper:
     1. **Model** — pick a model and revision.
     2. **Task parameters** — fields vary by task:
@@ -81,6 +82,8 @@ when a Slurm profile is selected.
         - *Translation*: source language, target language.
         - *Object Detection*: labels, threshold, batch size, sample FPS.
         - *OCR*: output format.
+        - *Embedding*: encode mode, normalize, truncate dimension,
+          batch size (multi-page PDF inputs only), encode options.
     3. **Data** — use the directory browser to select an input directory
        on the cluster and an output directory to write results to. Set
        the input file extension to filter inputs.
@@ -95,7 +98,9 @@ when a Slurm profile is selected.
 - Click a job row to view file-level details. Each row shows the
   input and output file names, start time, elapsed time, and status (success
   or failure). Click a file row to open a side panel with a preview of
-  the output and additional details.
+  the output and additional details. Binary outputs have no preview —
+  embedding results (`.npy`) show "Preview not available" and can be
+  downloaded instead.
 
 ### Manage models
 

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -577,6 +577,14 @@ COMPATIBLE_PIPELINES: dict[str, list[str]] = {
         "object-detection",
         "zero-shot-object-detection",
     ],
+    # Not a Hugging Face pipeline tag: "embedding" is our own label for the two
+    # tags sentence-transformers models actually carry. The embed *task* is
+    # named "embed" (tigerflow-ml's identifier); this is the service name the
+    # launcher filters models by.
+    "embedding": [
+        "sentence-similarity",
+        "feature-extraction",
+    ],
 }
 
 

--- a/lib/src/blackfish/server/jobs/tasks.py
+++ b/lib/src/blackfish/server/jobs/tasks.py
@@ -20,6 +20,7 @@ SUPPORTED_TASKS: dict[str, str] = {
     "transcribe": "tigerflow_ml.audio.transcribe.local",
     "translate": "tigerflow_ml.text.translate.local",
     "chat": "tigerflow_ml.multimodal.chat.local",
+    "embed": "tigerflow_ml.multimodal.embed.local",
 }
 
 # Default input file extensions for each task
@@ -29,6 +30,7 @@ DEFAULT_INPUT_EXT: dict[str, str] = {
     "transcribe": ".wav",
     "translate": ".txt",
     "chat": ".txt",
+    "embed": ".txt",
 }
 
 # Default output file extensions for each task
@@ -37,6 +39,10 @@ DEFAULT_OUTPUT_EXT: dict[str, str] = {
     "detect": ".json",  # Object detection always outputs JSON
     "translate": ".txt",  # Translation outputs text files
     "chat": ".txt",  # Chat writes the model response as text
+    # Embed saves a NumPy array. This is not merely a default: the task rejects
+    # any other suffix outright, so leaving it unset would make tigerflow write
+    # ".out" and fail every file.
+    "embed": ".npy",
 }
 
 

--- a/lib/tests/contract/test_tigerflow.py
+++ b/lib/tests/contract/test_tigerflow.py
@@ -31,6 +31,8 @@ EXPECTED_TASKS = [
     "ocr",
     "transcribe",
     "translate",
+    "chat",
+    "embed",
 ]
 
 

--- a/lib/tests/unit/test_jobs.py
+++ b/lib/tests/unit/test_jobs.py
@@ -1106,6 +1106,40 @@ class TestTasks:
         rendered = job._pipeline_yaml()
         assert "output_ext: .txt" in rendered
 
+    def test_build_pipeline_config_builds_embed_task(self) -> None:
+        """build_pipeline_config emits a local embed task with its params."""
+        config = build_pipeline_config(
+            task="embed",
+            input_ext=".txt",
+            params={
+                "model": "sentence-transformers/all-MiniLM-L6-v2",
+                "normalize": True,
+            },
+            output_ext=".npy",
+        )
+
+        task = config["tasks"][0]
+        assert task["name"] == "embed"
+        assert task["kind"] == "local"
+        assert task["module"] == "tigerflow_ml.multimodal.embed.local"
+        assert task["input_ext"] == ".txt"
+        assert task["output_ext"] == ".npy"
+        assert task["params"]["normalize"] is True
+
+    def test_embed_pipeline_yaml_sets_npy_output_ext(self) -> None:
+        """An embed job with no explicit output_ext falls back to .npy in the
+        pipeline. The embed task raises on any other suffix, so without this the
+        job would fail on every input file.
+        """
+        job = create_test_batch_job(
+            task="embed",
+            input_ext=".txt",
+            output_ext=None,
+            params={"normalize": True},
+        )
+        rendered = job._pipeline_yaml()
+        assert "output_ext: .npy" in rendered
+
 
 class TestBatchJobImagePinning:
     """Tests for the persisted container image (``image_ref``).

--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -484,6 +484,79 @@ export const TASKS = [
       },
     ],
   },
+  {
+    id: "embed",
+    name: "Embedding",
+    description: "Generate vector embeddings for files",
+    // Not an HF pipeline tag: a COMPATIBLE_PIPELINES key that expands to the
+    // sentence-similarity/feature-extraction tags these models carry.
+    service: "embedding",
+    defaultInputExt: ".txt",
+    defaultPrompt: null, // Embedding models don't take a prompt
+    inputExtOptions: [
+      { value: ".txt", label: "Plain text (.txt)" },
+      { value: ".md", label: "Markdown (.md)" },
+      { value: ".log", label: "Log (.log)" },
+      { value: ".png", label: "PNG (.png)" },
+      { value: ".jpg", label: "JPEG (.jpg)" },
+      { value: ".jpeg", label: "JPEG (.jpeg)" },
+      { value: ".tiff", label: "TIFF (.tiff)" },
+      { value: ".pdf", label: "PDF (.pdf)" },
+    ],
+    // No output_format param: the task saves a NumPy array and rejects any
+    // other suffix, so the extension comes from the backend's .npy default.
+    params: [
+      {
+        name: "encode_mode",
+        type: "select",
+        required: false,
+        label: "Encode Mode",
+        help: "Asymmetric models embed documents and queries differently. Use Default unless the model documents otherwise.",
+        default: "encode",
+        options: [
+          { value: "encode", label: "Default (encode)" },
+          { value: "document", label: "Document (encode_document)" },
+          { value: "query", label: "Query (encode_query)" },
+        ],
+      },
+      {
+        name: "normalize",
+        type: "checkbox",
+        valueType: "boolean",
+        required: false,
+        label: "Normalize vectors",
+        help: "Scale each embedding to unit length, so dot product equals cosine similarity.",
+        default: false,
+      },
+      {
+        name: "truncate_dim",
+        type: "text",
+        valueType: "number",
+        required: false,
+        label: "Truncate Dimension",
+        help: "Shorten embeddings to this many dimensions (Matryoshka models). Default: full size",
+        placeholder: "768",
+      },
+      {
+        name: "batch_size",
+        type: "text",
+        valueType: "number",
+        multiPageOnly: true,
+        required: false,
+        label: "Batch Size",
+        help: "Pages encoded per batch. Applies only to multi-page PDFs. Default: 32",
+        placeholder: "32",
+      },
+      {
+        name: "encode_kwargs",
+        type: "textarea",
+        required: false,
+        label: "Encode Options",
+        help: "Additional encode() kwargs as JSON, e.g. {\"prompt\": \"query: \"}.",
+        placeholder: "{}",
+      },
+    ],
+  },
 ];
 
 // Map output_format values to file extensions
@@ -506,10 +579,17 @@ const VIDEO_INPUT_EXTS = new Set([
   ".wmv",
 ]);
 
+// Input extensions that can hold multiple pages. Params flagged `multiPageOnly`
+// only apply to these — e.g. embed's batch_size, which the task reads only on
+// its multi-page branch. A single image always counts as one page (tigerflow's
+// count_images returns 1 for anything but a PDF), so batching never applies.
+const MULTI_PAGE_INPUT_EXTS = new Set([".pdf"]);
+
 // Whether a param applies given the current form state. Hides params the task
 // would ignore: `showWhen.modelType` params for a mismatched model (e.g.
 // detect's labels, zero-shot only), `videoOnly` params for image inputs (e.g.
-// detect's batch_size), and params gated on another param's value via
+// detect's batch_size), `multiPageOnly` params for single-page inputs (e.g.
+// embed's batch_size), and params gated on another param's value via
 // `showWhenParam` (e.g. transcribe's batch_size only applies when windowing is
 // "batched"). All three call sites (render, validation, submit) go through this
 // one predicate so a hidden param's stale value is never sent.
@@ -527,6 +607,9 @@ export function isParamVisible(param, { inputExt, taskParams, modelType } = {}) 
     return false;
   }
   if (param.videoOnly && !VIDEO_INPUT_EXTS.has(inputExt)) {
+    return false;
+  }
+  if (param.multiPageOnly && !MULTI_PAGE_INPUT_EXTS.has(inputExt)) {
     return false;
   }
   if (param.showWhenParam) {
@@ -585,6 +668,22 @@ export function applyTranslateSourceLang(params) {
     params.auto_lang_detect = true;
   } else if (params.source_lang) {
     params.auto_lang_detect = false;
+  }
+  return params;
+}
+
+// Embed exposes one "Encode Mode" dropdown, but the image has two mutually
+// exclusive booleans: use_encode_document and use_encode_query. The task raises
+// if both are true, so a single select makes that state unrepresentable rather
+// than a runtime failure. Only the selected mode's flag is sent; the default
+// ("encode") sends neither. Mutates the params object in place.
+export function applyEmbedEncodeMode(params) {
+  const mode = params.encode_mode;
+  delete params.encode_mode;
+  if (mode === "document") {
+    params.use_encode_document = true;
+  } else if (mode === "query") {
+    params.use_encode_query = true;
   }
   return params;
 }
@@ -1092,6 +1191,12 @@ function NewJobModal({ open, setOpen, profile, task, onJobCreated }) {
       // separate params (see applyTranslateSourceLang).
       if (task.id === "translate") {
         applyTranslateSourceLang(pipelineParams);
+      }
+
+      // The embed "Encode Mode" dropdown drives the image's two mutually
+      // exclusive booleans (see applyEmbedEncodeMode).
+      if (task.id === "embed") {
+        applyEmbedEncodeMode(pipelineParams);
       }
 
       // Default job name: a compact, Slurm-friendly token like

--- a/web/src/routes/jobs/components/NewJobModal.test.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.test.jsx
@@ -6,6 +6,7 @@ import {
   getDefaultTaskParams,
   isParamVisible,
   applyTranslateSourceLang,
+  applyEmbedEncodeMode,
   buildJobResources,
   isNoContainerStaged,
 } from "./NewJobModal";
@@ -13,6 +14,7 @@ import {
 const detect = TASKS.find((t) => t.id === "detect");
 const translate = TASKS.find((t) => t.id === "translate");
 const transcribe = TASKS.find((t) => t.id === "transcribe");
+const embed = TASKS.find((t) => t.id === "embed");
 
 describe("coerceParamValue", () => {
   test("coerces number-typed params to real numbers", () => {
@@ -123,6 +125,105 @@ describe("TASKS param definitions", () => {
     expect(chat.params.map((p) => p.name)).not.toContain("max_image_pixels");
     // The prompt help explains the {text} placeholder.
     expect(chat.promptHelp).toMatch(/\{text\}/);
+  });
+
+  test("embed is registered, prompt-free, and accepts text and image inputs", () => {
+    expect(embed).toBeDefined();
+    // Embedding models take no prompt, so the modal must not render the field.
+    expect(embed.defaultPrompt).toBeNull();
+    expect(embed.promptRequired).toBeFalsy();
+    const exts = embed.inputExtOptions.map((o) => o.value);
+    expect(exts).toContain(".txt");
+    expect(exts).toContain(".png");
+    expect(exts).toContain(".pdf");
+    // Numeric params coerce to real numbers at submit.
+    for (const name of ["truncate_dim", "batch_size"]) {
+      expect(embed.params.find((p) => p.name === name).valueType).toBe("number");
+    }
+    // normalize is a real boolean, not a string.
+    const normalize = embed.params.find((p) => p.name === "normalize");
+    expect(normalize.type).toBe("checkbox");
+    expect(normalize.valueType).toBe("boolean");
+  });
+
+  test("embed has no output_format param — output is always .npy", () => {
+    // The task rejects any suffix but .npy, so the extension comes from the
+    // backend default. A UI output_format would submit a competing output_ext.
+    expect(embed.params.map((p) => p.name)).not.toContain("output_format");
+  });
+
+  test("embed exposes encode mode as one select, not two booleans", () => {
+    // use_encode_document and use_encode_query are mutually exclusive and the
+    // task raises when both are true; a single select makes that unreachable.
+    const names = embed.params.map((p) => p.name);
+    expect(names).not.toContain("use_encode_document");
+    expect(names).not.toContain("use_encode_query");
+    const mode = embed.params.find((p) => p.name === "encode_mode");
+    expect(mode.type).toBe("select");
+    expect(mode.default).toBe("encode");
+    expect(mode.options.map((o) => o.value)).toEqual([
+      "encode",
+      "document",
+      "query",
+    ]);
+  });
+});
+
+describe("applyEmbedEncodeMode", () => {
+  test("the default mode sends neither boolean", () => {
+    // Omitting both is what makes the task call plain encode().
+    expect(applyEmbedEncodeMode({ encode_mode: "encode" })).toEqual({});
+  });
+
+  test("document and query each set only their own flag", () => {
+    expect(applyEmbedEncodeMode({ encode_mode: "document" })).toEqual({
+      use_encode_document: true,
+    });
+    expect(applyEmbedEncodeMode({ encode_mode: "query" })).toEqual({
+      use_encode_query: true,
+    });
+  });
+
+  test("never sets both flags, which the task rejects", () => {
+    for (const mode of ["encode", "document", "query"]) {
+      const params = applyEmbedEncodeMode({ encode_mode: mode });
+      expect(params.use_encode_document && params.use_encode_query).toBeFalsy();
+    }
+  });
+
+  test("drops the UI-only encode_mode key and keeps other params", () => {
+    const params = applyEmbedEncodeMode({
+      encode_mode: "query",
+      normalize: true,
+    });
+    expect(params).not.toHaveProperty("encode_mode");
+    expect(params.normalize).toBe(true);
+  });
+});
+
+describe("isParamVisible — multiPageOnly", () => {
+  const multiPageParam = embed.params.find((p) => p.name === "batch_size");
+
+  test("is shown for PDF input", () => {
+    // Only a PDF can hold multiple pages, which is the sole branch where the
+    // task reads batch_size.
+    expect(isParamVisible(multiPageParam, { inputExt: ".pdf" })).toBe(true);
+  });
+
+  test("is hidden for single images", () => {
+    // tigerflow's count_images returns 1 for any non-PDF, so a single image
+    // takes the one-shot branch and never batches.
+    expect(isParamVisible(multiPageParam, { inputExt: ".png" })).toBe(false);
+    expect(isParamVisible(multiPageParam, { inputExt: ".jpg" })).toBe(false);
+  });
+
+  test("is hidden for text input", () => {
+    expect(isParamVisible(multiPageParam, { inputExt: ".txt" })).toBe(false);
+  });
+
+  test("does not affect params without the flag", () => {
+    const normalize = embed.params.find((p) => p.name === "normalize");
+    expect(isParamVisible(normalize, { inputExt: ".txt" })).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Registers the tigerflow-ml \`embed\` task (added in 0.2.0, PR #178/#180) so batch jobs can produce vector embeddings for text, images, and PDFs.
- Maps \`embed\` -> \`tigerflow_ml.multimodal.embed.local\` in \`SUPPORTED_TASKS\`, defaults input to \`.txt\` and output to \`.npy\` (the task rejects any other suffix).
- Wires the launcher: \`COMPATIBLE_PIPELINES[\"embedding\"]\` -> \`sentence-similarity\` + \`feature-extraction\`; \`NewJobModal\` gets an \"embed\" entry, \`multiPageOnly\` param gate, and \`applyEmbedEncodeMode\` helper.
- Adds \`embed\` (and pre-existing gap \`chat\`) to \`EXPECTED_TASKS\` in \`test_tigerflow.py\` so the contract test guards them against future image bumps.

## Test plan
- [x] \`uv run just lint\`
- [x] \`uv run just test\` (972 pass, 7 skipped)
- [x] \`npm test\` (552 pass)
- [ ] End-to-end on Della: run an embed job over a directory of \`.txt\` files, confirm \`.npy\` outputs resolve in the results table.

## Notes
- Depends on tigerflow-ml 0.2.0, pinned in #510.
- Rebased onto today's \`main\`; the branch's original chat/embed under \`text/\` was updated to the 0.2.0 module layout (\`multimodal/\`) as part of the rebase.
- Dropped three tautological tests (\`test_embed_task_is_supported\`, \`test_embed_default_input_ext_is_text\`, \`test_embed_default_output_ext_is_npy\`) that just re-read \`SUPPORTED_TASKS\` / \`DEFAULT_*_EXT\`. Kept the two load-bearing ones (\`test_build_pipeline_config_builds_embed_task\`, \`test_embed_pipeline_yaml_sets_npy_output_ext\`) that exercise real assembly / yaml rendering.
- Removed the \"Until the pinned image is updated\" note from the CLI docs (moot now).

Closes #463