### PR TITLE
chore(web): sync batch job launcher params with tigerflow-ml 0.2.0

### DIFF
--- a/web/src/routes/jobs/components/NewJobModal.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.jsx
@@ -164,6 +164,26 @@ export const TASKS = [
         help: "Maximum tokens generated per image. Default: 4096",
         placeholder: "4096",
       },
+      {
+        name: "json_schema",
+        type: "textarea",
+        required: false,
+        showWhenParam: { name: "output_format", value: "json", default: "text" },
+        label: "JSON Schema",
+        help: 'Constrain the model to a JSON schema (vLLM structured outputs). Requires a supporting model.',
+        placeholder:
+          '{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}',
+      },
+      {
+        name: "buffer_size",
+        type: "text",
+        valueType: "number",
+        multiPageOnly: true,
+        required: false,
+        label: "PDF Buffer Size",
+        help: "PDF pages held in memory at once. Default: 100",
+        placeholder: "100",
+      },
     ],
   },
   {
@@ -453,16 +473,26 @@ export const TASKS = [
         help: "When the source language can't be determined, use a fallback prompt that omits {source_lang}.",
         default: false,
       },
+      {
+        name: "max_model_len",
+        type: "text",
+        valueType: "number",
+        required: false,
+        label: "Max Model Length",
+        help: "Total input + output tokens passed to vLLM. Defaults to (chunk_size * 2.5 + 512), capped by the model's context window.",
+        placeholder: "auto",
+      },
     ],
   },
   {
     id: "chat",
     name: "Chat",
-    description: "Apply a prompt to each text file",
+    description: "Prompt a chat model with text, images, audio, or video",
     service: "text-generation", // Uses LLM models
     defaultInputExt: ".txt",
-    // Chat has no server-side default prompt, so it is required. Preliminary
-    // support is text-only; image inputs (and max_image_pixels) come later.
+    // Chat has no server-side default prompt, so it is required. The prompt
+    // is still required for media inputs — the model needs it to know what
+    // to do with the media.
     defaultPrompt: "Summarize the following text:\n\n{text}",
     promptRequired: true,
     promptHelp:
@@ -471,6 +501,17 @@ export const TASKS = [
       { value: ".txt", label: "Plain text (.txt)" },
       { value: ".md", label: "Markdown (.md)" },
       { value: ".log", label: "Log (.log)" },
+      { value: ".png", label: "PNG (.png)" },
+      { value: ".jpg", label: "JPEG (.jpg)" },
+      { value: ".jpeg", label: "JPEG (.jpeg)" },
+      { value: ".tiff", label: "TIFF (.tiff)" },
+      { value: ".wav", label: "WAV (.wav)" },
+      { value: ".mp3", label: "MP3 (.mp3)" },
+      { value: ".flac", label: "FLAC (.flac)" },
+      { value: ".mp4", label: "MP4 (.mp4)" },
+      { value: ".mov", label: "MOV (.mov)" },
+      { value: ".mkv", label: "MKV (.mkv)" },
+      { value: ".webm", label: "WebM (.webm)" },
     ],
     params: [
       {
@@ -481,6 +522,44 @@ export const TASKS = [
         label: "Temperature",
         help: "Sampling temperature (0–2). Lower is more deterministic. Default: 0.0",
         placeholder: "0.0",
+      },
+      {
+        name: "max_image_pixels",
+        type: "text",
+        valueType: "number",
+        imageOnly: true,
+        required: false,
+        label: "Max Image Pixels",
+        help: "Maximum image dimension (width or height). Larger images are downscaled preserving aspect ratio. Default: no limit",
+        placeholder: "1024",
+      },
+      {
+        name: "audio_sampling_rate",
+        type: "text",
+        valueType: "number",
+        audioOnly: true,
+        required: false,
+        label: "Audio Sampling Rate (Hz)",
+        help: "Sampling rate audio inputs are resampled to before the model sees them. Default: 16000",
+        placeholder: "16000",
+      },
+      {
+        name: "video_sample_fps",
+        type: "text",
+        valueType: "number",
+        videoOnly: true,
+        required: false,
+        label: "Video Sample FPS",
+        help: "Frame rate video inputs are resampled to; frames are dropped to hit this rate. Default: no resampling",
+        placeholder: "1.0",
+      },
+      {
+        name: "response_schema",
+        type: "textarea",
+        required: false,
+        label: "Response Schema",
+        help: 'Constrain output via vLLM structured outputs. Format: "<type>=<value>". Types: choice, json, regex, grammar. Example: json={"type":"object","properties":{"text":{"type":"string"}}}',
+        placeholder: 'json={"type":"object","properties":{"text":{"type":"string"}}}',
       },
     ],
   },
@@ -585,14 +664,34 @@ const VIDEO_INPUT_EXTS = new Set([
 // count_images returns 1 for anything but a PDF), so batching never applies.
 const MULTI_PAGE_INPUT_EXTS = new Set([".pdf"]);
 
+// Image and audio extension sets used by chat's `imageOnly` / `audioOnly`
+// param gates so, e.g., `max_image_pixels` only appears when the input is
+// actually an image and `audio_sampling_rate` when it is audio.
+const IMAGE_INPUT_EXTS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".tiff",
+  ".webp",
+  ".gif",
+  ".bmp",
+]);
+const AUDIO_INPUT_EXTS = new Set([
+  ".wav",
+  ".mp3",
+  ".flac",
+  ".m4a",
+  ".ogg",
+]);
+
 // Whether a param applies given the current form state. Hides params the task
 // would ignore: `showWhen.modelType` params for a mismatched model (e.g.
-// detect's labels, zero-shot only), `videoOnly` params for image inputs (e.g.
-// detect's batch_size), `multiPageOnly` params for single-page inputs (e.g.
-// embed's batch_size), and params gated on another param's value via
-// `showWhenParam` (e.g. transcribe's batch_size only applies when windowing is
-// "batched"). All three call sites (render, validation, submit) go through this
-// one predicate so a hidden param's stale value is never sent.
+// detect's labels, zero-shot only); `videoOnly` / `imageOnly` / `audioOnly` /
+// `multiPageOnly` params for mismatched input extensions (e.g. chat's
+// `max_image_pixels` for text inputs); and params gated on another param's
+// value via `showWhenParam` (e.g. transcribe's batch_size only applies when
+// windowing is "batched"). All three call sites (render, validation, submit)
+// go through this one predicate so a hidden param's stale value is never sent.
 // Whether discovery *succeeded* and reported no staged image. Distinct from
 // "we could not reach the profile" (container undefined), which must not block
 // a launch — the backend still resolves its configured default. Only this case
@@ -607,6 +706,12 @@ export function isParamVisible(param, { inputExt, taskParams, modelType } = {}) 
     return false;
   }
   if (param.videoOnly && !VIDEO_INPUT_EXTS.has(inputExt)) {
+    return false;
+  }
+  if (param.imageOnly && !IMAGE_INPUT_EXTS.has(inputExt)) {
+    return false;
+  }
+  if (param.audioOnly && !AUDIO_INPUT_EXTS.has(inputExt)) {
     return false;
   }
   if (param.multiPageOnly && !MULTI_PAGE_INPUT_EXTS.has(inputExt)) {

--- a/web/src/routes/jobs/components/NewJobModal.test.jsx
+++ b/web/src/routes/jobs/components/NewJobModal.test.jsx
@@ -15,6 +15,7 @@ const detect = TASKS.find((t) => t.id === "detect");
 const translate = TASKS.find((t) => t.id === "translate");
 const transcribe = TASKS.find((t) => t.id === "transcribe");
 const embed = TASKS.find((t) => t.id === "embed");
+const chat = TASKS.find((t) => t.id === "chat");
 
 describe("coerceParamValue", () => {
   test("coerces number-typed params to real numbers", () => {
@@ -109,20 +110,24 @@ describe("TASKS param definitions", () => {
     expect(targetLang.default).toBe("en");
   });
 
-  test("chat is registered, text-only, with a required prompt", () => {
+  test("chat is registered, multimodal, with a required prompt", () => {
     const chat = TASKS.find((t) => t.id === "chat");
     expect(chat).toBeDefined();
     expect(chat.promptRequired).toBe(true);
     expect(chat.defaultPrompt).toBeTruthy();
-    // Preliminary support is text-only (no image extensions yet).
+    // 0.2.0 accepts text, images, audio, and video.
     const exts = chat.inputExtOptions.map((o) => o.value);
-    expect(exts).toContain(".txt");
-    expect(exts).not.toContain(".jpg");
+    expect(exts).toEqual(expect.arrayContaining([".txt", ".jpg", ".wav", ".mp4"]));
     // temperature is numeric so it coerces to a real number at submit.
     const temp = chat.params.find((p) => p.name === "temperature");
     expect(temp.valueType).toBe("number");
-    // max_image_pixels is deferred with image inputs.
-    expect(chat.params.map((p) => p.name)).not.toContain("max_image_pixels");
+    // Media params are registered and modality-gated.
+    const maxPixels = chat.params.find((p) => p.name === "max_image_pixels");
+    expect(maxPixels?.imageOnly).toBe(true);
+    const audioRate = chat.params.find((p) => p.name === "audio_sampling_rate");
+    expect(audioRate?.audioOnly).toBe(true);
+    const videoFps = chat.params.find((p) => p.name === "video_sample_fps");
+    expect(videoFps?.videoOnly).toBe(true);
     // The prompt help explains the {text} placeholder.
     expect(chat.promptHelp).toMatch(/\{text\}/);
   });
@@ -258,6 +263,36 @@ describe("isParamVisible — videoOnly", () => {
     expect(dtype.videoOnly).toBeUndefined();
     expect(isParamVisible(dtype, { inputExt: ".jpg" })).toBe(true);
     expect(isParamVisible(dtype, { inputExt: ".mp4" })).toBe(true);
+  });
+});
+
+describe("isParamVisible — imageOnly", () => {
+  const imageParam = chat.params.find((p) => p.name === "max_image_pixels");
+
+  test("is shown for image inputs", () => {
+    expect(isParamVisible(imageParam, { inputExt: ".png" })).toBe(true);
+    expect(isParamVisible(imageParam, { inputExt: ".jpg" })).toBe(true);
+  });
+
+  test("is hidden for non-image inputs", () => {
+    expect(isParamVisible(imageParam, { inputExt: ".txt" })).toBe(false);
+    expect(isParamVisible(imageParam, { inputExt: ".wav" })).toBe(false);
+    expect(isParamVisible(imageParam, { inputExt: ".mp4" })).toBe(false);
+  });
+});
+
+describe("isParamVisible — audioOnly", () => {
+  const audioParam = chat.params.find((p) => p.name === "audio_sampling_rate");
+
+  test("is shown for audio inputs", () => {
+    expect(isParamVisible(audioParam, { inputExt: ".wav" })).toBe(true);
+    expect(isParamVisible(audioParam, { inputExt: ".mp3" })).toBe(true);
+  });
+
+  test("is hidden for non-audio inputs", () => {
+    expect(isParamVisible(audioParam, { inputExt: ".txt" })).toBe(false);
+    expect(isParamVisible(audioParam, { inputExt: ".png" })).toBe(false);
+    expect(isParamVisible(audioParam, { inputExt: ".mp4" })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
Closes the drift between \`NewJobModal\`'s task schemas and the \`Params\` classes shipped in tigerflow-ml 0.2.0. \`transcribe\` and \`detect\` are already in sync; this covers the three tasks with gaps.

- **ocr**: expose \`json_schema\` (gated on the JSON output format) and \`buffer_size\` (multi-page PDF only).
- **translate**: expose \`max_model_len\` for models with larger context windows than the default \`chunk_size * 2.5 + 512\` formula.
- **chat**: 0.2.0 accepts images, audio, and video alongside text. Widen \`inputExtOptions\` accordingly and add \`max_image_pixels\`, \`audio_sampling_rate\`, \`video_sample_fps\`, and \`response_schema\`. Media params are modality-gated so the modal only shows what applies to the selected input.

Two new gates in \`isParamVisible\` — \`imageOnly\` and \`audioOnly\` — mirror the existing \`videoOnly\`.

## Notes on the free-form JSON textareas
\`json_schema\` (ocr) and \`response_schema\` (chat) are **not** validated client-side. tigerflow-ml's \`parse_kwargs\` accepts both JSON and Python-literal dict syntax, and \`chat.response_schema\` uses a \`<type>=<value>\` format where \`<value>\` can be JSON, a list, a regex, or a grammar. A strict \`JSON.parse\` would reject inputs the help text explicitly advertises. Malformed input surfaces as a clear tigerflow-ml error at task setup.

## Test plan
- [x] \`npm run lint\`
- [x] \`npm test\` (556 pass; +4 new — imageOnly x2, audioOnly x2)
- [x] Manual: launch a chat job on Della with an image input; confirm \`max_image_pixels\` is shown and audio/video params are hidden.
- [x] Manual: launch an ocr job with JSON output and a schema; confirm the schema flows to tigerflow.

## Notes
- No backend change. \`BatchJobRequest.params\` is a passthrough dict, and tigerflow-ml validates and defaults each param.
- Sub-task of #451.

Closes #513