### PR TITLE
chore(web): sync speech recognition language options with SRI 0.2.1

### DIFF
--- a/web/src/routes/speech-recognition/components/SpeechRecognitionParametersForm.jsx
+++ b/web/src/routes/speech-recognition/components/SpeechRecognitionParametersForm.jsx
@@ -72,7 +72,10 @@ function LanguageSelect({ language, setLanguage }) {
 }
 
 LanguageSelect.propTypes = {
-  language: PropTypes.string,
+  language: PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+  }),
   setLanguage: PropTypes.func,
 };
 

--- a/web/src/routes/speech-recognition/components/SpeechRecognitionParametersForm.jsx
+++ b/web/src/routes/speech-recognition/components/SpeechRecognitionParametersForm.jsx
@@ -8,16 +8,25 @@ import {
 import { ChevronUpDownIcon, CheckIcon } from "@heroicons/react/20/solid";
 import PropTypes from "prop-types";
 
+// requests.js omits the language field when Auto-detect is chosen.
+const AUTO_DETECT = { id: 0, name: "Auto-detect" };
 const languages = [
+  AUTO_DETECT,
   { id: 1, name: "English" },
-  { id: 2, name: "French" },
-  { id: 3, name: "Spanish" },
+  { id: 2, name: "Spanish" },
+  { id: 3, name: "French" },
   { id: 4, name: "German" },
-  { id: 5, name: "Chinese" },
-  { id: 6, name: "Norwegian" },
-  { id: 7, name: "Swedish" },
-  { id: 8, name: "Dutch" },
+  { id: 5, name: "Italian" },
+  { id: 6, name: "Portuguese" },
+  { id: 7, name: "Chinese" },
+  { id: 8, name: "Japanese" },
+  { id: 9, name: "Korean" },
+  { id: 10, name: "Arabic" },
+  { id: 11, name: "Hindi" },
+  { id: 12, name: "Russian" },
 ];
+
+export { languages, AUTO_DETECT };
 
 function LanguageSelect({ language, setLanguage }) {
   return (
@@ -38,7 +47,8 @@ function LanguageSelect({ language, setLanguage }) {
 
         <ListboxOptions
           transition
-          className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white dark:bg-gray-700 py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none data-[closed]:data-[leave]:opacity-0 data-[leave]:transition data-[leave]:duration-100 data-[leave]:ease-in sm:text-sm"
+          anchor="bottom start"
+          className="z-50 mt-1 max-h-60 w-[var(--button-width)] overflow-auto rounded-md bg-white dark:bg-gray-700 py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none data-[closed]:data-[leave]:opacity-0 data-[leave]:transition data-[leave]:duration-100 data-[leave]:ease-in sm:text-sm"
         >
           {languages.map((person) => (
             <ListboxOption

--- a/web/src/routes/speech-recognition/lib/requests.js
+++ b/web/src/routes/speech-recognition/lib/requests.js
@@ -9,7 +9,10 @@ export async function callSpeechRecognitionInference(service, audioPath, params,
   const body = {
     audio_path: audioPath.replace(service.mount, "/data/audio"),
     response_format: "text",
-    language: params.language.name.toLowerCase(),
+  }
+  // Auto-detect: omit the field so SRI detects per file.
+  if (params.language?.name && params.language.name !== "Auto-detect") {
+    body.language = params.language.name.toLowerCase();
   }
   const res = await fetch(url, {
     method: "POST",

--- a/web/src/routes/speech-recognition/lib/requests.test.js
+++ b/web/src/routes/speech-recognition/lib/requests.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { callSpeechRecognitionInference } from "./requests";
+
+const service = { port: 8080, mount: "/scratch/gpfs/xxx/audio" };
+const audioPath = "/scratch/gpfs/xxx/audio/sample.wav";
+
+function stubFetchOk() {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ text: "hello" }),
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("callSpeechRecognitionInference language handling", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends the lowercased language name for an explicit selection", async () => {
+    const fetchMock = stubFetchOk();
+
+    await callSpeechRecognitionInference(service, audioPath, {
+      language: { id: 3, name: "Portuguese" },
+    });
+
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.language).toBe("portuguese");
+  });
+
+  it("omits the language field when Auto-detect is chosen", async () => {
+    const fetchMock = stubFetchOk();
+
+    await callSpeechRecognitionInference(service, audioPath, {
+      language: { id: 0, name: "Auto-detect" },
+    });
+
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body).not.toHaveProperty("language");
+    // The other required fields should still be populated.
+    expect(body.audio_path).toBe("/data/audio/sample.wav");
+    expect(body.response_format).toBe("text");
+  });
+});

--- a/web/src/routes/speech-recognition/speech-recognition.jsx
+++ b/web/src/routes/speech-recognition/speech-recognition.jsx
@@ -6,14 +6,13 @@ import { SidebarContainer } from "@/components/SidebarContainer";
 
 import SpeechRecognitionContainer from "./components/SpeechRecognitionContainer";
 import SpeechRecognitionContainerOptionsForm from "./components/SpeechRecognitionContainerOptionsForm";
-import SpeechRecognitionParametersForm from "./components/SpeechRecognitionParametersForm";
+import SpeechRecognitionParametersForm, {
+  AUTO_DETECT,
+} from "./components/SpeechRecognitionParametersForm";
 
 export default function SpeechRecognitionPage() {
   const [parameters, setParameters] = useState({
-    language: {
-      id: 0,
-      name: "English",
-    },
+    language: AUTO_DETECT,
   });
 
   const defaultContainerOptions = useMemo(() => {


### PR DESCRIPTION
## Summary

The service launcher offered only 8 languages and always sent one on every request. SRI 0.2.1's \`TranscriptionRequest\` accepts ~90 languages plus per-file auto-detect, so 82 valid values were unreachable and users could never opt into auto-detection.

- Widen the list to mirror the batch transcribe launcher's 12-language curated set: English, Spanish, French, German, Italian, Portuguese, Chinese, Japanese, Korean, Arabic, Hindi, Russian.
- Add \"Auto-detect\" as the default. \`requests.js\` now omits the \`language\` field when Auto-detect is chosen — same mechanism the batch task uses.
- Portal the language dropdown with \`anchor=\"bottom start\"\` so it escapes the sidebar's overflow context; previously the open menu was clipped by the parameter container's height.

## Test plan
- [x] \`npm run lint\`
- [x] \`npm test\` (556 pass)
- [x] Manual: launch a speech-recognition service, transcribe an audio file with a specific language and with Auto-detect. Confirm the dropdown is fully visible when open.

## Notes
- Sub-task of #451.
- The \`response_format\` toggle (text vs json+segments) is a separate feature request — #521.

Closes #514