### PR TITLE
chore: sync text generation launcher with vLLM 0.26

### DIFF
--- a/lib/src/blackfish/server/templates/text_generation_local.sh
+++ b/lib/src/blackfish/server/templates/text_generation_local.sh
@@ -6,7 +6,7 @@ docker run -d {{ '--runtime nvidia --gpus all' if job_config.gres else '' }} \
   -v {{ container_config.model_dir }}:/data \
   --name {{ name }} \
   {{ image.docker_ref }} \
-  --model /data/snapshots/{{ container_config['revision'] }} \
+  /data/snapshots/{{ container_config['revision'] }} \
   --port {{ container_config.port }} \
   --revision {{ container_config.revision }} \
   --trust-remote-code \
@@ -17,7 +17,7 @@ apptainer instance run {{ ' --nv' if job_config.gres > 0 else '' }} \
   --bind {{ container_config.model_dir }}:/data \
   {{ profile.cache_dir }}/images/{{ image.sif }} \
   {{ name }} \
-  --model /data/snapshots/{{ container_config['revision'] }} \
+  /data/snapshots/{{ container_config['revision'] }} \
   --port {{ container_config.port }} \
   --revision {{ container_config.revision }} \
   --trust-remote-code \

--- a/lib/src/blackfish/server/templates/text_generation_slurm.sh
+++ b/lib/src/blackfish/server/templates/text_generation_slurm.sh
@@ -5,7 +5,7 @@ apptainer run {{ '--nv' if job_config.gres else '' }} \
   --env PYTHONNOUSERSITE=1 \
   --bind {{ container_config.model_dir }}:/data \
   {{ profile.cache_dir }}/images/{{ image.sif }} \
-  --model /data/snapshots/{{ container_config['revision'] }} \
+  /data/snapshots/{{ container_config['revision'] }} \
   --port $port \
   --revision {{ container_config.revision }} \
   --trust-remote-code \

--- a/lib/tests/dev/test_text_generation.py
+++ b/lib/tests/dev/test_text_generation.py
@@ -14,7 +14,7 @@ def test_remote_slurm():
         "scheduler": "slurm",
         "grace_period": 180,
         "mount": "/home/cs7101",
-        "container_options": {"disable_custom_kernels": True, "revision": "latest"},
+        "container_options": {"revision": "latest"},
         "job_options": {
             "ntasks_per_node": 8,
             "mem": "16",
@@ -42,7 +42,7 @@ def test_local_slurm():
         "provider": "apptainer",
         "grace_period": 180,
         "mount": "/home/cs7101",
-        "container_options": {"disable_custom_kernels": True, "revision": "latest"},
+        "container_options": {"revision": "latest"},
         "job_options": {
             "ntasks_per_node": 8,
             "mem": "16",
@@ -66,7 +66,7 @@ def test_local():
         "cache_dir": "/home/cs7101/.blackfish",
         "provider": "docker",
         "grace_period": 180,
-        "container_options": {"disable_custom_kernels": True, "revision": "latest"},
+        "container_options": {"revision": "latest"},
         "job_options": {
             "ntasks_per_node": 8,
             "mem": "16",

--- a/web/src/components/SidebarContainer.jsx
+++ b/web/src/components/SidebarContainer.jsx
@@ -38,7 +38,6 @@ SystemMessageInput.propTypes = {
  * @param {string} options.task
  * @param {object} options.defaultContainerOptions
  * @param {string} options.defaultContainerOptions.input_dir
- * @param {boolean} options.defaultContainerOptions.disable_custom_kernels
  * @param {JSX.Element} options.ContainerOptionsFormComponent
  * @param {JSX.Element} options.ParametersFormComponent
  * @param {object} options.parametersFormProps
@@ -83,7 +82,6 @@ SidebarContainer.propTypes = {
   task: PropTypes.string,
   defaultContainerOptions: PropTypes.shape({
     input_dir: PropTypes.string,
-    disable_custom_kernels: PropTypes.bool,
   }),
   ContainerOptionsFormComponent: PropTypes.elementType,
   ParametersFormComponent: PropTypes.elementType,

--- a/web/src/components/SidebarContainer.test.jsx
+++ b/web/src/components/SidebarContainer.test.jsx
@@ -48,8 +48,7 @@ test("SidebarContainer", () => {
       <SidebarContainer
         task="speech-recognition"
         defaultContainerOptions={{
-          input_dir: "",
-          disable_custom_kernels: false
+          input_dir: ""
         }}
         ContainerOptionsFormComponent={
           TextGenerationContainerOptionsForm

--- a/web/src/lib/requests.test.js
+++ b/web/src/lib/requests.test.js
@@ -5,11 +5,9 @@ describe("buildContainerConfig", () => {
   it("strips disable_thinking when false and adds no launch_kwargs", () => {
     const out = buildContainerConfig({
       disable_thinking: false,
-      disable_custom_kernels: false,
       input_dir: "/data",
     });
     expect(out).toEqual({
-      disable_custom_kernels: false,
       input_dir: "/data",
     });
     expect(out).not.toHaveProperty("disable_thinking");
@@ -19,13 +17,11 @@ describe("buildContainerConfig", () => {
   it("translates disable_thinking=true into launch_kwargs and strips the flag", () => {
     const out = buildContainerConfig({
       disable_thinking: true,
-      disable_custom_kernels: false,
     });
     expect(out).not.toHaveProperty("disable_thinking");
     expect(out.launch_kwargs).toBe(
       `--default-chat-template-kwargs '{"enable_thinking": false, "thinking": false}'`
     );
-    expect(out.disable_custom_kernels).toBe(false);
   });
 });
 

--- a/web/src/routes/text-generation/components/TextGenerationContainerOptionsForm.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationContainerOptionsForm.jsx
@@ -34,18 +34,6 @@ function TextGenerationContainerOptionsForm({
         {expanded && (
           <div className="mt-3 space-y-3">
             <ServiceModalCheckbox
-              checked={containerOptions.disable_custom_kernels}
-              onChange={() => setContainerOptions(prevContainerOptions => {
-                return {
-                  ...prevContainerOptions,
-                  disable_custom_kernels: !prevContainerOptions.disable_custom_kernels,
-                };
-              })}
-              label="Disable Custom Kernels"
-              help="Disables custom CUDA kernels that may not work on all devices."
-              disabled={disabled}
-            />
-            <ServiceModalCheckbox
               checked={containerOptions.disable_thinking}
               onChange={() => setContainerOptions(prevContainerOptions => {
                 return {

--- a/web/src/routes/text-generation/components/TextGenerationContainerOptionsForm.test.jsx
+++ b/web/src/routes/text-generation/components/TextGenerationContainerOptionsForm.test.jsx
@@ -4,7 +4,6 @@ import { describe, it, expect, vi } from "vitest";
 import TextGenerationContainerOptionsForm from "./TextGenerationContainerOptionsForm";
 
 const defaultOptions = {
-  disable_custom_kernels: false,
   disable_thinking: true,
 };
 
@@ -37,7 +36,6 @@ describe("TextGenerationContainerOptionsForm", () => {
     expect(queryByText("Disable Thinking")).not.toBeInTheDocument();
     await user.click(getByText("Deployment Options"));
     expect(checkboxFor(container, "Disable Thinking")).toBeInTheDocument();
-    expect(checkboxFor(container, "Disable Custom Kernels")).toBeInTheDocument();
   });
 
   it("renders Disable Thinking checked when disable_thinking is true", async () => {

--- a/web/src/routes/text-generation/text-generation.jsx
+++ b/web/src/routes/text-generation/text-generation.jsx
@@ -200,7 +200,6 @@ export default function TextGenerationPage() {
 
   const defaultContainerOptions = useMemo(() => {
     return {
-      disable_custom_kernels: false,
       disable_thinking: true,
     };
   }, []);


### PR DESCRIPTION
## Summary

Two narrow fixes surfaced by the vLLM v0.26 audit.

**Migrate \`--model\` to a positional argument.** v0.26 emits a deprecation warning on every service start:

> With \`vllm serve\`, you should provide the model as a positional argument or in a config file instead of via the \`--model\` option. The \`--model\` option will be removed in a future version.

Migrating now avoids a hard break on the next vLLM bump. Applies to \`text_generation_slurm.sh\` and both branches of \`text_generation_local.sh\` (docker + apptainer).

**Remove the Disable Custom Kernels toggle.** It has been a phantom option for a while: the toggle sets container state and appears in the request body, but neither the active \`text_generation_*.sh\` templates nor the backend translate it into a vLLM flag — only the \`templates/deprecated/\` copies mention \`--disable-custom-kernels\`. The toggle told users they were changing behavior; they were not. Cleans up UI, initial state, propTypes, tests, and dev fixtures.

## Test plan
- [x] \`uv run just lint\`
- [x] \`uv run just test\` (969 pass)
- [x] \`npm run lint\`
- [x] \`npm test\` (558 pass)
- [x] Manual: launch a text-generation service on Della, confirm the vLLM deprecation warning is gone from the container log.

## Notes
- Sub-task of #451. Follows the v0.26 bump (#523).
- Follow-up issues to file after this lands: expose \`--max-model-len\`, expose \`--gpu-memory-utilization\`, expose \`thinking_token_budget\`.

Closes #515