### PR TITLE
fix(lib): discover Docker image tags for local profiles

### DIFF
--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -94,7 +94,7 @@ from blackfish.server.jobs.base import (
 from blackfish.server.jobs.tasks import (
     get_default_output_ext,
 )
-from blackfish.server.config import config as blackfish_config
+from blackfish.server.config import ContainerProvider, config as blackfish_config
 from blackfish.server.utils import find_port
 from blackfish.server.models.profile import (
     deserialize_profiles,
@@ -1070,11 +1070,18 @@ async def list_containers(profile: str) -> list[StagedContainer]:
     if resolved is None:
         raise NotFoundException(detail=f"Profile '{profile}' not found.")
 
+    # CONTAINER_PROVIDER reflects what is installed on the server host, which
+    # is only relevant for local profiles. Slurm clusters run Apptainer — the
+    # server's own Docker install (common on dev boxes) must not misroute the
+    # probe into `docker image ls` over SSH on a login node.
+    provider = (
+        ContainerProvider.Apptainer
+        if isinstance(resolved, SlurmProfile)
+        else blackfish_config.CONTAINER_PROVIDER
+    )
     try:
         staged = await list_staged_tags(
-            resolved,
-            blackfish_config.IMAGES,
-            provider=blackfish_config.CONTAINER_PROVIDER,
+            resolved, blackfish_config.IMAGES, provider=provider
         )
     except TigerFlowError as e:
         logger.warning(f"Failed to list containers for {profile}: {e.error_type}")

--- a/lib/src/blackfish/server/asgi.py
+++ b/lib/src/blackfish/server/asgi.py
@@ -1071,7 +1071,11 @@ async def list_containers(profile: str) -> list[StagedContainer]:
         raise NotFoundException(detail=f"Profile '{profile}' not found.")
 
     try:
-        staged = await list_staged_tags(resolved, blackfish_config.IMAGES)
+        staged = await list_staged_tags(
+            resolved,
+            blackfish_config.IMAGES,
+            provider=blackfish_config.CONTAINER_PROVIDER,
+        )
     except TigerFlowError as e:
         logger.warning(f"Failed to list containers for {profile}: {e.error_type}")
         raise InternalServerException(detail=e.user_message())

--- a/lib/src/blackfish/server/image_probe.py
+++ b/lib/src/blackfish/server/image_probe.py
@@ -1,13 +1,16 @@
 """Discover which container images are actually staged on a profile.
 
 Images are staged out of band by administrators (``apptainer pull`` into
-``{cache_dir}/images/``). ``config.IMAGES`` records only the *pinned* spec per
-service, so it cannot answer "which versions could this profile run?" — that is
-what this module is for.
+``{cache_dir}/images/`` for Apptainer, or ``docker pull`` into the local Docker
+daemon). ``config.IMAGES`` records only the *pinned* spec per service, so it
+cannot answer "which versions could this profile run?" — that is what this
+module is for.
 
-The repo always comes from configuration and only the tag from the filename:
-``ImageSpec.sif`` drops the registry prefix (``<host>/<org>/<name>:<tag>`` ->
-``<name>_<tag>.sif``), so a filename alone cannot identify a repo.
+The repo always comes from configuration and only the tag from what is on the
+host: ``ImageSpec.sif`` drops the registry prefix (``<host>/<org>/<name>:<tag>``
+-> ``<name>_<tag>.sif``), so an Apptainer filename alone cannot identify a
+repo. For Docker, ``docker image ls`` reports the fully qualified repo, so
+matching is exact.
 """
 
 from __future__ import annotations
@@ -18,6 +21,7 @@ from typing import TYPE_CHECKING
 
 from packaging.version import InvalidVersion, Version
 
+from blackfish.server.config import ContainerProvider
 from blackfish.server.jobs.client import LocalRunner, SSHRunner
 
 if TYPE_CHECKING:
@@ -96,22 +100,64 @@ async def _list_sif_files(profile: "BlackfishProfile") -> list[str]:
     ]
 
 
+async def _list_docker_refs(profile: "BlackfishProfile") -> list[str]:
+    """List ``repo:tag`` refs of images present in the local Docker daemon.
+
+    ``docker image ls`` reports ``<none>`` for untagged images and can surface
+    ``<none>:<none>`` rows; those are filtered out because they cannot be
+    matched against a configured repo. A missing docker binary or daemon is
+    treated the same as a fresh profile: no images, no error.
+    """
+    command = "docker image ls --format '{{.Repository}}:{{.Tag}}' 2>/dev/null || true"
+
+    runner = _runner_for(profile)
+    _, stdout, _ = await runner.run(command)
+    return [
+        line.strip()
+        for line in stdout.decode("utf-8").splitlines()
+        if line.strip() and "<none>" not in line
+    ]
+
+
+def extract_docker_tag(ref: str, spec: "ImageSpec") -> str | None:
+    """Return the tag in ``ref`` (``repo:tag``) for ``spec``, or None."""
+    if ":" not in ref:
+        return None
+    repo, tag = ref.rsplit(":", 1)
+    if repo != spec.repo or not tag:
+        return None
+    return tag
+
+
 async def list_staged_tags(
-    profile: "BlackfishProfile", images: dict[str, "ImageSpec"]
+    profile: "BlackfishProfile",
+    images: dict[str, "ImageSpec"],
+    provider: ContainerProvider | None = None,
 ) -> dict[str, list[str]]:
     """Map each configured service to the tags staged on ``profile``.
 
     Every service in ``images`` appears in the result, with an empty list when
-    nothing is staged for it. Staged files matching no configured service (for
+    nothing is staged for it. Staged images matching no configured service (for
     example a deprecated image left on disk) are ignored — without a repo there
     is nothing launchable to attach them to.
+
+    ``provider`` selects the discovery backend. Docker inspects the local
+    daemon; anything else falls back to the Apptainer SIF layout, which is the
+    only sensible default for Slurm profiles.
 
     Raises:
         TigerFlowError: the profile could not be reached.
     """
-    filenames = await _list_sif_files(profile)
+    if provider == ContainerProvider.Docker:
+        refs = await _list_docker_refs(profile)
+        staged: dict[str, list[str]] = {}
+        for service, spec in images.items():
+            tags = [t for r in refs if (t := extract_docker_tag(r, spec)) is not None]
+            staged[service] = sort_tags(tags)
+        return staged
 
-    staged: dict[str, list[str]] = {}
+    filenames = await _list_sif_files(profile)
+    staged = {}
     for service, spec in images.items():
         tags = [t for f in filenames if (t := extract_tag(f, spec)) is not None]
         staged[service] = sort_tags(tags)

--- a/lib/tests/api/test_containers.py
+++ b/lib/tests/api/test_containers.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 from litestar.testing import AsyncTestClient
 
+from blackfish.server.config import ContainerProvider
 from blackfish.server.images import ImageSpec
 from blackfish.server.jobs.client import TigerFlowError
 
@@ -100,6 +101,55 @@ class TestListContainersAPI:
 
         assert response.status_code == 200
         assert all(row["tags"] == [] for row in response.json())
+
+    async def test_slurm_profile_forces_apptainer_provider(
+        self, client: AsyncTestClient
+    ) -> None:
+        """CONTAINER_PROVIDER reflects the server host, not the target. A
+        Slurm profile must not send `docker image ls` over SSH to a login
+        node, even when the server itself has Docker installed."""
+        seen: dict[str, ContainerProvider | None] = {}
+
+        async def _spy(profile, images, provider=None):
+            seen["provider"] = provider
+            return {"text_generation": [], "tigerflow_ml": []}
+
+        with (
+            patch("blackfish.server.asgi.blackfish_config.IMAGES", IMAGES),
+            patch(
+                "blackfish.server.asgi.blackfish_config.CONTAINER_PROVIDER",
+                ContainerProvider.Docker,
+            ),
+            patch("blackfish.server.asgi.list_staged_tags", new=_spy),
+        ):
+            response = await client.get("/api/containers?profile=hpc")
+
+        assert response.status_code == 200
+        assert seen["provider"] == ContainerProvider.Apptainer
+
+    async def test_local_profile_uses_configured_container_provider(
+        self, client: AsyncTestClient
+    ) -> None:
+        """The server's CONTAINER_PROVIDER only applies to local profiles,
+        which run on the same host."""
+        seen: dict[str, ContainerProvider | None] = {}
+
+        async def _spy(profile, images, provider=None):
+            seen["provider"] = provider
+            return {"text_generation": [], "tigerflow_ml": []}
+
+        with (
+            patch("blackfish.server.asgi.blackfish_config.IMAGES", IMAGES),
+            patch(
+                "blackfish.server.asgi.blackfish_config.CONTAINER_PROVIDER",
+                ContainerProvider.Docker,
+            ),
+            patch("blackfish.server.asgi.list_staged_tags", new=_spy),
+        ):
+            response = await client.get("/api/containers?profile=default")
+
+        assert response.status_code == 200
+        assert seen["provider"] == ContainerProvider.Docker
 
     async def test_unreachable_profile_returns_a_friendly_500(
         self, client: AsyncTestClient

--- a/lib/tests/unit/test_image_probe.py
+++ b/lib/tests/unit/test_image_probe.py
@@ -3,7 +3,9 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from blackfish.server.config import ContainerProvider
 from blackfish.server.image_probe import (
+    extract_docker_tag,
     extract_tag,
     list_staged_tags,
     sort_tags,
@@ -169,4 +171,82 @@ class TestListStagedTags:
 
         command = runner.run.call_args.args[0]
         assert command.endswith("|| true")
+        assert "/cache/images" in command
+
+
+class TestExtractDockerTag:
+    def test_extracts_the_tag_for_a_matching_ref(self) -> None:
+        assert extract_docker_tag("vllm/vllm-openai:v0.20.0", VLLM) == "v0.20.0"
+
+    def test_requires_the_full_repo_to_match(self) -> None:
+        """Docker refs carry the registry prefix, so `vllm-openai:...` alone
+        (missing the `vllm/` org) is a different repo."""
+        assert extract_docker_tag("vllm-openai:v0.20.0", VLLM) is None
+
+    def test_ignores_a_different_repo(self) -> None:
+        assert extract_docker_tag("ghcr.io/foo/bar:1.0", VLLM) is None
+
+    def test_rejects_a_ref_without_a_tag(self) -> None:
+        assert extract_docker_tag("vllm/vllm-openai", VLLM) is None
+
+
+class TestListStagedTagsDocker:
+    async def test_groups_tags_by_service_from_docker_output(self) -> None:
+        images = {"text_generation": VLLM, "tigerflow_ml": TIGERFLOW}
+        refs = [
+            "vllm/vllm-openai:v0.8.4",
+            "vllm/vllm-openai:v0.20.0",
+            "ghcr.io/princeton-ddss/tigerflow-ml:0.1.1",
+            "ghcr.io/other/thing:1.0",  # orphan
+        ]
+        runner = _mock_runner("\n".join(refs).encode())
+
+        with patch("blackfish.server.image_probe._runner_for", return_value=runner):
+            staged = await list_staged_tags(
+                _profile(), images, provider=ContainerProvider.Docker
+            )
+
+        assert staged["text_generation"] == ["v0.8.4", "v0.20.0"]
+        assert staged["tigerflow_ml"] == ["0.1.1"]
+
+    async def test_filters_none_tagged_images(self) -> None:
+        """`docker image ls` prints `<none>` for untagged images; those rows
+        cannot be matched to any spec and would otherwise leak in as a tag."""
+        runner = _mock_runner(
+            b"vllm/vllm-openai:<none>\n<none>:<none>\nvllm/vllm-openai:v0.20.0\n"
+        )
+
+        with patch("blackfish.server.image_probe._runner_for", return_value=runner):
+            staged = await list_staged_tags(
+                _profile(), {"text_generation": VLLM}, provider=ContainerProvider.Docker
+            )
+
+        assert staged["text_generation"] == ["v0.20.0"]
+
+    async def test_missing_docker_yields_empty_not_an_error(self) -> None:
+        """A profile without docker installed is a valid state — the `|| true`
+        turns the failure into empty output, matching the SIF behavior."""
+        runner = _mock_runner(b"")
+
+        with patch("blackfish.server.image_probe._runner_for", return_value=runner):
+            staged = await list_staged_tags(
+                _profile(), {"text_generation": VLLM}, provider=ContainerProvider.Docker
+            )
+
+        assert staged["text_generation"] == []
+
+    async def test_apptainer_provider_uses_sif_layout(self) -> None:
+        """Anything other than Docker (including None) must fall back to the
+        SIF probe, since Slurm profiles have no Docker daemon to inspect."""
+        runner = _mock_runner(b"vllm-openai_v0.20.0.sif\n")
+
+        with patch("blackfish.server.image_probe._runner_for", return_value=runner):
+            staged = await list_staged_tags(
+                _profile(),
+                {"text_generation": VLLM},
+                provider=ContainerProvider.Apptainer,
+            )
+
+        assert staged["text_generation"] == ["v0.20.0"]
+        command = runner.run.call_args.args[0]
         assert "/cache/images" in command


### PR DESCRIPTION
## Summary

- `image_probe` only listed SIF files, so local + Docker profiles reported zero staged tags and the launcher's Advanced Options rendered orphan help text with no version selector.
- Add a Docker discovery path that queries the local daemon (`docker image ls --format '{{.Repository}}:{{.Tag}}'`) and matches full refs against each configured `ImageSpec.repo`.
- `list_staged_tags` now takes the container provider and dispatches: Docker uses the new path, everything else (Slurm profiles) keeps the SIF layout.

Closes #520

## Test plan

- [x] `uv run just lint`
- [x] `uv run just test` (977 passed)
- [ ] Manual smoke test on local + Docker profile: launcher shows a populated Version dropdown once an image is pulled.
- [ ] Manual smoke test on Slurm profile: version list still comes from SIF filenames.

Follow-up (separate PR): alert in the launcher when no images are staged for the configured service — applies to both local and Slurm.