### PR TITLE
chore(lib): bump speech-recognition-inference to 0.2.1

### DIFF
--- a/lib/docs/setup/management.md
+++ b/lib/docs/setup/management.md
@@ -44,13 +44,13 @@ This lists each pinned image — one per service, plus the tigerflow-ml image us
 Services deployed on HPC systems require Apptainer, which uses Single Image Format (SIF) images instead of Docker's OCI format. Docker images must be converted to SIF files before Blackfish can use them. For most images—including those hosted on the GitHub container registry—running `apptainer pull` will do this automatically. For example,
 
 ```shell
-apptainer pull docker://ghcr.io/princeton-ddss/speech-recognition-inference:0.1.2
+apptainer pull docker://ghcr.io/princeton-ddss/speech-recognition-inference:<tag>
 ```
 
-This command generates a file `speech-recognition-inference_0.1.2.sif` in the directory where it is run. The tigerflow-ml image used for batch jobs is staged the same way — pull the version reported by `blackfish image ls`, e.g.
+This command generates a file `speech-recognition-inference_<tag>.sif` in the directory where it is run. Use the version reported by `blackfish image ls`. The tigerflow-ml image used for batch jobs is staged the same way:
 
 ```shell
-apptainer pull docker://ghcr.io/princeton-ddss/tigerflow-ml:0.1.1
+apptainer pull docker://ghcr.io/princeton-ddss/tigerflow-ml:<tag>
 ```
 
 Blackfish looks for images in the `cache_dir/images` directory specified by your profile. If you are an HPC admin setting up a shared environment, move images to the shared cache directory (e.g., `/shared/.blackfish/images`). If you are an individual user and your cache directory is read-only, ask your admin to add the required images or set your profile's `cache_dir` to a directory you can write to.

--- a/lib/src/blackfish/server/images.py
+++ b/lib/src/blackfish/server/images.py
@@ -64,7 +64,7 @@ DEFAULT_IMAGES: dict[str, ImageSpec] = {
     "text_generation": ImageSpec(repo="vllm/vllm-openai", tag="v0.20.0"),
     "speech_recognition": ImageSpec(
         repo="ghcr.io/princeton-ddss/speech-recognition-inference",
-        tag="0.1.2",
+        tag="0.2.1",
     ),
     # Note: the GHCR image tag is "0.2.0" (no leading "v"), unlike the
     # "v0.2.0" GitHub release tag.

--- a/lib/src/blackfish/server/templates/speech_recognition_local.sh
+++ b/lib/src/blackfish/server/templates/speech_recognition_local.sh
@@ -8,8 +8,8 @@ docker run -d {{ '--runtime nvidia --gpus all' if job_config.gres else '' }} \
   --name {{ name }} \
   {{ image.docker_ref }} \
   launch \
-  --model_dir /data/models \
-  --model_id {{ model }} \
+  --model-dir /data/models \
+  --model-id {{ model }} \
   {%- if container_config.revision %}
   --revision {{container_config.revision }} \
   {%- endif %}
@@ -23,8 +23,8 @@ apptainer instance run {{ ' --nv' if job_config.gres > 0 else '' }} \
   {{ profile.cache_dir }}/images/{{ image.sif }} \
   {{ name }} \
   launch \
-  --model_dir /data/models \
-  --model_id {{ model }} \
+  --model-dir /data/models \
+  --model-id {{ model }} \
   {%- if container_config.revision %}
   --revision {{ container_config.revision }}\
   {%- endif %}

--- a/lib/src/blackfish/server/templates/speech_recognition_local.sh
+++ b/lib/src/blackfish/server/templates/speech_recognition_local.sh
@@ -7,11 +7,13 @@ docker run -d {{ '--runtime nvidia --gpus all' if job_config.gres else '' }} \
   -v {{ container_config.model_dir }}:/data/models \
   --name {{ name }} \
   {{ image.docker_ref }} \
+  launch \
   --model_dir /data/models \
   --model_id {{ model }} \
   {%- if container_config.revision %}
   --revision {{container_config.revision }} \
   {%- endif %}
+  --host 0.0.0.0 \
   --port {{ container_config.port }}
 {%- elif provider == 'apptainer' %}
 apptainer instance run {{ ' --nv' if job_config.gres > 0 else '' }} \
@@ -20,11 +22,13 @@ apptainer instance run {{ ' --nv' if job_config.gres > 0 else '' }} \
   --bind {{ container_config.model_dir }}:/data/models \
   {{ profile.cache_dir }}/images/{{ image.sif }} \
   {{ name }} \
+  launch \
   --model_dir /data/models \
   --model_id {{ model }} \
   {%- if container_config.revision %}
   --revision {{ container_config.revision }}\
   {%- endif %}
+  --host 0.0.0.0 \
   --port {{ container_config.port }}
 {%- endif %}
 {%- endblock %}

--- a/lib/src/blackfish/server/templates/speech_recognition_slurm.sh
+++ b/lib/src/blackfish/server/templates/speech_recognition_slurm.sh
@@ -9,8 +9,8 @@ apptainer run {{ ' --nv' if job_config.gres > 0 else '' }} \
   --bind {{ container_config.model_dir }}:/data/models \
   {{ profile.cache_dir }}/images/{{ image.sif }} \
   launch \
-  --model_dir /data/models \
-  --model_id {{ model }} \
+  --model-dir /data/models \
+  --model-id {{ model }} \
   --revision {{ container_config.revision }} \
   --host 0.0.0.0 \
   --port $port

--- a/lib/src/blackfish/server/templates/speech_recognition_slurm.sh
+++ b/lib/src/blackfish/server/templates/speech_recognition_slurm.sh
@@ -8,8 +8,10 @@ apptainer run {{ ' --nv' if job_config.gres > 0 else '' }} \
   --bind {{ mount }}:/data/audio \
   --bind {{ container_config.model_dir }}:/data/models \
   {{ profile.cache_dir }}/images/{{ image.sif }} \
+  launch \
   --model_dir /data/models \
   --model_id {{ model }} \
   --revision {{ container_config.revision }} \
+  --host 0.0.0.0 \
   --port $port
 {%- endblock %}


### PR DESCRIPTION
## Summary
SRI 0.2.0 restructured the project. The container's ENTRYPOINT is now \`speech_recognition\` (a typer CLI) with \`launch\` and \`pipeline\` subcommands, and the API's default host binding changed from \`0.0.0.0\` to \`localhost\`. Update the launch templates:

- Insert \`launch\` as the first arg after the container so the typer CLI routes to the API subcommand. Existing flags (\`--model_dir\`, \`--model_id\`, \`--revision\`, \`--port\`) are unchanged and forwarded to it.
- Add \`--host 0.0.0.0\` so the API is reachable from outside the container. Without this the CLI binds to localhost, which is unreachable through Docker port forwarding or the SSH tunnel Blackfish opens for Slurm services.

Applies to \`speech_recognition_slurm.sh\` and both branches of \`speech_recognition_local.sh\` (docker + apptainer).

## Test plan
- [x] \`uv run just lint\`
- [x] \`uv run just test\` (969 pass, 7 skipped)
- [x] \`docker pull ghcr.io/princeton-ddss/speech-recognition-inference:0.2.1\` and stage the SIF on the test profile.
- [ ] Launch a speech-recognition service on Della; confirm the API responds on the tunnel'd port and can transcribe a sample \`.wav\`.

## Notes
- Sub-task of #451. Launcher-side param drift for SRI is a separate task (#514).

Closes #511