### PR TITLE
fix(lib): give local dry-run services an id so rendering works

### DIFF
--- a/lib/docs/assets/img/coverage.svg
+++ b/lib/docs/assets/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">71%</text>
-        <text x="80" y="14">71%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">72%</text>
+        <text x="80" y="14">72%</text>
     </g>
 </svg>

--- a/lib/src/blackfish/cli/services/speech_recognition.py
+++ b/lib/src/blackfish/cli/services/speech_recognition.py
@@ -209,6 +209,7 @@ def run_speech_recognition(
 
         if dry_run:
             service = SpeechRecognition(
+                id=uuid4(),
                 name=name,
                 model=repo_id,
                 profile=profile.name,

--- a/lib/src/blackfish/cli/services/text_generation.py
+++ b/lib/src/blackfish/cli/services/text_generation.py
@@ -212,6 +212,7 @@ def run_text_generation(
 
         if dry_run:
             service = TextGeneration(
+                id=uuid4(),
                 name=name,
                 model=repo_id,
                 profile=profile.name,

--- a/lib/tests/cli/conftest.py
+++ b/lib/tests/cli/conftest.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from click.testing import CliRunner
 from unittest.mock import patch
 
+from blackfish.server.config import ContainerProvider
+
 
 @pytest.fixture()
 def cli_runner() -> CliRunner:
@@ -18,4 +20,7 @@ def mock_config():
         mock_config.HOME_DIR = (
             Path(__file__).parent.parent / "tests",
         )  # "/tmp/blackfish-test"
+        # A real provider, so job scripts rendered from this config aren't
+        # empty: the templates branch on `provider == "docker"`.
+        mock_config.CONTAINER_PROVIDER = ContainerProvider.Docker
         yield mock_config

--- a/lib/tests/cli/test_cli_run.py
+++ b/lib/tests/cli/test_cli_run.py
@@ -8,7 +8,7 @@ This module tests the CLI commands for running inference services:
 import shlex
 import pytest
 import requests
-from unittest.mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock
 from blackfish.cli.__main__ import main
 from blackfish.server.models.profile import LocalProfile, SlurmProfile
 
@@ -99,9 +99,6 @@ class TestRunTextGeneration:
             patch(
                 "blackfish.cli.services.text_generation.get_model_dir"
             ) as mock_get_model_dir,
-            patch(
-                "blackfish.cli.services.text_generation.TextGeneration"
-            ) as mock_service_class,
         ):
             mock_deserialize.return_value = local_profile
             mock_get_models.return_value = ["openai/gpt-2"]
@@ -109,16 +106,15 @@ class TestRunTextGeneration:
             mock_get_latest.return_value = "abc123"
             mock_get_model_dir.return_value = "/path/to/model"
 
-            mock_service = MagicMock()
-            mock_service.image = "text_generation"
-            mock_service.render_job_script.return_value = "#!/bin/bash\necho test"
-            mock_service_class.return_value = mock_service
-
             result = cli_runner.invoke(main, cmd)
 
+        assert result.exit_code == 0, result.exception
         assert "Rendering job script" in result.output
         assert "model: openai/gpt-2" in result.output
         assert "profile: default" in result.output
+        # The script itself, not just the echoed metadata above it.
+        script = result.output.split("> image_ref:")[-1]
+        assert "docker run" in script
 
     def test_dry_run_slurm_profile(self, cli_runner, mock_config, slurm_profile):
         """Test dry run with SlurmProfile renders job script."""
@@ -147,9 +143,6 @@ class TestRunTextGeneration:
             patch(
                 "blackfish.cli.services.text_generation.get_model_dir"
             ) as mock_get_model_dir,
-            patch(
-                "blackfish.cli.services.text_generation.TextGeneration"
-            ) as mock_service_class,
         ):
             mock_deserialize.return_value = slurm_profile
             mock_get_models.return_value = ["openai/gpt-2"]
@@ -157,17 +150,16 @@ class TestRunTextGeneration:
             mock_get_latest.return_value = "abc123"
             mock_get_model_dir.return_value = "/path/to/model"
 
-            mock_service = MagicMock()
-            mock_service.scheduler = "slurm"
-            mock_service.render_job_script.return_value = "#!/bin/bash\n#SBATCH"
-            mock_service_class.return_value = mock_service
-
             result = cli_runner.invoke(main, cmd)
 
+        assert result.exit_code == 0, result.exception
         assert "Rendering job script" in result.output
         assert "model: openai/gpt-2" in result.output
         assert "profile: cluster" in result.output
         assert "host: hpc.example.com" in result.output
+        # The script itself, not just the echoed metadata above it.
+        script = result.output.split("> image_ref:")[-1]
+        assert "#SBATCH" in script
 
     def test_success_local_profile(self, cli_runner, mock_config, local_profile):
         """Test successful API call with LocalProfile."""
@@ -627,9 +619,6 @@ class TestRunSpeechRecognition:
             patch(
                 "blackfish.cli.services.speech_recognition.get_model_dir"
             ) as mock_get_model_dir,
-            patch(
-                "blackfish.cli.services.speech_recognition.SpeechRecognition"
-            ) as mock_service_class,
         ):
             mock_deserialize.return_value = local_profile
             mock_get_models.return_value = ["openai/whisper-tiny"]
@@ -637,16 +626,15 @@ class TestRunSpeechRecognition:
             mock_get_latest.return_value = "abc123"
             mock_get_model_dir.return_value = "/path/to/models/whisper-tiny"
 
-            mock_service = MagicMock()
-            mock_service.image = "speech_recognition"
-            mock_service.render_job_script.return_value = "#!/bin/bash\necho test"
-            mock_service_class.return_value = mock_service
-
             result = cli_runner.invoke(main, cmd)
 
+        assert result.exit_code == 0, result.exception
         assert "Rendering job script" in result.output
         assert "model: openai/whisper-tiny" in result.output
         assert "profile: default" in result.output
+        # The script itself, not just the echoed metadata above it.
+        script = result.output.split("> image_ref:")[-1]
+        assert "docker run" in script
 
     def test_dry_run_slurm_profile(self, cli_runner, mock_config, slurm_profile):
         """Test dry run with SlurmProfile renders job script."""
@@ -675,9 +663,6 @@ class TestRunSpeechRecognition:
             patch(
                 "blackfish.cli.services.speech_recognition.get_model_dir"
             ) as mock_get_model_dir,
-            patch(
-                "blackfish.cli.services.speech_recognition.SpeechRecognition"
-            ) as mock_service_class,
         ):
             mock_deserialize.return_value = slurm_profile
             mock_get_models.return_value = ["openai/whisper-tiny"]
@@ -685,17 +670,16 @@ class TestRunSpeechRecognition:
             mock_get_latest.return_value = "abc123"
             mock_get_model_dir.return_value = "/path/to/models/whisper-tiny"
 
-            mock_service = MagicMock()
-            mock_service.scheduler = "slurm"
-            mock_service.render_job_script.return_value = "#!/bin/bash\n#SBATCH"
-            mock_service_class.return_value = mock_service
-
             result = cli_runner.invoke(main, cmd)
 
+        assert result.exit_code == 0, result.exception
         assert "Rendering job script" in result.output
         assert "model: openai/whisper-tiny" in result.output
         assert "profile: cluster" in result.output
         assert "host: hpc.example.com" in result.output
+        # The script itself, not just the echoed metadata above it.
+        script = result.output.split("> image_ref:")[-1]
+        assert "#SBATCH" in script
 
     def test_success_local_profile(self, cli_runner, mock_config, local_profile):
         """Test successful API call with LocalProfile."""


### PR DESCRIPTION
## Summary

- `blackfish run --dry-run` crashed with `AttributeError: 'NoneType' object has no attribute 'hex'` for local profiles. The local branch constructed its service without an `id`, unlike the Slurm branch, and `render_job_script` reads `self.id.hex`. A dry-run service is never flushed to the database, so nothing else assigns one. Fixed by adding `id=uuid4()` to the local constructors in both `text_generation.py` and `speech_recognition.py`.
- The four dry-run tests patched the service class, so the real renderer never ran and the crash was invisible. They now use the real service and assert on the script body, not just the metadata echoed above it.
- That change exposed a second gap: `mock_config` left `CONTAINER_PROVIDER` as a bare `MagicMock`, so the local templates — which branch on `provider == "docker"` — rendered an empty script. The fixture now sets `ContainerProvider.Docker`.

## Test plan

- Reproduced the crash on `main` via `CliRunner` (exit 1, `AttributeError`); the same invocation now exits 0 and prints a full `docker run` script.
- Confirmed the updated tests fail without the source fix and pass with it — the point of the change.
- `cd lib && uv run pytest tests/cli` → 142 passed.
- `cd lib && uv run just lint` → all hooks pass (ruff, ruff format, mypy, codespell).
- Coverage badge regenerated: 71% → 72%.

Closes #530

---
_Generated by [Claude Code](https://claude.ai/code/session_011Aj5BVf85qjSaKT9kJxap8)_
