### PR TITLE
chore(lib): bump vllm/vllm-openai to v0.26.0

### DIFF
--- a/lib/src/blackfish/cli/__main__.py
+++ b/lib/src/blackfish/cli/__main__.py
@@ -405,7 +405,7 @@ def start(reload: bool | None) -> None:  # pragma: no cover
     type=str,
     default=None,
     help=(
-        "Pin the container image, e.g. 'vllm/vllm-openai:v0.20.0'. Defaults to"
+        "Pin the container image, e.g. 'vllm/vllm-openai:v0.26.0'. Defaults to"
         " the configured image. See `blackfish ls` for the version in use."
     ),
 )

--- a/lib/src/blackfish/client.py
+++ b/lib/src/blackfish/client.py
@@ -305,7 +305,7 @@ class Blackfish:
             mount: Optional directory to mount
             grace_period: Time in seconds to wait before marking unhealthy
             image_ref: Pin the container image as "repo:tag" (e.g.
-                "vllm/vllm-openai:v0.20.0"). None uses the configured image,
+                "vllm/vllm-openai:v0.26.0"). None uses the configured image,
                 which is then recorded on the service so restarts reuse it.
             auto_cleanup: If True, automatically stop and delete this service when the
                 Python script exits (default: True)

--- a/lib/src/blackfish/server/images.py
+++ b/lib/src/blackfish/server/images.py
@@ -61,7 +61,7 @@ def resolve_image(image_ref: str | None, default: ImageSpec) -> ImageSpec:
 
 
 DEFAULT_IMAGES: dict[str, ImageSpec] = {
-    "text_generation": ImageSpec(repo="vllm/vllm-openai", tag="v0.20.0"),
+    "text_generation": ImageSpec(repo="vllm/vllm-openai", tag="v0.26.0"),
     "speech_recognition": ImageSpec(
         repo="ghcr.io/princeton-ddss/speech-recognition-inference",
         tag="0.2.1",

--- a/lib/tests/cli/test_cli_run.py
+++ b/lib/tests/cli/test_cli_run.py
@@ -1286,4 +1286,6 @@ class TestRunGroupOptions:
         # The script itself, not the echo line above it.
         script = result.output.split("> image_ref:")[-1]
         assert "vllm-openai_v9.9.9" in script
-        assert "vllm-openai_v0.20.0" not in script
+        from blackfish.server.images import DEFAULT_IMAGES
+
+        assert DEFAULT_IMAGES["text_generation"].sif not in script


### PR DESCRIPTION
## Summary

Two-year jump from \`v0.20.0\` (Aug 2024) to \`v0.26.0\` (Jul 2026). The launch template's flags (\`--model\`, \`--port\`, \`--revision\`, \`--trust-remote-code\`, \`--tensor-parallel-size\`) are unchanged between the two versions, and the Disable Thinking toggle's \`--default-chat-template-kwargs\` shape was not touched.

Motivation: v0.20 pre-dates many models we now cache. Concretely, Gemma 4 (v0.21+), gpt-oss (v0.24), and TranslateGemma (v0.26) either fail or are hit-and-miss on the current pin.

## Testing status

Runtime override for pre-merge validation:

\`\`\`shell
BLACKFISH_TEXT_GENERATION_IMAGE=vllm/vllm-openai:v0.26.0 blackfish start
\`\`\`

Full checklist tracked on the issue — #512. Highlights already green:

- [x] \`google/gemma-4-12b-it\`
- [x] \`google/gemma-3-4b-it\`
- [x] \`deepseek-ai/DeepSeek-OCR-2\`

Still to smoke test before this leaves draft:

- [ ] \`TinyLlama/TinyLlama-1.1B-Chat-v1.0\` (sanity)
- [ ] \`meta-llama/Llama-3.3-70B-Instruct\` (flagship dense regression + multi-GPU)
- [ ] \`Qwen/Qwen2.5-72B-Instruct\` (Qwen 2.5 regression + Disable Thinking flag)
- [ ] \`openai/gpt-oss-20b\` (new arch, v0.24)
- [ ] \`google/translategemma-4b-it\` (new arch, v0.26)
- [ ] Parameter checklist (temperature/max_tokens/stop/stream/seed/penalties in one request; deterministic seed check)

## Notes

- Follows the earlier tigerflow-ml pattern for tests that used to hard-code the default tag: assert against \`DEFAULT_IMAGES\` instead of the literal so future bumps don't touch \`test_cli_run.py\`.
- Opaque test fixtures elsewhere (\`test_image_probe.py\`, \`ImageVersionSelect.test.jsx\`, etc.) intentionally not touched — the strings are arbitrary inputs to the units under test, not claims about the default.
- Sub-task of #451. #515 (launcher param sync after this bump) is the natural follow-up.

Refs #512